### PR TITLE
Update rule metadata benchmark format

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,10 @@ opa eval data.main.findings --format pretty -i input.json -b . > output.json
         }
       },
       "rule": {
-        "benchmark": "CIS Kubernetes",
+        "benchmark": {
+            "name": "CIS Kubernetes V1.20",
+            "version": "v1.0.0"
+        },
         "description": "The API server pod specification file controls various parameters that set the behavior of the API server. You should restrict its file permissions to maintain the integrity of the file. The file should be writable by only the administrators on the system.",
         "impact": "None",
         "name": "Ensure that the API server pod specification file permissions are set to 644 or more restrictive",
@@ -98,16 +101,17 @@ opa eval data.main.findings --format pretty -i input.json -b . > output.json
         }
       },
       "rule": {
-        "benchmark": "CIS Kubernetes",
+        "benchmark": {
+            "name": "CIS Kubernetes V1.20",
+            "version": "v1.0.0"
+        },
         "description": "The API server pod specification file controls various parameters that set the behavior of the API server. You should set its file ownership to maintain the integrity of the file. The file should be owned by root:root.",
         "impact": "None",
         "name": "Ensure that the API server pod specification file ownership is set to root:root",
         "remediation": "chown root:root /etc/kubernetes/manifests/kube-apiserver.yaml",
         "tags": [
           "CIS",
-          "CIS v1.6.0",
           "Kubernetes",
-          "CIS 1.1.2",
           "Master Node Configuration"
         ]
       }

--- a/compliance/cis_eks/cis_eks.rego
+++ b/compliance/cis_eks/cis_eks.rego
@@ -2,9 +2,12 @@ package compliance.cis_eks
 
 import data.compliance.cis_eks.rules
 
-default_tags := ["CIS", "CIS v1.0.1", "EKS"]
+default_tags := ["CIS", "EKS"]
 
-benchmark_name := "CIS Amazon Elastic Kubernetes Service (EKS) Benchmark"
+benchmark_metadata := {
+	"name": "CIS Amazon Elastic Kubernetes Service (EKS) Benchmark",
+	"version": "v1.0.1",
+}
 
 findings[finding] {
 	# if activated rules were configured for this benchmark run only them

--- a/compliance/cis_eks/rules/cis_2_1_1/rule.rego
+++ b/compliance/cis_eks/rules/cis_2_1_1/rule.rego
@@ -41,6 +41,6 @@ To enable or disable control plane logs with the console.
 Open the Amazon EKS console at https://console.aws.amazon.com/eks/home#/clusters.
 Amazon EKS Information in CloudTrail CloudTrail is enabled on your AWS account when you create the account.
 When activity occurs in Amazon EKS, that activity is recorded in a CloudTrail event along with other AWS service events in Event history.`,
-	"benchmark": cis_eks.benchmark_name,
+	"benchmark": cis_eks.benchmark_metadata,
 	"remediation": `aws --region "${REGION_CODE}" eks describe-cluster --name "${CLUSTER_NAME}" --query 'cluster.logging.clusterLogging[?enabled==true].types`,
 }

--- a/compliance/cis_eks/rules/cis_3_1_1/rule.rego
+++ b/compliance/cis_eks/rules/cis_3_1_1/rule.rego
@@ -30,6 +30,6 @@ It is possible to run kubelet with the kubeconfig parameters configured as a Kub
 	"impact": "None",
 	"tags": array.concat(cis_eks.default_tags, ["CIS 3.1.1", "Worker Node Configuration"]),
 	"default_value": "See the AWS EKS documentation for the default value.",
-	"benchmark": cis_eks.benchmark_name,
+	"benchmark": cis_eks.benchmark_metadata,
 	"remediation": "chmod 644 /var/lib/kubelet/kubeconfig",
 }

--- a/compliance/cis_eks/rules/cis_3_1_2/rule.rego
+++ b/compliance/cis_eks/rules/cis_3_1_2/rule.rego
@@ -29,7 +29,7 @@ You should set its file ownership to maintain the integrity of the file.
 The fileshould be owned by root:root.`,
 	"impact": "None",
 	"tags": array.concat(cis_eks.default_tags, ["CIS 3.1.2", "Worker Node Configuration"]),
-	"benchmark": cis_eks.benchmark_name,
+	"benchmark": cis_eks.benchmark_metadata,
 	"remediation": "chown root:root /var/lib/kubelet/kubeconfig",
 	"default_value": "See the AWS EKS documentation for the default value.",
 }

--- a/compliance/cis_eks/rules/cis_3_1_3/rule.rego
+++ b/compliance/cis_eks/rules/cis_3_1_3/rule.rego
@@ -28,7 +28,7 @@ If this file is specified you should restrict its file permissions to maintain t
 The file should be writable by only the administrators on the system.`,
 	"impact": "None",
 	"tags": array.concat(cis_eks.default_tags, ["CIS 3.1.3", "Worker Node Configuration"]),
-	"benchmark": cis_eks.benchmark_name,
+	"benchmark": cis_eks.benchmark_metadata,
 	"remediation": "chmod 644 /etc/kubernetes/kubelet/kubelet-config.json",
 	"default_value": "See the AWS EKS documentation for the default value.",
 }

