### PR TITLE
removing the config file integration from cis_k8s

### DIFF
--- a/compliance/cis_k8s/cis_k8s.rego
+++ b/compliance/cis_k8s/cis_k8s.rego
@@ -8,7 +8,7 @@ benchmark_name := "CIS Kubernetes"
 
 findings[finding] {
 	some rule_id
-	data.activated_rules.cis_k8s[rule_id]
+	# data.activated_rules.cis_k8s[rule_id]
 	finding = {
 		"result": rules[rule_id].finding,
 		"rule": rules[rule_id].metadata,


### PR DESCRIPTION
since the config file integration is not yet ready on the beat side they need to do [this](https://github.com/build-security/beats/tree/master/kubebeat#prerequisites) on every update of the repo.
This is a workaround until we have the full configuration file from the beat side