### PR TITLE
Feature/add_Eks_Benchmark_to_main

### DIFF
--- a/compliance/main.rego
+++ b/compliance/main.rego
@@ -9,7 +9,12 @@ import data.compliance.lib.common
 
 resource = input.resource
 
-# iterating over all the benchmarks and aggregate all findings
-findings := [finding | data.compliance[benchmark].findings[finding]]
+findings := f {
+	# iterate over activated benchmarks
+	benchmarks := [key | data.activated_rules[key]]
+
+	# aggregate findings from activated benchmarks
+	f := [finding | data.compliance[benchmarks[_]].findings[finding]]
+}
 
 metadata = common.metadata


### PR DESCRIPTION
We would like our Rego policy to be able to support multiple benchmark evaluations.
That is when a user will config an evaluation of a few benchmarks like the following:

``` yaml
activated_rules:
  cis_k8s:
    - cis_1_1_1
    - cis_1_1_2
  cis_eks:
    - cis_3_1_1
    - cis_3_1_2
```

Then OPA will evaluate all of the relevant benchmarks and will separate the findings by a comma. 
More elaboration can be found here -> https://github.com/elastic/security-team/issues/2512