--- a/compliance/cis_eks/rules/cis_3_1_4/rule.rego
+++ b/compliance/cis_eks/rules/cis_3_1_4/rule.rego
@@ -29,7 +29,7 @@ metadata = {
 If this file is specified you should restrict its file permissions to maintain the integrity of the file.
 The file should be writable by only the administrators on the system.`,
 	"tags": array.concat(cis_eks.default_tags, ["CIS 3.1.4", "Worker Node Configuration"]),
-	"benchmark": cis_eks.benchmark_name,
+	"benchmark": cis_eks.benchmark_metadata,
 	"remediation": "chown root:root /etc/kubernetes/kubelet/kubelet-config.json",
 	"default_value": "See the AWS EKS documentation for the default value.",
 }

--- a/compliance/cis_k8s/cis_k8s.rego
+++ b/compliance/cis_k8s/cis_k8s.rego
@@ -2,9 +2,12 @@ package compliance.cis_k8s
 
 import data.compliance.cis_k8s.rules
 
-default_tags := ["CIS", "CIS v1.6.0", "Kubernetes"]
+default_tags := ["CIS", "Kubernetes"]
 
-benchmark_name := "CIS Kubernetes"
+benchmark_metadata := {
+	"name": "CIS Kubernetes V1.20",
+	"version": "v1.0.0",
+}
 
 findings[finding] {
 	# if activated rules were configured for this benchmark run only them

--- a/compliance/cis_k8s/rules/cis_1_1_1/rule.rego
+++ b/compliance/cis_k8s/rules/cis_1_1_1/rule.rego
@@ -22,6 +22,6 @@ metadata = {
 	"description": "The API server pod specification file controls various parameters that set the behavior of the API server. You should restrict its file permissions to maintain the integrity of the file. The file should be writable by only the administrators on the system.",
 	"impact": "None",
 	"tags": array.concat(cis_k8s.default_tags, ["CIS 1.1.1", "Master Node Configuration"]),
-	"benchmark": cis_k8s.benchmark_name,
+	"benchmark": cis_k8s.benchmark_metadata,
 	"remediation": "chmod 644 /etc/kubernetes/manifests/kube-apiserver.yaml",
 }

--- a/compliance/cis_k8s/rules/cis_1_1_11/rule.rego
+++ b/compliance/cis_k8s/rules/cis_1_1_11/rule.rego
@@ -22,6 +22,6 @@ metadata = {
 	"description": "etcd is a highly-available key-value store used by Kubernetes deployments for persistent storage of all of its REST API objects. This data directory should be protected from any unauthorized reads or writes. It should not be readable or writable by any group members or the world.",
 	"impact": "None",
 	"tags": array.concat(cis_k8s.default_tags, ["CIS 1.1.11", "Master Node Configuration"]),
-	"benchmark": cis_k8s.benchmark_name,
+	"benchmark": cis_k8s.benchmark_metadata,
 	"remediation": "chmod 700 /var/lib/etcd",
 }

--- a/compliance/cis_k8s/rules/cis_1_1_12/rule.rego
+++ b/compliance/cis_k8s/rules/cis_1_1_12/rule.rego
@@ -23,6 +23,6 @@ metadata = {
 	"description": "etcd is a highly-available key-value store used by Kubernetes deployments for persistent storage of all of its REST API objects. This data directory should be protected from any unauthorized reads or writes. It should be owned by etcd:etcd.",
 	"impact": "None",
 	"tags": array.concat(cis_k8s.default_tags, ["CIS 1.1.12", "Master Node Configuration"]),
-	"benchmark": cis_k8s.benchmark_name,
+	"benchmark": cis_k8s.benchmark_metadata,
 	"remediation": "chown etcd:etcd /var/lib/etcd",
 }

--- a/compliance/cis_k8s/rules/cis_1_1_13/rule.rego
+++ b/compliance/cis_k8s/rules/cis_1_1_13/rule.rego
@@ -22,6 +22,6 @@ metadata = {
 	"description": "The admin.conf is the administrator kubeconfig file defining various settings for the administration of the cluster. You should restrict its file permissions to maintain the integrity of the file. The file should be writable by only the administrators on the system.",
 	"impact": "None",
 	"tags": array.concat(cis_k8s.default_tags, ["CIS 1.1.13", "Master Node Configuration"]),
-	"benchmark": cis_k8s.benchmark_name,
+	"benchmark": cis_k8s.benchmark_metadata,
 	"remediation": "chmod 644 /etc/kubernetes/admin.conf",
 }

--- a/compliance/cis_k8s/rules/cis_1_1_14/rule.rego
+++ b/compliance/cis_k8s/rules/cis_1_1_14/rule.rego
@@ -23,6 +23,6 @@ metadata = {
 	"description": "The admin.conf file contains the admin credentials for the cluster. You should set its file ownership to maintain the integrity of the file. The file should be owned by root:root.",
 	"impact": "None",
 	"tags": array.concat(cis_k8s.default_tags, ["CIS 1.1.14", "Master Node Configuration"]),
-	"benchmark": cis_k8s.benchmark_name,
+	"benchmark": cis_k8s.benchmark_metadata,
 	"remediation": "chown root:root /etc/kubernetes/admin.conf",
 }

--- a/compliance/cis_k8s/rules/cis_1_1_15/rule.rego
+++ b/compliance/cis_k8s/rules/cis_1_1_15/rule.rego
@@ -22,6 +22,6 @@ metadata = {
 	"description": "The scheduler.conf file is the kubeconfig file for the Scheduler. You should restrict its file permissions to maintain the integrity of the file. The file should be writable by only the administrators on the system.",
 	"impact": "None",
 	"tags": array.concat(cis_k8s.default_tags, ["CIS 1.1.15", "Master Node Configuration"]),
-	"benchmark": cis_k8s.benchmark_name,
+	"benchmark": cis_k8s.benchmark_metadata,
 	"remediation": "chmod 644 /etc/kubernetes/scheduler.conf",
 }

--- a/compliance/cis_k8s/rules/cis_1_1_16/rule.rego
+++ b/compliance/cis_k8s/rules/cis_1_1_16/rule.rego
@@ -23,6 +23,6 @@ metadata = {
 	"description": "The scheduler.conf file is the kubeconfig file for the Scheduler. You should set its file ownership to maintain the integrity of the file. The file should be owned by root:root.",
 	"impact": "None",
 	"tags": array.concat(cis_k8s.default_tags, ["CIS 1.1.16", "Master Node Configuration"]),
-	"benchmark": cis_k8s.benchmark_name,
+	"benchmark": cis_k8s.benchmark_metadata,
 	"remediation": "chown root:root /etc/kubernetes/scheduler.conf",
 }

--- a/compliance/cis_k8s/rules/cis_1_1_17/rule.rego
+++ b/compliance/cis_k8s/rules/cis_1_1_17/rule.rego
@@ -22,6 +22,6 @@ metadata = {
 	"description": "The controller-manager.conf file is the kubeconfig file for the Controller Manager. You should restrict its file permissions to maintain the integrity of the file. The file should be writable by only the administrators on the system.",
 	"impact": "None",
 	"tags": array.concat(cis_k8s.default_tags, ["CIS 1.1.17", "Master Node Configuration"]),
-	"benchmark": cis_k8s.benchmark_name,
+	"benchmark": cis_k8s.benchmark_metadata,
 	"remediation": "chmod 644 /etc/kubernetes/controller-manager.conf",
 }

--- a/compliance/cis_k8s/rules/cis_1_1_18/rule.rego
+++ b/compliance/cis_k8s/rules/cis_1_1_18/rule.rego
@@ -23,6 +23,6 @@ metadata = {
 	"description": "The controller-manager.conf file is the kubeconfig file for the Controller Manager. You should set its file ownership to maintain the integrity of the file. The file should be owned by root:root.",
 	"impact": "None",
 	"tags": array.concat(cis_k8s.default_tags, ["CIS 1.1.18", "Master Node Configuration"]),
-	"benchmark": cis_k8s.benchmark_name,
+	"benchmark": cis_k8s.benchmark_metadata,
 	"remediation": "chown root:root /etc/kubernetes/controller-manager.conf",
 }

--- a/compliance/cis_k8s/rules/cis_1_1_19/rule.rego
+++ b/compliance/cis_k8s/rules/cis_1_1_19/rule.rego
@@ -24,6 +24,6 @@ metadata = {
 	"description": "Kubernetes makes use of a number of certificates as part of its operation. You should set the ownership of the directory containing the PKI information and all files in that directory to maintain their integrity. The directory and files should be owned by root:root.",
 	"impact": "None",
 	"tags": array.concat(cis_k8s.default_tags, ["CIS 1.1.19", "Master Node Configuration"]),
-	"benchmark": cis_k8s.benchmark_name,
+	"benchmark": cis_k8s.benchmark_metadata,
 	"remediation": "chown -R root:root /etc/kubernetes/pki/",
 }

--- a/compliance/cis_k8s/rules/cis_1_1_2/rule.rego
+++ b/compliance/cis_k8s/rules/cis_1_1_2/rule.rego
@@ -23,6 +23,6 @@ metadata = {
 	"description": "The API server pod specification file controls various parameters that set the behavior of the API server. You should set its file ownership to maintain the integrity of the file. The file should be owned by root:root.",
 	"impact": "None",
 	"tags": array.concat(cis_k8s.default_tags, ["CIS 1.1.2", "Master Node Configuration"]),
-	"benchmark": cis_k8s.benchmark_name,
+	"benchmark": cis_k8s.benchmark_metadata,
 	"remediation": "chown root:root /etc/kubernetes/manifests/kube-apiserver.yaml",
 }

--- a/compliance/cis_k8s/rules/cis_1_1_3/rule.rego
+++ b/compliance/cis_k8s/rules/cis_1_1_3/rule.rego
@@ -22,6 +22,6 @@ metadata = {
 	"description": "The controller manager pod specification file controls various parameters that set the behavior of the Controller Manager on the master node. You should restrict its file permissions to maintain the integrity of the file. The file should be writable by only the administrators on the system.",
 	"impact": "None",
 	"tags": array.concat(cis_k8s.default_tags, ["CIS 1.1.3", "Master Node Configuration"]),
-	"benchmark": cis_k8s.benchmark_name,
+	"benchmark": cis_k8s.benchmark_metadata,
 	"remediation": "chmod 644 /etc/kubernetes/manifests/kube-controller-manager.yaml",
 }

--- a/compliance/cis_k8s/rules/cis_1_1_4/rule.rego
+++ b/compliance/cis_k8s/rules/cis_1_1_4/rule.rego
@@ -23,6 +23,6 @@ metadata = {
 	"description": "The controller manager pod specification file controls various parameters that set the behavior of various components of the master node. You should set its file ownership to maintain the integrity of the file. The file should be owned by root:root.",
 	"impact": "None",
 	"tags": array.concat(cis_k8s.default_tags, ["CIS 1.1.4", "Master Node Configuration"]),
-	"benchmark": cis_k8s.benchmark_name,
+	"benchmark": cis_k8s.benchmark_metadata,
 	"remediation": "chown root:root /etc/kubernetes/manifests/kube-controller-manager.yaml",
 }

--- a/compliance/cis_k8s/rules/cis_1_1_5/rule.rego
+++ b/compliance/cis_k8s/rules/cis_1_1_5/rule.rego
@@ -22,6 +22,6 @@ metadata = {
 	"description": "The scheduler pod specification file controls various parameters that set the behavior of the Scheduler service in the master node. You should restrict its file permissions to maintain the integrity of the file. The file should be writable by only the administrators on the system.",
 	"impact": "None",
 	"tags": array.concat(cis_k8s.default_tags, ["CIS 1.1.5", "Master Node Configuration"]),
-	"benchmark": cis_k8s.benchmark_name,
+	"benchmark": cis_k8s.benchmark_metadata,
 	"remediation": "chmod 644 /etc/kubernetes/manifests/kube-scheduler.yaml",
 }

--- a/compliance/cis_k8s/rules/cis_1_1_6/rule.rego
+++ b/compliance/cis_k8s/rules/cis_1_1_6/rule.rego
@@ -23,6 +23,6 @@ metadata = {
 	"description": "The scheduler pod specification file controls various parameters that set the behavior of the kube-scheduler service in the master node. You should set its file ownership to maintain the integrity of the file. The file should be owned by root:root.",
 	"impact": "None",
 	"tags": array.concat(cis_k8s.default_tags, ["CIS 1.1.6", "Master Node Configuration"]),
-	"benchmark": cis_k8s.benchmark_name,
+	"benchmark": cis_k8s.benchmark_metadata,
 	"remediation": "chown root:root /etc/kubernetes/manifests/kube-scheduler.yaml",
 }

--- a/compliance/cis_k8s/rules/cis_1_1_7/rule.rego
+++ b/compliance/cis_k8s/rules/cis_1_1_7/rule.rego
@@ -22,6 +22,6 @@ metadata = {
 	"description": "The etcd pod specification file /etc/kubernetes/manifests/etcd.yaml controls various parameters that set the behavior of the etcd service in the master node. etcd is a highly available key-value store which Kubernetes uses for persistent storage of all of its REST API object. You should restrict its file permissions to maintain the integrity of the file. The file should be writable by only the administrators on the system.",
 	"impact": "None",
 	"tags": array.concat(cis_k8s.default_tags, ["CIS 1.1.7", "Master Node Configuration"]),
-	"benchmark": cis_k8s.benchmark_name,
+	"benchmark": cis_k8s.benchmark_metadata,
 	"remediation": "chmod 644 /etc/kubernetes/manifests/etcd.yaml",
 }

--- a/compliance/cis_k8s/rules/cis_1_1_8/rule.rego
+++ b/compliance/cis_k8s/rules/cis_1_1_8/rule.rego
@@ -23,6 +23,6 @@ metadata = {
 	"description": "The etcd pod specification file /etc/kubernetes/manifests/etcd.yaml controls various parameters that set the behavior of the etcd service in the master node. etcd is a highly available key-value store which Kubernetes uses for persistent storage of all of its REST API object. You should set its file ownership to maintain the integrity of the file. The file should be owned by root:root.",
 	"impact": "None",
 	"tags": array.concat(cis_k8s.default_tags, ["CIS 1.1.8", "Master Node Configuration"]),
-	"benchmark": cis_k8s.benchmark_name,
+	"benchmark": cis_k8s.benchmark_metadata,
 	"remediation": "chown root:root /etc/kubernetes/manifests/etcd.yaml",
 }

--- a/compliance/cis_k8s/rules/cis_1_2_11/rule.rego
+++ b/compliance/cis_k8s/rules/cis_1_2_11/rule.rego
@@ -26,6 +26,6 @@ metadata = {
 	"description": "Setting admission control plugin AlwaysAdmit allows all requests and do not filter any requests.",
 	"impact": "Only requests explicitly allowed by the admissions control plugins would be served.",
 	"tags": array.concat(cis_k8s.default_tags, ["CIS 1.2.11", "API Server"]),
-	"benchmark": "CIS Kubernetes",
+	"benchmark": cis_k8s.benchmark_metadata,
 	"remediation": "Edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml on the master node and either remove the --enable-admission-plugins parameter, or set it to a value that does not include AlwaysAdmit.",
 }

--- a/compliance/cis_k8s/rules/cis_1_2_14/rule.rego
+++ b/compliance/cis_k8s/rules/cis_1_2_14/rule.rego
@@ -33,6 +33,6 @@ metadata = {
 	"description": "When you create a pod, if you do not specify a service account, it is automatically assigned the default service account in the same namespace. You should create your own service account and let the API server manage its security tokens.",
 	"impact": "None",
 	"tags": array.concat(cis_k8s.default_tags, ["CIS 1.2.14", "API Server"]),
-	"benchmark": cis_k8s.benchmark_name,
+	"benchmark": cis_k8s.benchmark_metadata,
 	"remediation": "Follow the documentation and create ServiceAccount objects as per your environment. Then, edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml on the master node and ensure that the --disable-admission-plugins parameter is set to a value that does not include ServiceAccount.",
 }

--- a/compliance/cis_k8s/rules/cis_1_2_15/rule.rego
+++ b/compliance/cis_k8s/rules/cis_1_2_15/rule.rego
@@ -33,6 +33,6 @@ metadata = {
 	"description": "Setting admission control policy to NamespaceLifecycle ensures that objects cannot be created in non-existent namespaces, and that namespaces undergoing termination are not used for creating the new objects. This is recommended to enforce the integrity of the namespace termination process and also for the availability of the newer objects.",
 	"impact": "None",
 	"tags": array.concat(cis_k8s.default_tags, ["CIS 1.2.15", "API Server"]),
-	"benchmark": cis_k8s.benchmark_name,
+	"benchmark": cis_k8s.benchmark_metadata,
 	"remediation": "Edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml on the master node and set the --disable-admission-plugins parameter to ensure it does not include NamespaceLifecycle.",
 }

--- a/compliance/cis_k8s/rules/cis_1_2_16/rule.rego
+++ b/compliance/cis_k8s/rules/cis_1_2_16/rule.rego
@@ -25,6 +25,6 @@ metadata = {
 	"description": "A Pod Security Policy is a cluster-level resource that controls the actions that a pod can perform and what it has the ability to access. The PodSecurityPolicy objects define a set of conditions that a pod must run with in order to be accepted into the system. Pod Security Policies are comprised of settings and strategies that control the security features a pod has access to and hence this must be used to control pod access permissions.",
 	"impact": "The policy objects must be created and granted before pod creation would be allowed.",
 	"tags": array.concat(cis_k8s.default_tags, ["CIS 1.2.16", "API Server"]),
-	"benchmark": cis_k8s.benchmark_name,
+	"benchmark": cis_k8s.benchmark_metadata,
 	"remediation": "Edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml on the master node and set the --disable-admission-plugins parameter to ensure it does not include NamespaceLifecycle.",
 }

--- a/compliance/cis_k8s/rules/cis_1_2_17/rule.rego
+++ b/compliance/cis_k8s/rules/cis_1_2_17/rule.rego
@@ -25,6 +25,6 @@ metadata = {
 	"description": "Using the NodeRestriction plug-in ensures that the kubelet is restricted to the Node and Pod objects that it could modify as defined. Such kubelets will only be allowed to modify their own Node API object, and only modify Pod API objects that are bound to their node.",
 	"impact": "None",
 	"tags": array.concat(cis_k8s.default_tags, ["CIS 1.2.17", "API Server"]),
-	"benchmark": cis_k8s.benchmark_name,
+	"benchmark": cis_k8s.benchmark_metadata,
 	"remediation": "Follow the Kubernetes documentation and configure NodeRestriction plug-in on kubelets. Then, edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml on the master node and set the --enable-admission-plugins parameter to a value that includes NodeRestriction.",
 }

--- a/compliance/cis_k8s/rules/cis_1_2_18/rule.rego
+++ b/compliance/cis_k8s/rules/cis_1_2_18/rule.rego
@@ -26,6 +26,6 @@ metadata = {
 	"description": "The apiserver, by default, does not authenticate itself to the kubelet's HTTPS endpoints. The requests from the apiserver are treated anonymously. You should set up certificate-based kubelet authentication to ensure that the apiserver authenticates itself to kubelets when submitting requests.",
 	"impact": "Connections to the API server will require valid authentication credentials.",
 	"tags": array.concat(cis_k8s.default_tags, ["CIS 1.2.18", "API Server"]),
-	"benchmark": cis_k8s.benchmark_name,
+	"benchmark": cis_k8s.benchmark_metadata,
 	"remediation": "Follow the Kubernetes documentation and set up the TLS connection between the apiserver and kubelets. Then, edit API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml on the master node and set the kubelet client certificate and key parameters",
 }

--- a/compliance/cis_k8s/rules/cis_1_2_19/rule.rego
+++ b/compliance/cis_k8s/rules/cis_1_2_19/rule.rego
@@ -25,6 +25,6 @@ metadata = {
 	"description": "Setting up the apiserver to serve on an insecure port would allow unauthenticated and unencrypted access to your master node. This would allow attackers who could access this port, to easily take control of the cluster.",
 	"impact": "All components that use the API must connect via the secured port, authenticate themselves, and be authorized to use the API. Including kube-controller-manage, kube-proxy, kube-scheduler, kubelets",
 	"tags": array.concat(cis_k8s.default_tags, ["CIS 1.2.19", "API Server"]),
-	"benchmark": cis_k8s.benchmark_name,
+	"benchmark": cis_k8s.benchmark_metadata,
 	"remediation": "Edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml on the master node and set to --insecure-port=0.",
 }

--- a/compliance/cis_k8s/rules/cis_1_2_2/rule.rego
+++ b/compliance/cis_k8s/rules/cis_1_2_2/rule.rego
@@ -26,6 +26,6 @@ metadata = {
 	"description": "Basic authentication uses plaintext credentials for authentication. Currently, the basic authentication credentials last indefinitely, and the password cannot be changed without restarting the API server. The basic authentication is currently supported for convenience. Hence, basic authentication should not be used.",
 	"impact": "You will have to configure and use alternate authentication mechanisms such as tokens and certificates. Username and password for basic authentication could no longer be used.",
 	"tags": array.concat(cis_k8s.default_tags, ["CIS 1.2.2", "API Server"]),
-	"benchmark": cis_k8s.benchmark_name,
+	"benchmark": cis_k8s.benchmark_metadata,
 	"remediation": "Follow the documentation and configure alternate mechanisms for authentication. Then, edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml on the master node and remove the --basic-auth-file=<filename> parameter.",
 }

--- a/compliance/cis_k8s/rules/cis_1_2_20/rule.rego
+++ b/compliance/cis_k8s/rules/cis_1_2_20/rule.rego
@@ -26,6 +26,6 @@ metadata = {
 	"description": "The secure port is used to serve https with authentication and authorization. If you disable it, no https traffic is served and all traffic is served unencrypted.",
 	"impact": "You need to set the API Server up with the right TLS certificates.",
 	"tags": array.concat(cis_k8s.default_tags, ["CIS 1.2.20", "API Server"]),
-	"benchmark": cis_k8s.benchmark_name,
+	"benchmark": cis_k8s.benchmark_metadata,
 	"remediation": "Edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml on the master node and either remove the --secure-port parameter or set it to a different (non-zero) desired port.",
 }

--- a/compliance/cis_k8s/rules/cis_1_2_21/rule.rego
+++ b/compliance/cis_k8s/rules/cis_1_2_21/rule.rego
@@ -25,6 +25,6 @@ metadata = {
 	"description": "Profiling allows for the identification of specific performance bottlenecks. It generates a significant amount of program data that could potentially be exploited to uncover system and program details. If you are not experiencing any bottlenecks and do not need the profiler for troubleshooting purposes, it is recommended to turn it off to reduce the potential attack surface.",
 	"impact": "Profiling information would not be available.",
 	"tags": array.concat(cis_k8s.default_tags, ["CIS 1.2.21", "API Server"]),
-	"benchmark": cis_k8s.benchmark_name,
+	"benchmark": cis_k8s.benchmark_metadata,
 	"remediation": "Edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml on the master node and set --profiling=false",
 }

--- a/compliance/cis_k8s/rules/cis_1_2_22/rule.rego
+++ b/compliance/cis_k8s/rules/cis_1_2_22/rule.rego
@@ -25,6 +25,6 @@ metadata = {
 	"description": "Auditing the Kubernetes API Server provides a security-relevant chronological set of records documenting the sequence of activities that have affected system by individual users, administrators or other components of the system. Even though currently, Kubernetes provides only basic audit capabilities, it should be enabled. You can enable it by setting an appropriate audit log path.",
 	"impact": "None",
 	"tags": array.concat(cis_k8s.default_tags, ["CIS 1.2.22", "API Server"]),
-	"benchmark": cis_k8s.benchmark_name,
+	"benchmark": cis_k8s.benchmark_metadata,
 	"remediation": "Edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml on the master node and set the --audit-log-path parameter to a suitable path and file where you would like audit logs to be written, for example: --audit-log-path=/var/log/apiserver/audit.log",
 }

--- a/compliance/cis_k8s/rules/cis_1_2_23/rule.rego
+++ b/compliance/cis_k8s/rules/cis_1_2_23/rule.rego
@@ -32,6 +32,6 @@ metadata = {
 	"description": "Retaining logs for at least 30 days ensures that you can go back in time and investigate or correlate any events. Set your audit log retention period to 30 days or as per your business requirements.",
 	"impact": "None",
 	"tags": array.concat(cis_k8s.default_tags, ["CIS 1.2.23", "API Server"]),
-	"benchmark": cis_k8s.benchmark_name,
+	"benchmark": cis_k8s.benchmark_metadata,
 	"remediation": "Edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml on the master node and set the --audit-log-maxage parameter to 30 or as an appropriate number of days: --audit-log-maxage=30",
 }

--- a/compliance/cis_k8s/rules/cis_1_2_24/rule.rego
+++ b/compliance/cis_k8s/rules/cis_1_2_24/rule.rego
@@ -32,6 +32,6 @@ metadata = {
 	"description": "Kubernetes automatically rotates the log files. Retaining old log files ensures that you would have sufficient log data available for carrying out any investigation or correlation. For example, if you have set file size of 100 MB and the number of old log files to keep as 10, you would approximate have 1 GB of log data that you could potentially use for your analysis.",
 	"impact": "None",
 	"tags": array.concat(cis_k8s.default_tags, ["CIS 1.2.24", "API Server"]),
-	"benchmark": cis_k8s.benchmark_name,
+	"benchmark": cis_k8s.benchmark_metadata,
 	"remediation": "Edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml on the master node and set the --audit-log-maxbackup parameter to 10 or to an appropriate value --audit-log-maxbackup=10",
 }

--- a/compliance/cis_k8s/rules/cis_1_2_25/rule.rego
+++ b/compliance/cis_k8s/rules/cis_1_2_25/rule.rego
@@ -32,6 +32,6 @@ metadata = {
 	"description": "Kubernetes automatically rotates the log files. Retaining old log files ensures that you would have sufficient log data available for carrying out any investigation or correlation. If you have set file size of 100 MB and the number of old log files to keep as 10, you would approximate have 1 GB of log data that you could potentially use for your analysis.",
 	"impact": "None",
 	"tags": array.concat(cis_k8s.default_tags, ["CIS 1.2.25", "API Server"]),
-	"benchmark": cis_k8s.benchmark_name,
+	"benchmark": cis_k8s.benchmark_metadata,
 	"remediation": "Edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml on the master node and set the --audit-log-maxsize parameter to an appropriate size in MB. For example, to set it as 100 MB: --audit-log-maxsize=100",
 }

--- a/compliance/cis_k8s/rules/cis_1_2_26/rule.rego
+++ b/compliance/cis_k8s/rules/cis_1_2_26/rule.rego
@@ -32,6 +32,6 @@ metadata = {
 	"description": "Setting global request timeout allows extending the API server request timeout limit to a duration appropriate to the user's connection speed. By default, it is set to 60 seconds which might be problematic on slower connections making cluster resources inaccessible once the data volume for requests exceeds what can be transmitted in 60 seconds. But, setting this timeout limit to be too large can exhaust the API server resources making it prone to Denial-of-Service attack. Hence, it is recommended to set this limit as appropriate and change the default limit of 60 seconds only if needed.",
 	"impact": "None",
 	"tags": array.concat(cis_k8s.default_tags, ["CIS 1.2.26", "API Server"]),
-	"benchmark": cis_k8s.benchmark_name,
+	"benchmark": cis_k8s.benchmark_metadata,
 	"remediation": "Edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml and set the below parameter as appropriate and if needed. For example: --request-timeout=300s",
 }

--- a/compliance/cis_k8s/rules/cis_1_2_27/rule.rego
+++ b/compliance/cis_k8s/rules/cis_1_2_27/rule.rego
@@ -36,6 +36,6 @@ metadata = {
 	"description": "If --service-account-lookup is not enabled, the apiserver only verifies that the authentication token is valid, and does not validate that the service account token mentioned in the request is actually present in etcd. This allows using a service account token even after the corresponding service account is deleted. This is an example of time of check to time of use security issue.",
 	"impact": "None",
 	"tags": array.concat(cis_k8s.default_tags, ["CIS 1.2.27", "API Server"]),
-	"benchmark": cis_k8s.benchmark_name,
+	"benchmark": cis_k8s.benchmark_metadata,
 	"remediation": "Edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml on the master node and set the below parameter. --service-account-lookup=true",
 }

--- a/compliance/cis_k8s/rules/cis_1_2_28/rule.rego
+++ b/compliance/cis_k8s/rules/cis_1_2_28/rule.rego
@@ -25,6 +25,6 @@ metadata = {
 	"description": "By default, if no --service-account-key-file is specified to the apiserver, it uses the private key from the TLS serving certificate to verify service account tokens. To ensure that the keys for service account tokens could be rotated as needed, a separate public/private key pair should be used for signing service account tokens. Hence, the public key should be specified to the apiserver with --service-account-key-file.",
 	"impact": "The corresponding private key must be provided to the controller manager. You would need to securely maintain the key file and rotate the keys based on your organization's key rotation policy.",
 	"tags": array.concat(cis_k8s.default_tags, ["CIS 1.2.28", "API Server"]),
-	"benchmark": cis_k8s.benchmark_name,
+	"benchmark": cis_k8s.benchmark_metadata,
 	"remediation": "Edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml on the master node and set the below parameter. --service-account-lookup=true",
 }

--- a/compliance/cis_k8s/rules/cis_1_2_29/rule.rego
+++ b/compliance/cis_k8s/rules/cis_1_2_29/rule.rego
@@ -32,6 +32,6 @@ metadata = {
 	"description": "etcd is a highly-available key value store used by Kubernetes deployments for persistent storage of all of its REST API objects. These objects are sensitive in nature and should be protected by client authentication. This requires the API server to identify itself to the etcd server using a client certificate and key.",
 	"impact": "TLS and client certificate authentication must be configured for etcd.",
 	"tags": array.concat(cis_k8s.default_tags, ["CIS 1.2.29", "API Server"]),
-	"benchmark": cis_k8s.benchmark_name,
+	"benchmark": cis_k8s.benchmark_metadata,
 	"remediation": "Follow the Kubernetes documentation and set up the TLS connection between the apiserver and etcd. Then, edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml on the master node and set the etcd certificate and key file parameters.",
 }

--- a/compliance/cis_k8s/rules/cis_1_2_3/rule.rego
+++ b/compliance/cis_k8s/rules/cis_1_2_3/rule.rego
@@ -26,6 +26,6 @@ metadata = {
 	"description": "The token-based authentication utilizes static tokens to authenticate requests to the apiserver. The tokens are stored in clear-text in a file on the apiserver, and cannot be revoked or rotated without restarting the apiserver. Hence, do not use static token-based authentication.",
 	"impact": "You will have to configure and use alternate authentication mechanisms such as tokens and certificates. Username and password for basic authentication could no longer be used.",
 	"tags": array.concat(cis_k8s.default_tags, ["CIS 1.2.3", "API Server"]),
-	"benchmark": cis_k8s.benchmark_name,
+	"benchmark": cis_k8s.benchmark_metadata,
 	"remediation": "Follow the documentation and configure alternate mechanisms for authentication. Then, edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml on the master node and remove the --token-auth-file=<filename> parameter.",
 }

--- a/compliance/cis_k8s/rules/cis_1_2_30/rule.rego
+++ b/compliance/cis_k8s/rules/cis_1_2_30/rule.rego
@@ -32,6 +32,6 @@ metadata = {
 	"description": "API server communication contains sensitive parameters that should remain encrypted in transit. Configure the API server to serve only HTTPS traffic.",
 	"impact": "TLS and client certificate authentication must be configured for your Kubernetes cluster deployment.",
 	"tags": array.concat(cis_k8s.default_tags, ["CIS 1.2.30", "API Server"]),
-	"benchmark": cis_k8s.benchmark_name,
+	"benchmark": cis_k8s.benchmark_metadata,
 	"remediation": "Follow the Kubernetes documentation and set up the TLS connection on the apiserver. Then, edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml on the master node and set the TLS certificate and private key file parameters.",
 }

--- a/compliance/cis_k8s/rules/cis_1_2_31/rule.rego
+++ b/compliance/cis_k8s/rules/cis_1_2_31/rule.rego
@@ -25,6 +25,6 @@ metadata = {
 	"description": "API server communication contains sensitive parameters that should remain encrypted in transit. Configure the API server to serve only HTTPS traffic. If --client-ca-file argument is set, any request presenting a client certificate signed by one of the authorities in the client-ca-file is authenticated with an identity corresponding to the CommonName of the client certificate.",
 	"impact": "TLS and client certificate authentication must be configured for your Kubernetes cluster deployment.",
 	"tags": array.concat(cis_k8s.default_tags, ["CIS 1.2.31", "API Server"]),
-	"benchmark": cis_k8s.benchmark_name,
+	"benchmark": cis_k8s.benchmark_metadata,
 	"remediation": "Follow the Kubernetes documentation and set up the TLS connection on the apiserver. Then, edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml on the master node and set the client certificate authority file.",
 }

--- a/compliance/cis_k8s/rules/cis_1_2_32/rule.rego
+++ b/compliance/cis_k8s/rules/cis_1_2_32/rule.rego
@@ -25,6 +25,6 @@ metadata = {
 	"description": "etcd is a highly-available key value store used by Kubernetes deployments for persistent storage of all of its REST API objects. These objects are sensitive in nature and should be protected by client authentication. This requires the API server to identify itself to the etcd server using a SSL Certificate Authority file.",
 	"impact": "TLS and client certificate authentication must be configured for etcd.",
 	"tags": array.concat(cis_k8s.default_tags, ["CIS 1.2.32", "API Server"]),
-	"benchmark": cis_k8s.benchmark_name,
+	"benchmark": cis_k8s.benchmark_metadata,
 	"remediation": "Follow the Kubernetes documentation and set up the TLS connection on the apiserver. Then, edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml on the master node and set the client certificate authority file.",
 }

--- a/compliance/cis_k8s/rules/cis_1_2_4/rule.rego
+++ b/compliance/cis_k8s/rules/cis_1_2_4/rule.rego
@@ -26,6 +26,6 @@ metadata = {
 	"description": "Connections from apiserver to kubelets could potentially carry sensitive data such as secrets and keys. It is thus important to use in-transit encryption for any communication between the apiserver and kubelets.",
 	"impact": "You require TLS to be configured on apiserver as well as kubelets.",
 	"tags": array.concat(cis_k8s.default_tags, ["CIS 1.2.4", "API Server"]),
-	"benchmark": cis_k8s.benchmark_name,
+	"benchmark": cis_k8s.benchmark_metadata,
 	"remediation": "Edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml on the master node and remove the --kubelet-https parameter.",
 }

--- a/compliance/cis_k8s/rules/cis_1_2_5/rule.rego
+++ b/compliance/cis_k8s/rules/cis_1_2_5/rule.rego
@@ -32,6 +32,6 @@ metadata = {
 	"description": "The apiserver, by default, does not authenticate itself to the kubelet's HTTPS endpoints. The requests from the apiserver are treated anonymously. You should set up certificate-based kubelet authentication to ensure that the apiserver authenticates itself to kubelets when submitting requests.",
 	"impact": "You require TLS to be configured on apiserver as well as kubelets.",
 	"tags": array.concat(cis_k8s.default_tags, ["CIS 1.2.5", "API Server"]),
-	"benchmark": cis_k8s.benchmark_name,
+	"benchmark": cis_k8s.benchmark_metadata,
 	"remediation": "Follow the Kubernetes documentation and set up the TLS connection between the apiserver and kubelets. Then, edit API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml on the master node and set the kubelet client certificate and key parameters",
 }

--- a/compliance/cis_k8s/rules/cis_1_2_6/rule.rego
+++ b/compliance/cis_k8s/rules/cis_1_2_6/rule.rego
@@ -25,6 +25,6 @@ metadata = {
 	"description": "The connections from the apiserver to the kubelet are used for fetching logs for pods, attaching (through kubectl) to running pods, and using the kubelet’s port-forwarding functionality. These connections terminate at the kubelet’s HTTPS endpoint. By default, the apiserver does not verify the kubelet’s serving certificate, which makes the connection subject to man-in-the-middle attacks, and unsafe to run over untrusted and/or public networks.",
 	"impact": "You require TLS to be configured on apiserver as well as kubelets.",
 	"tags": array.concat(cis_k8s.default_tags, ["CIS 1.2.6", "API Server"]),
-	"benchmark": cis_k8s.benchmark_name,
+	"benchmark": cis_k8s.benchmark_metadata,
 	"remediation": "Follow the Kubernetes documentation and setup the TLS connection between the apiserver and kubelets. Then, edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml on the master node and set the --kubelet-certificate-authority parameter to the path to the cert file for the certificate authority.",
 }

--- a/compliance/cis_k8s/rules/cis_1_2_7/rule.rego
+++ b/compliance/cis_k8s/rules/cis_1_2_7/rule.rego
@@ -26,6 +26,6 @@ metadata = {
 	"description": "The API Server, can be configured to allow all requests. This mode should not be used on any production cluster.",
 	"impact": "Only authorized requests will be served.",
 	"tags": array.concat(cis_k8s.default_tags, ["CIS 1.2.7", "API Server"]),
-	"benchmark": cis_k8s.benchmark_name,
+	"benchmark": cis_k8s.benchmark_metadata,
 	"remediation": "Edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml on the master node and set the --authorization-mode parameter to values other than AlwaysAllow",
 }

--- a/compliance/cis_k8s/rules/cis_1_2_8/rule.rego
+++ b/compliance/cis_k8s/rules/cis_1_2_8/rule.rego
@@ -25,6 +25,6 @@ metadata = {
 	"description": "The Node authorization mode only allows kubelets to read Secret, ConfigMap, PersistentVolume, and PersistentVolumeClaim objects associated with their nodes.",
 	"impact": "None",
 	"tags": array.concat(cis_k8s.default_tags, ["CIS 1.2.8", "API Server"]),
-	"benchmark": cis_k8s.benchmark_name,
+	"benchmark": cis_k8s.benchmark_metadata,
 	"remediation": "Edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml on the master node and set the --authorization-mode parameter to a value that includes Node.",
 }

--- a/compliance/cis_k8s/rules/cis_1_2_9/rule.rego
+++ b/compliance/cis_k8s/rules/cis_1_2_9/rule.rego
@@ -25,6 +25,6 @@ metadata = {
 	"description": "Role Based Access Control (RBAC) allows fine-grained control over the operations that different entities can perform on different objects in the cluster. It is recommended to use the RBAC authorization mode.",
 	"impact": "When RBAC is enabled you will need to ensure that appropriate RBAC settings (including Roles, RoleBindings and ClusterRoleBindings) are configured to allow appropriate access.",
 	"tags": array.concat(cis_k8s.default_tags, ["CIS 1.2.9", "API Server"]),
-	"benchmark": cis_k8s.benchmark_name,
+	"benchmark": cis_k8s.benchmark_metadata,
 	"remediation": "Edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml on the master node and set the --authorization-mode parameter to a value that includes RBAC, for example: --authorization-mode=Node,RBAC",
 }

--- a/compliance/cis_k8s/rules/cis_1_3_2/rule.rego
+++ b/compliance/cis_k8s/rules/cis_1_3_2/rule.rego
@@ -25,6 +25,6 @@ metadata = {
 	"description": "Profiling allows for the identification of specific performance bottlenecks. It generates a significant amount of program data that could potentially be exploited to uncover system and program details. If you are not experiencing any bottlenecks and do not need the profiler for troubleshooting purposes, it is recommended to turn it off to reduce the potential attack surface.",
 	"impact": "Profiling information would not be available.",
 	"tags": array.concat(cis_k8s.default_tags, ["CIS 1.3.2", "Controller Manager"]),
-	"benchmark": cis_k8s.benchmark_name,
+	"benchmark": cis_k8s.benchmark_metadata,
 	"remediation": "Edit the Controller Manager pod specification file /etc/kubernetes/manifests/kube-controller-manager.yaml on the master node and set to --profiling=false",
 }

--- a/compliance/cis_k8s/rules/cis_1_3_3/rule.rego
+++ b/compliance/cis_k8s/rules/cis_1_3_3/rule.rego
@@ -25,6 +25,6 @@ metadata = {
 	"description": "The controller manager creates a service account per controller in the kube-system namespace, generates a credential for it, and builds a dedicated API client with that service account credential for each controller loop to use. Setting the --use-service-account-credentials to true runs each control loop within the controller manager using a separate service account credential. When used in combination with RBAC, this ensures that the control loops run with the minimum permissions required to perform their intended tasks.",
 	"impact": "Whatever authorizer is configured for the cluster, it must grant sufficient permissions to the service accounts to perform their intended tasks. When using the RBAC authorizer, those roles are created and bound to the appropriate service accounts in the kube-system namespace automatically with default roles and rolebindings that are auto-reconciled on startup.",
 	"tags": array.concat(cis_k8s.default_tags, ["CIS 1.3.3", "Controller Manager"]),
-	"benchmark": cis_k8s.benchmark_name,
+	"benchmark": cis_k8s.benchmark_metadata,
 	"remediation": "Edit the Controller Manager pod specification file /etc/kubernetes/manifests/kube-controller-manager.yaml on the master node to set to --use-service-account-credentials=true",
 }

--- a/compliance/cis_k8s/rules/cis_1_3_4/rule.rego
+++ b/compliance/cis_k8s/rules/cis_1_3_4/rule.rego
@@ -25,6 +25,6 @@ metadata = {
 	"description": "To ensure that keys for service account tokens can be rotated as needed, a separate public/private key pair should be used for signing service account tokens. The private key should be specified to the controller manager with --service-account-private-key-file as appropriate.",
 	"impact": "You would need to securely maintain the key file and rotate the keys based on your organization's key rotation policy.",
 	"tags": array.concat(cis_k8s.default_tags, ["CIS 1.3.4", "Controller Manager"]),
-	"benchmark": cis_k8s.benchmark_name,
+	"benchmark": cis_k8s.benchmark_metadata,
 	"remediation": "Edit the Controller Manager pod specification file /etc/kubernetes/manifests/kube-controller-manager.yaml on the master node and set the --service-account-private-key-file parameter to the private key file for service accounts.",
 }

--- a/compliance/cis_k8s/rules/cis_1_3_5/rule.rego
+++ b/compliance/cis_k8s/rules/cis_1_3_5/rule.rego
@@ -25,6 +25,6 @@ metadata = {
 	"description": "Processes running within pods that need to contact the API server must verify the API server's serving certificate. Failing to do so could be a subject to man-in-the-middle attacks. Providing the root certificate for the API server's serving certificate to the controller manager with the --root-ca-file argument allows the controller manager to inject the trusted bundle into pods so that they can verify TLS connections to the API server.",
 	"impact": "You need to setup and maintain root certificate authority file.",
 	"tags": array.concat(cis_k8s.default_tags, ["CIS 1.3.5", "Controller Manager"]),
-	"benchmark": cis_k8s.benchmark_name,
+	"benchmark": cis_k8s.benchmark_metadata,
 	"remediation": "Edit the Controller Manager pod specification file /etc/kubernetes/manifests/kube-controller-manager.yaml on the master node and set the --root-ca-file parameter to the certificate bundle file` --root-ca-file=<path/to/file>",
 }

