### PR TITLE
added opa server example

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,3 +156,21 @@ see [pre-commit](https://pre-commit.com/) package
 ```console
 docker run --rm -p 8181:8181 -v $(pwd):/bundle openpolicyagent/opa:0.36.1 run -s -b /bundle
 ```
+
+Test it 🚀
+```curl
+curl --location --request POST 'http://localhost:8181/v1/data/main' \
+--header 'Content-Type: application/json' \
+--data-raw '{
+    "input": {
+        "resource": {
+            "type": "file-system",
+            "mode": "0700",
+            "path": "/hostfs/etc/kubernetes/manifests/kube-apiserver.yaml",
+            "uid": "etc",
+            "filename": "kube-apiserver.yaml",
+            "gid": "root"
+        }
+    }
+}'
+```


### PR DESCRIPTION
part of https://github.com/elastic/security-team/issues/2800
I've added a nice example how to quickly run opa as server so you can have it running locally using docker