### PR TITLE
new data.yaml format support

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,11 @@ should contain the list of rules you want to evaluate (also supports json)
 ```yaml
 activated_rules:
   cis_k8s:
-    cis_1_1_1: true
-    cis_1_1_2: true
+    - cis_1_1_1
+    - cis_1_1_2
+  cis_eks:
+    - cis_3_1_1
+    - cis_3_1_2
 ```
 
 ##### `input.json`

--- a/compliance/cis_eks/cis_eks.rego
+++ b/compliance/cis_eks/cis_eks.rego
@@ -7,8 +7,7 @@ default_tags := ["CIS", "CIS v1.0.1", "EKS"]
 benchmark_name := "CIS Amazon Elastic Kubernetes Service (EKS) Benchmark"
 
 findings[finding] {
-	some rule_id
-	data.activated_rules.cis_eks[rule_id]
+	rule_id := data.activated_rules.cis_eks[_]
 	finding = {
 		"result": rules[rule_id].finding,
 		"rule": rules[rule_id].metadata,

--- a/compliance/cis_k8s/cis_k8s.rego
+++ b/compliance/cis_k8s/cis_k8s.rego
@@ -7,9 +7,7 @@ default_tags := ["CIS", "CIS v1.6.0", "Kubernetes"]
 benchmark_name := "CIS Kubernetes"
 
 findings[finding] {
-	some rule_id
-
-	# data.activated_rules.cis_k8s[rule_id]
+	rule_id := data.activated_rules.cis_k8s[_]
 	finding = {
 		"result": rules[rule_id].finding,
 		"rule": rules[rule_id].metadata,


### PR DESCRIPTION
Supports new `data.yaml` format

### Original format:
```yml
activated_rules:
  cis_k8s:
    cis_1_1_1: true
    cis_1_1_2: true
  cis_eks:
    cis_1_1_1: true
```

### New format:
```yml
activated_rules:
  cis_k8s:
    - cis_1_1_1
    - cis_1_1_2
  cis_eks:
    - cis_1_1_1
```
___
- closes https://github.com/elastic/security-team/issues/2487