--- a/compliance/cis_k8s/rules/cis_1_3_6/rule.rego
+++ b/compliance/cis_k8s/rules/cis_1_3_6/rule.rego
@@ -25,6 +25,6 @@ metadata = {
 	"description": "Enable kubelet server certificate rotation on controller-manager.",
 	"impact": "None",
 	"tags": array.concat(cis_k8s.default_tags, ["CIS 1.3.6", "Controller Manager"]),
-	"benchmark": cis_k8s.benchmark_name,
+	"benchmark": cis_k8s.benchmark_metadata,
 	"remediation": "Edit the Controller Manager pod specification file /etc/kubernetes/manifests/kube-controller-manager.yaml on the master node and set the --feature-gates parameter to include RotateKubeletServerCertificate=true. --feature-gates=RotateKubeletServerCertificate=true",
 }

--- a/compliance/cis_k8s/rules/cis_1_3_7/rule.rego
+++ b/compliance/cis_k8s/rules/cis_1_3_7/rule.rego
@@ -25,6 +25,6 @@ metadata = {
 	"description": "Do not bind the Controller Manager service to non-loopback insecure addresses.",
 	"impact": "None",
 	"tags": array.concat(cis_k8s.default_tags, ["CIS 1.3.7", "Controller Manager"]),
-	"benchmark": cis_k8s.benchmark_name,
+	"benchmark": cis_k8s.benchmark_metadata,
 	"remediation": "Edit the Controller Manager pod specification file /etc/kubernetes/manifests/kube-controller-manager.yaml on the master node and ensure the correct value for the --bind-address parameter",
 }

--- a/compliance/cis_k8s/rules/cis_1_4_1/rule.rego
+++ b/compliance/cis_k8s/rules/cis_1_4_1/rule.rego
@@ -25,6 +25,6 @@ metadata = {
 	"description": "Disable profiling, if not needed.",
 	"impact": "Profiling information would not be available.",
 	"tags": array.concat(cis_k8s.default_tags, ["CIS 1.4.1", "Scheduler"]),
-	"benchmark": cis_k8s.benchmark_name,
+	"benchmark": cis_k8s.benchmark_metadata,
 	"remediation": "Edit the Scheduler pod specification file /etc/kubernetes/manifests/kube-scheduler.yaml file on the master node and set to --profiling=false",
 }

--- a/compliance/cis_k8s/rules/cis_1_4_2/rule.rego
+++ b/compliance/cis_k8s/rules/cis_1_4_2/rule.rego
@@ -25,6 +25,6 @@ metadata = {
 	"description": "Do not bind the scheduler service to non-loopback insecure addresses.",
 	"impact": "None",
 	"tags": array.concat(cis_k8s.default_tags, ["CIS 1.4.2", "Scheduler"]),
-	"benchmark": cis_k8s.benchmark_name,
+	"benchmark": cis_k8s.benchmark_metadata,
 	"remediation": "Edit the Scheduler pod specification file /etc/kubernetes/manifests/kube-scheduler.yaml on the master node and ensure the correct value for the --bind-address parameter",
 }

--- a/compliance/cis_k8s/rules/cis_2_1/rule.rego
+++ b/compliance/cis_k8s/rules/cis_2_1/rule.rego
@@ -32,6 +32,6 @@ metadata = {
 	"description": "Configure TLS encryption for the etcd service.",
 	"impact": "Client connections only over TLS would be served.",
 	"tags": array.concat(cis_k8s.default_tags, ["CIS 2.1", "etcd"]),
-	"benchmark": cis_k8s.benchmark_name,
+	"benchmark": cis_k8s.benchmark_metadata,
 	"remediation": "Follow the etcd service documentation and configure TLS encryption. Then, edit the etcd pod specification file /etc/kubernetes/manifests/etcd.yaml on the master node and set  --cert-file=</path/to/ca-file> --key-file=</path/to/key-file>",
 }

--- a/compliance/cis_k8s/rules/cis_2_2/rule.rego
+++ b/compliance/cis_k8s/rules/cis_2_2/rule.rego
@@ -25,6 +25,6 @@ metadata = {
 	"description": "Enable client authentication on etcd service.",
 	"impact": "All clients attempting to access the etcd server will require a valid client certificate.",
 	"tags": array.concat(cis_k8s.default_tags, ["CIS 2.2", "etcd"]),
-	"benchmark": cis_k8s.benchmark_name,
+	"benchmark": cis_k8s.benchmark_metadata,
 	"remediation": "Edit the etcd pod specification file /etc/kubernetes/manifests/etcd.yaml on the master node and set to --client-cert-auth=true",
 }

--- a/compliance/cis_k8s/rules/cis_2_3/rule.rego
+++ b/compliance/cis_k8s/rules/cis_2_3/rule.rego
@@ -28,6 +28,6 @@ metadata = {
 	"description": "Do not use self-signed certificates for TLS.",
 	"impact": "Clients will not be able to use self-signed certificates for TLS.",
 	"tags": array.concat(cis_k8s.default_tags, ["CIS 2.3", "etcd"]),
-	"benchmark": cis_k8s.benchmark_name,
+	"benchmark": cis_k8s.benchmark_metadata,
 	"remediation": "Edit the etcd pod specification file /etc/kubernetes/manifests/etcd.yaml on the master node and either remove the --auto-tls parameter or set it to false. --auto-tls=false",
 }

--- a/compliance/cis_k8s/rules/cis_2_4/rule.rego
+++ b/compliance/cis_k8s/rules/cis_2_4/rule.rego
@@ -32,6 +32,6 @@ metadata = {
 	"description": "etcd should be configured to make use of TLS encryption for peer connections.",
 	"impact": "etcd cluster peers would need to set up TLS for their communication.",
 	"tags": array.concat(cis_k8s.default_tags, ["CIS 2.4", "etcd"]),
-	"benchmark": cis_k8s.benchmark_name,
+	"benchmark": cis_k8s.benchmark_metadata,
 	"remediation": "Follow the etcd service documentation and configure peer TLS encryption as appropriate for your etcd cluster. Then, edit the etcd pod specification file /etc/kubernetes/manifests/etcd.yaml on the master node and set --peer-cert-file=</path/to/peer-cert-file> --peer-key-file=</path/to/peer-key-file>",
 }

--- a/compliance/cis_k8s/rules/cis_2_5/rule.rego
+++ b/compliance/cis_k8s/rules/cis_2_5/rule.rego
@@ -25,6 +25,6 @@ metadata = {
 	"description": "etcd should be configured for peer authentication.",
 	"impact": "All peers attempting to communicate with the etcd server will require a valid client certificate for authentication.",
 	"tags": array.concat(cis_k8s.default_tags, ["CIS 2.5", "etcd"]),
-	"benchmark": cis_k8s.benchmark_name,
+	"benchmark": cis_k8s.benchmark_metadata,
 	"remediation": "Edit the etcd pod specification file /etc/kubernetes/manifests/etcd.yaml on the master node and set to --peer-client-cert-auth=true",
 }

--- a/compliance/cis_k8s/rules/cis_2_6/rule.rego
+++ b/compliance/cis_k8s/rules/cis_2_6/rule.rego
@@ -28,6 +28,6 @@ metadata = {
 	"description": "Do not use automatically generated self-signed certificates for TLS connections between peers.",
 	"impact": "All peers attempting to communicate with the etcd server will require a valid client certificate for authentication.",
 	"tags": array.concat(cis_k8s.default_tags, ["CIS 2.6", "etcd"]),
-	"benchmark": cis_k8s.benchmark_name,
+	"benchmark": cis_k8s.benchmark_metadata,
 	"remediation": "Edit the etcd pod specification file /etc/kubernetes/manifests/etcd.yaml on the master node and either remove the --peer-auto-tls parameter or set it to false.",
 }

--- a/compliance/cis_k8s/rules/cis_4_1_1/rule.rego
+++ b/compliance/cis_k8s/rules/cis_4_1_1/rule.rego
@@ -22,6 +22,6 @@ metadata = {
 	"description": "Ensure that the kubelet service file has permissions of 644 or more restrictive.",
 	"impact": "None",
 	"tags": array.concat(cis_k8s.default_tags, ["CIS 4.1.1", "Worker Node Configuration"]),
-	"benchmark": cis_k8s.benchmark_name,
+	"benchmark": cis_k8s.benchmark_metadata,
 	"remediation": "Run the below command (based on the file location on your system) on the each worker node. For example, chmod 755 /etc/systemd/system/kubelet.service.d/10-kubeadm.conf",
 }

--- a/compliance/cis_k8s/rules/cis_4_1_10/rule.rego
+++ b/compliance/cis_k8s/rules/cis_4_1_10/rule.rego
@@ -23,6 +23,6 @@ metadata = {
 	"description": "Ensure that if the kubelet refers to a configuration file with the --config argument, that file is owned by root:root",
 	"impact": "None",
 	"tags": array.concat(cis_k8s.default_tags, ["CIS 4.1.10", "Worker Node Configuration"]),
-	"benchmark": cis_k8s.benchmark_name,
+	"benchmark": cis_k8s.benchmark_metadata,
 	"remediation": "chown root:root /etc/kubernetes/kubelet.conf",
 }

--- a/compliance/cis_k8s/rules/cis_4_1_2/rule.rego
+++ b/compliance/cis_k8s/rules/cis_4_1_2/rule.rego
@@ -23,6 +23,6 @@ metadata = {
 	"description": "Ensure that the kubelet service file ownership is set to root:root.",
 	"impact": "None",
 	"tags": array.concat(cis_k8s.default_tags, ["CIS 4.1.2", "Worker Node Configuration"]),
-	"benchmark": cis_k8s.benchmark_name,
+	"benchmark": cis_k8s.benchmark_metadata,
 	"remediation": "Run the below command (based on the file location on your system) on the each worker node. For example, chown root:root /etc/systemd/system/kubelet.service.d/10-kubeadm.conf",
 }

--- a/compliance/cis_k8s/rules/cis_4_1_5/rule.rego
+++ b/compliance/cis_k8s/rules/cis_4_1_5/rule.rego
@@ -22,6 +22,6 @@ metadata = {
 	"description": "Ensure that the kubelet service file has permissions of 644 or more restrictive.",
 	"impact": "None",
 	"tags": array.concat(cis_k8s.default_tags, ["CIS 4.1.5", "Worker Node Configuration"]),
-	"benchmark": cis_k8s.benchmark_name,
+	"benchmark": cis_k8s.benchmark_metadata,
 	"remediation": "Run the below command (based on the file location on your system) on the each worker node. For example, chmod 644 /etc/kubernetes/kubelet.conf",
 }

--- a/compliance/cis_k8s/rules/cis_4_1_9/rule.rego
+++ b/compliance/cis_k8s/rules/cis_4_1_9/rule.rego
@@ -22,6 +22,6 @@ metadata = {
 	"description": "Ensure that if the kubelet refers to a configuration file with the --config argument, that file has permissions of 644 or more restrictive.",
 	"impact": "None",
 	"tags": array.concat(cis_k8s.default_tags, ["CIS 4.1.9", "Worker Node Configuration"]),
-	"benchmark": cis_k8s.benchmark_name,
+	"benchmark": cis_k8s.benchmark_metadata,
 	"remediation": "chmod 644 /var/lib/kubelet/config.yaml",
 }

--- a/compliance/cis_k8s/rules/cis_4_2_1/rule.rego
+++ b/compliance/cis_k8s/rules/cis_4_2_1/rule.rego
@@ -25,6 +25,6 @@ metadata = {
 	"description": "Disable anonymous requests to the Kubelet server.",
 	"impact": "Anonymous requests will be rejected.",
 	"tags": array.concat(cis_k8s.default_tags, ["CIS 4.2.1", "Kubelet"]),
-	"benchmark": cis_k8s.benchmark_name,
+	"benchmark": cis_k8s.benchmark_metadata,
 	"remediation": "If using a Kubelet config file, edit the file to set authentication: anonymous: enabled to false. If using executable arguments, edit the kubelet service file /etc/systemd/system/kubelet.service.d/10-kubeadm.conf on each worker node and set the below parameter in KUBELET_SYSTEM_PODS_ARGS variable. --anonymous-auth=false Based on your system, restart the kubelet service.",
 }

--- a/compliance/cis_k8s/rules/cis_4_2_2/rule.rego
+++ b/compliance/cis_k8s/rules/cis_4_2_2/rule.rego
@@ -37,6 +37,6 @@ metadata = {
 	"description": "Do not allow all requests. Enable explicit authorization.",
 	"impact": "Unauthorized requests will be denied.",
 	"tags": array.concat(cis_k8s.default_tags, ["CIS 4.2.2", "Kubelet"]),
-	"benchmark": cis_k8s.benchmark_name,
+	"benchmark": cis_k8s.benchmark_metadata,
 	"remediation": "If using a Kubelet config file, edit the file to set authorization: mode to Webhook. If using executable arguments, edit the kubelet service file /etc/systemd/system/kubelet.service.d/10-kubeadm.conf on each worker node and set the below parameter in KUBELET_AUTHZ_ARGS variable. --authorization-mode=Webhook Based on your system, restart the kubelet service",
 }

--- a/compliance/cis_k8s/rules/cis_4_2_3/rule.rego
+++ b/compliance/cis_k8s/rules/cis_4_2_3/rule.rego
@@ -25,6 +25,6 @@ metadata = {
 	"description": "Enable Kubelet authentication using certificates.",
 	"impact": "You require TLS to be configured on apiserver as well as kubelets.",
 	"tags": array.concat(cis_k8s.default_tags, ["CIS 4.2.3", "Kubelet"]),
-	"benchmark": cis_k8s.benchmark_name,
+	"benchmark": cis_k8s.benchmark_metadata,
 	"remediation": "If using a Kubelet config file, edit the file to set authentication: x509: clientCAFile to the location of the client CA file. If using command line arguments, edit the kubelet service file /etc/systemd/system/kubelet.service.d/10-kubeadm.conf on each worker node and set the below parameter in KUBELET_AUTHZ_ARGS variable. --client-ca-file=<path/to/client-ca-file> Based on your system, restart the kubelet service.",
 }

--- a/compliance/cis_k8s/rules/cis_4_2_6/rule.rego
+++ b/compliance/cis_k8s/rules/cis_4_2_6/rule.rego
@@ -26,6 +26,6 @@ metadata = {
 	"description": "Protect tuned kernel parameters from overriding kubelet default kernel parameter values.",
 	"impact": "You would have to re-tune kernel parameters to match kubelet parameters.",
 	"tags": array.concat(cis_k8s.default_tags, ["CIS 4.2.6", "Kubelet"]),
-	"benchmark": cis_k8s.benchmark_name,
+	"benchmark": cis_k8s.benchmark_metadata,
 	"remediation": "If using a Kubelet config file, edit the file to set protectKernelDefaults: true. If using command line arguments, edit the kubelet service file /etc/systemd/system/kubelet.service.d/10-kubeadm.conf on each worker node and set the below parameter in KUBELET_SYSTEM_PODS_ARGS variable. --protect-kernel-defaults=true Based on your system, restart the kubelet service.",
 }

--- a/compliance/cis_k8s/rules/cis_4_2_7/rule.rego
+++ b/compliance/cis_k8s/rules/cis_4_2_7/rule.rego
@@ -28,6 +28,6 @@ metadata = {
 	"description": "Allow Kubelet to manage iptables.",
 	"impact": "Kubelet would manage the iptables on the system and keep it in sync. If you are using any other iptables management solution, then there might be some conflicts.",
 	"tags": array.concat(cis_k8s.default_tags, ["CIS 4.2.7", "Kubelet"]),
-	"benchmark": cis_k8s.benchmark_name,
+	"benchmark": cis_k8s.benchmark_metadata,
 	"remediation": "If using a Kubelet config file, edit the file to set makeIPTablesUtilChains: true. If using command line arguments, edit the kubelet service file /etc/systemd/system/kubelet.service.d/10-kubeadm.conf on each worker node and remove the --make-iptables-util-chains argument from the KUBELET_SYSTEM_PODS_ARGS variable. Based on your system, restart the kubelet service.",
 }

--- a/compliance/cis_k8s/rules/cis_5_2_1/rule.rego
+++ b/compliance/cis_k8s/rules/cis_5_2_1/rule.rego
@@ -41,6 +41,6 @@ If you need to run privileged containers, this should be defined in a separate P
 	"impact": "Pods defined with spec.containers[].securityContext.privileged: true will not be permitted.",
 	"remediation": "Create a PSP as described in the Kubernetes documentation, ensuring that the .spec.privileged field is omitted or set to false.",
 	"default_value": "By default, PodSecurityPolicies are not defined.",
-	"benchmark": cis_k8s.benchmark_name,
+	"benchmark": cis_k8s.benchmark_metadata,
 	"tags": array.concat(cis_k8s.default_tags, ["CIS 5.2.1", "Pod Security Policies"]),
 }

--- a/compliance/cis_k8s/rules/cis_5_2_2/rule.rego
+++ b/compliance/cis_k8s/rules/cis_5_2_2/rule.rego
@@ -30,6 +30,6 @@ If you need to run containers which require hostPID, this should be defined in a
 	"impact": "Pods defined with spec.hostPID: true will not be permitted unless they are run under a specific PSP.",
 	"remediation": "Create a PSP as described in the Kubernetes documentation, ensuring that the .spec.hostPID field is omitted or set to false.",
 	"default_value": "By default, PodSecurityPolicies are not defined.",
-	"benchmark": cis_k8s.benchmark_name,
+	"benchmark": cis_k8s.benchmark_metadata,
 	"tags": array.concat(cis_k8s.default_tags, ["CIS 5.2.2", "Pod Security Policies"]),
 }

--- a/compliance/cis_k8s/rules/cis_5_2_3/rule.rego
+++ b/compliance/cis_k8s/rules/cis_5_2_3/rule.rego
@@ -29,6 +29,6 @@ If you have a requirement to containers which require hostIPC, this should be de
 	"impact": "Pods defined with spec.hostIPC: true will not be permitted unless they are run under a specific PSP.",
 	"remediation": "Create a PSP as described in the Kubernetes documentation, ensuring that the .spec.hostIPC field is omitted or set to false.",
 	"default_value": "By default, PodSecurityPolicies are not defined.",
-	"benchmark": cis_k8s.benchmark_name,
+	"benchmark": cis_k8s.benchmark_metadata,
 	"tags": array.concat(cis_k8s.default_tags, ["CIS 5.2.3", "Pod Security Policies"]),
 }

--- a/compliance/cis_k8s/rules/cis_5_2_4/rule.rego
+++ b/compliance/cis_k8s/rules/cis_5_2_4/rule.rego
@@ -29,6 +29,6 @@ If you have need to run containers which require hostNetwork, this should be def
 	"impact": "Pods defined with spec.hostNetwork: true will not be permitted unless they are run under a specific PSP.",
 	"remediation": "Create a PSP as described in the Kubernetes documentation, ensuring that the .spec.hostNetwork field is omitted or set to false.",
 	"default_value": "By default, PodSecurityPolicies are not defined.",
-	"benchmark": cis_k8s.benchmark_name,
+	"benchmark": cis_k8s.benchmark_metadata,
 	"tags": array.concat(cis_k8s.default_tags, ["CIS 5.2.4", "Pod Security Policies"]),
 }

--- a/compliance/cis_k8s/rules/cis_5_2_5/rule.rego
+++ b/compliance/cis_k8s/rules/cis_5_2_5/rule.rego
@@ -40,6 +40,6 @@ this should be defined in a separate PSP and you should carefully check RBAC con
 	"impact": "Pods defined with spec.allowPrivilegeEscalation: true will not be permitted unless they are run under a specific PSP.",
 	"remediation": "Create a PSP as described in the Kubernetes documentation, ensuring that the .spec.allowPrivilegeEscalation field is omitted or set to false.",
 	"default_value": "By default, PodSecurityPolicies are not defined.",
-	"benchmark": cis_k8s.benchmark_name,
+	"benchmark": cis_k8s.benchmark_metadata,
 	"tags": array.concat(cis_k8s.default_tags, ["CIS 5.2.5", "Pod Security Policies"]),
 }

--- a/compliance/cis_k8s/rules/cis_5_2_6/rule.rego
+++ b/compliance/cis_k8s/rules/cis_5_2_6/rule.rego
@@ -46,6 +46,6 @@ If you need to run root containers, this should be defined in a separate PSP and
 	"impact": "Pods with containers which run as the root user will not be permitted.",
 	"remediation": "Create a PSP as described in the Kubernetes documentation, ensuring that the .spec.runAsUser.rule is set to either MustRunAsNonRoot or MustRunAs with the range of UIDs not including 0.",
 	"default_value": "By default, PodSecurityPolicies are not defined.",
-	"benchmark": cis_k8s.benchmark_name,
+	"benchmark": cis_k8s.benchmark_metadata,
 	"tags": array.concat(cis_k8s.default_tags, ["CIS 5.2.6", "Pod Security Policies"]),
 }

--- a/compliance/cis_k8s/rules/cis_5_2_7/rule.rego
+++ b/compliance/cis_k8s/rules/cis_5_2_7/rule.rego
@@ -46,6 +46,6 @@ this should be defined in a separate PSP and you should carefully check RBAC con
 	"impact": "Pods with containers which run with the NET_RAW capability will not be permitted.",
 	"remediation": "Create a PSP as described in the Kubernetes documentation, ensuring that the .spec.requiredDropCapabilities is set to include either NET_RAW or ALL.",
 	"default_value": "By default, PodSecurityPolicies are not defined.",
-	"benchmark": cis_k8s.benchmark_name,
+	"benchmark": cis_k8s.benchmark_metadata,
 	"tags": array.concat(cis_k8s.default_tags, ["CIS 5.2.7", "Pod Security Policies"]),
 }

--- a/compliance/cis_k8s/rules/cis_5_2_8/rule.rego
+++ b/compliance/cis_k8s/rules/cis_5_2_8/rule.rego
@@ -32,6 +32,6 @@ If you need to run containers with additional capabilities, this should be defin
 	"impact": "Pods with containers which require capabilities outwith the default set will not be permitted.",
 	"remediation": "Ensure that allowedCapabilities is not present in PSPs for the cluster unless it is set to an empty array.",
 	"default_value": "By default, PodSecurityPolicies are not defined.",
-	"benchmark": cis_k8s.benchmark_name,
+	"benchmark": cis_k8s.benchmark_metadata,
 	"tags": array.concat(cis_k8s.default_tags, ["CIS 5.2.8", "Pod Security Policies"]),
 }

--- a/compliance/cis_k8s/rules/cis_5_2_9/rule.rego
+++ b/compliance/cis_k8s/rules/cis_5_2_9/rule.rego
@@ -37,6 +37,6 @@ so from the perspective of the principal of least privilege use of capabilities 
 	"remediation": `Review the use of capabilites in applications runnning on your cluster.
 Where a namespace contains applicaions which do not require any Linux capabities to operate consider adding a PSP which forbids the admission of containers which do not drop all capabilities.`,
 	"default_value": "By default, PodSecurityPolicies are not defined.",
-	"benchmark": cis_k8s.benchmark_name,
+	"benchmark": cis_k8s.benchmark_metadata,
 	"tags": array.concat(cis_k8s.default_tags, ["CIS 5.2.9", "Pod Security Policies"]),
 }

--- a/compliance/lib/output_validations/output_validations.rego
+++ b/compliance/lib/output_validations/output_validations.rego
@@ -8,6 +8,8 @@ validate_metadata(metadata) {
 	metadata.impact
 	metadata.tags
 	metadata.benchmark
+	metadata.benchmark.name
+	metadata.benchmark.version
 	metadata.remediation
 } else = false {
 	true

--- a/compliance/lib/output_validations/test.rego
+++ b/compliance/lib/output_validations/test.rego
@@ -6,7 +6,7 @@ test_validate_metadata_invalid_remediation {
 		"description": "rule description",
 		"impact": "rule impact",
 		"tags": ["tag 1", "tag 2"],
-		"benchmark": "benchmark name-version",
+		"benchmark": {"name": "benchmark", "version": "v1.0.0"},
 		"Remediation": "rule remidiation", # <- capitalized. should be "remediation"
 	}
 
@@ -19,7 +19,7 @@ test_validate_metadata_invalid_name {
 		"description": "rule description",
 		"impact": "rule impact",
 		"tags": ["tag 1", "tag 2"],
-		"benchmark": "benchmark name-version",
+		"benchmark": {"name": "benchmark", "version": "v1.0.0"},
 		"remediation": "rule remidiation",
 	}
 
@@ -32,7 +32,7 @@ test_validate_metadata_invalid_desc {
 		"Description": "rule description", # <- capitalized. should be "Description"
 		"impact": "rule impact",
 		"tags": ["tag 1", "tag 2"],
-		"benchmark": "benchmark name-version",
+		"benchmark": {"name": "benchmark", "version": "v1.0.0"},
 		"remediation": "rule remidiation",
 	}
 
@@ -45,7 +45,7 @@ test_validate_metadata_invalid_impact {
 		"description": "rule description",
 		"Impact": "rule impact", # <- capitalized. should be "impact"
 		"tags": ["tag 1", "tag 2"],
-		"benchmark": "benchmark name-version",
+		"benchmark": {"name": "benchmark", "version": "v1.0.0"},
 		"remediation": "rule remidiation",
 	}
 
@@ -58,7 +58,7 @@ test_validate_metadata_invalid_tags {
 		"description": "rule description",
 		"impact": "rule impact",
 		"Tags": ["tag 1", "tag 2"], # <- capitalized. should be "tags"
-		"benchmark": "benchmark name-version",
+		"benchmark": {"name": "benchmark", "version": "v1.0.0"},
 		"remediation": "rule remidiation",
 	}
 
@@ -71,7 +71,7 @@ test_validate_metadata_invalid_benchmark {
 		"description": "rule description",
 		"impact": "rule impact",
 		"tags": ["tag 1", "tag 2"],
-		"Benchmark": "benchmark name-version", # <- capitalized. should be "benchmark"
+		"Benchmark": {"name": "benchmark", "version": "v1.0.0"}, # <- capitalized. should be "benchmark"
 		"remediation": "rule remidiation",
 	}
 
@@ -84,7 +84,7 @@ test_validate_metadata_invalid_remediation {
 		"description": "rule description",
 		"impact": "rule impact",
 		"tags": ["tag 1", "tag 2"],
-		"benchmark": "benchmark name-version",
+		"benchmark": {"name": "benchmark", "version": "v1.0.0"},
 		"Remediation": "rule remidiation", # <- capitalized. should be "remediation"
 	}
 
@@ -97,7 +97,7 @@ test_validate_metadata_valid {
 		"description": "rule description",
 		"impact": "rule impact",
 		"tags": ["tag 1", "tag 2"],
-		"benchmark": "benchmark name-version",
+		"benchmark": {"name": "benchmark", "version": "v1.0.0"},
 		"remediation": "rule remidiation",
 	}
 


### PR DESCRIPTION
Update the `benchmark` field according to the [doc](https://github.com/elastic/security-team/blob/main/docs/cloud-security-posture-team/Onboarding/Security_Policies.md), i.e.:
```rego
benchmark_name := "CIS Amazon Elastic Kubernetes Service (EKS) Benchmark"
```
into:
```rego
benchmark_metadata := {
	"name": "CIS Amazon Elastic Kubernetes Service (EKS) Benchmark",
	"version": "v1.0.1",
}
```
____
- related: https://github.com/elastic/security-team/issues/3177
- closes: https://github.com/elastic/security-team/issues/3178