### PR TITLE
Adding-pod-security-policy-rules-for-EKS

### DIFF
--- a/compliance/cis_eks/rules/cis_4_2_1/rule.rego
+++ b/compliance/cis_eks/rules/cis_4_2_1/rule.rego
@@ -1,0 +1,46 @@
+package compliance.cis_eks.rules.cis_4_2_1
+
+import data.compliance.cis_eks
+import data.compliance.lib.assert
+import data.compliance.lib.common
+import data.compliance.lib.data_adapter
+
+# Minimize the admission of privileged containers (Automated)
+
+# evaluate
+default rule_evaluation = true
+
+# Verify that there is at least one PSP which does not return true.
+rule_evaluation = false {
+	container := data_adapter.containers[_]
+	common.contains_key_with_value(container.securityContext, "privileged", true)
+}
+
+finding = result {
+	# filter
+	data_adapter.is_kube_api
+
+	# set result
+	result := {
+		"evaluation": common.calculate_result(rule_evaluation),
+		"evidence": {
+			"uid": data_adapter.pod.uid,
+			"containers": {json.filter(c, ["name", "securityContext/privileged"]) | c := data_adapter.containers[_]},
+		},
+	}
+}
+
+metadata = {
+	"name": "Minimize the admission of privileged containers",
+	"description": "Do not generally permit containers to be run with the securityContext.privileged flag set to true.",
+	"rationale": `Privileged containers have access to all Linux Kernel capabilities and devices.
+A container running with full privileges can do almost everything that the host can do.
+This flag exists to allow special use-cases, like manipulating the network stack and accessing devices.
+There should be at least one PodSecurityPolicy (PSP) defined which does not permit privileged containers.
+If you need to run privileged containers, this should be defined in a separate PSP and you should carefully check RBAC controls to ensure that only limited service accounts and users are given permission to access that PSP.`,
+	"impact": "Pods defined with spec.containers[].securityContext.privileged: true will not be permitted.",
+	"remediation": "Create a PSP as described in the Kubernetes documentation, ensuring that the .spec.privileged field is omitted or set to false.",
+	"default_value": "By default, when you provision an EKS cluster, a pod security policy called eks.privileged is automatically created.",
+	"benchmark": cis_eks.benchmark_metadata,
+	"tags": array.concat(cis_eks.default_tags, ["CIS 4.2.1", "Pod Security Policies"]),
+}

--- a/compliance/cis_eks/rules/cis_4_2_1/test.rego
+++ b/compliance/cis_eks/rules/cis_4_2_1/test.rego
@@ -1,0 +1,68 @@
+package compliance.cis_eks.rules.cis_4_2_1
+
+import data.kubernetes_common.test_data
+import data.lib.test
+
+test_violation {
+	test.assert_fail(finding) with input as rule_input(violating_psp)
+	test.assert_fail(finding) with input as rule_input(violating_psp2)
+	test.assert_fail(finding) with input as rule_input(violating_psp3)
+	test.assert_fail(finding) with input as rule_input(violating_psp4)
+}
+
+test_pass {
+	test.assert_pass(finding) with input as rule_input(non_violating_psp)
+	test.assert_pass(finding) with input as rule_input(non_violating_psp2)
+}
+
+test_not_evaluated {
+	not finding with input as {"type": "no-kube-api"}
+}
+
+rule_input(resource) = test_data.kube_api_input(resource)
+
+violating_psp = {
+	"kind": "Pod",
+	"uid": "00000aa0-0aa0-00aa-00aa-00aa000a0000",
+	"spec": {"containers": [{"name": "container_1", "securityContext": {"privileged": true}}]},
+}
+
+violating_psp2 = {
+	"kind": "Pod",
+	"uid": "00000aa0-0aa0-00aa-00aa-00aa000a0000",
+	"spec": {"containers": [
+		{"name": "container_1", "securityContext": {"privileged": true}},
+		{"name": "container_2", "securityContext": {"privileged": false}},
+	]},
+}
+
+violating_psp3 = {
+	"kind": "Pod",
+	"uid": "00000aa0-0aa0-00aa-00aa-00aa000a0000",
+	"spec": {"containers": [
+		{"name": "container_1", "securityContext": {"privileged": true}},
+		{"name": "container_2", "securityContext": {}},
+	]},
+}
+
+violating_psp4 = {
+	"kind": "Pod",
+	"uid": "00000aa0-0aa0-00aa-00aa-00aa000a0000",
+	"spec": {"containers": [
+		{"name": "container_1", "securityContext": {"privileged": true}},
+		{"name": "container_2", "securityContext": {}},
+		{"name": "container_3"},
+	]},
+}
+
+non_violating_psp = {
+	"kind": "Pod",
+	"uid": "00000aa0-0aa0-00aa-00aa-00aa000a0000",
+	"spec": {"containers": [{"name": "container_1", "securityContext": {"privileged": false}}]},
+}
+
+non_violating_psp2 = {
+	"kind": "Pod",
+	"uid": "00000aa0-0aa0-00aa-00aa-00aa000a0000",
+	"spec": {"containers": [{"name": "container_1", "securityContext": {}}]},
+}

--- a/compliance/cis_eks/rules/cis_4_2_2/rule.rego
+++ b/compliance/cis_eks/rules/cis_4_2_2/rule.rego
@@ -1,0 +1,35 @@
+package compliance.cis_eks.rules.cis_4_2_2
+
+import data.compliance.cis_eks
+import data.compliance.lib.assert
+import data.compliance.lib.common
+import data.compliance.lib.data_adapter
+
+# Minimize the admission of containers wishing to share the host process ID namespace (Automated)
+finding = result {
+	# filter
+	data_adapter.is_kube_api
+
+	# evaluate
+	rule_evaluation := assert.is_false(common.contains_key_with_value(data_adapter.pod.spec, "hostPID", true))
+
+	# set result
+	result := {
+		"evaluation": common.calculate_result(rule_evaluation),
+		"evidence": json.filter(data_adapter.pod, ["uid", "spec/hostPID"]),
+	}
+}
+
+metadata = {
+	"name": "Minimize the admission of containers wishing to share the host process ID namespace",
+	"description": "Do not generally permit containers to be run with the hostPID flag set to true.",
+	"rationale": `A container running in the host's PID namespace can inspect processes running outside the container.
+If the container also has access to ptrace capabilities this can be used to escalate privileges outside of the container.
+There should be at least one PodSecurityPolicy (PSP) defined which does not permit containers to share the host PID namespace.
+If you need to run containers which require hostPID, this should be defined in a separate PSP and you should carefully check RBAC controls to ensure that only limited service accounts and users are given permission to access that PSP.`,
+	"impact": "Pods defined with spec.hostPID: true will not be permitted unless they are run under a specific PSP.",
+	"remediation": "Create a PSP as described in the Kubernetes documentation, ensuring that the .spec.hostPID field is omitted or set to false.",
+	"default_value": "By default, PodSecurityPolicies are not defined.",
+	"benchmark": cis_eks.benchmark_metadata,
+	"tags": array.concat(cis_eks.default_tags, ["CIS 4.2.2", "Pod Security Policies"]),
+}

--- a/compliance/cis_eks/rules/cis_4_2_2/test.rego
+++ b/compliance/cis_eks/rules/cis_4_2_2/test.rego
@@ -1,0 +1,37 @@
+package compliance.cis_eks.rules.cis_4_2_2
+
+import data.kubernetes_common.test_data
+import data.lib.test
+
+test_violation {
+	test.assert_fail(finding) with input as rule_input(violating_psp)
+}
+
+test_pass {
+	test.assert_pass(finding) with input as rule_input(non_violating_psp)
+	test.assert_pass(finding) with input as rule_input(non_violating_psp2)
+}
+
+test_not_evaluated {
+	not finding with input as {"type": "no-kube-api"}
+}
+
+rule_input(resource) = test_data.kube_api_input(resource)
+
+violating_psp = {
+	"kind": "Pod",
+	"uid": "00000aa0-0aa0-00aa-00aa-00aa000a0000",
+	"spec": {"hostPID": true},
+}
+
+non_violating_psp = {
+	"kind": "Pod",
+	"uid": "00000aa0-0aa0-00aa-00aa-00aa000a0000",
+	"spec": {},
+}
+
+non_violating_psp2 = {
+	"kind": "Pod",
+	"uid": "00000aa0-0aa0-00aa-00aa-00aa000a0000",
+	"spec": {"hostPID": false},
+}

--- a/compliance/cis_eks/rules/cis_4_2_3/rule.rego
+++ b/compliance/cis_eks/rules/cis_4_2_3/rule.rego
@@ -1,0 +1,34 @@
+package compliance.cis_eks.rules.cis_4_2_3
+
+import data.compliance.cis_eks
+import data.compliance.lib.assert
+import data.compliance.lib.common
+import data.compliance.lib.data_adapter
+
+# Minimize the admission of containers wishing to share the host IPC namespace (Automated)
+finding = result {
+	# filter
+	data_adapter.is_kube_api
+
+	# evaluate
+	rule_evaluation := assert.is_false(common.contains_key_with_value(data_adapter.pod.spec, "hostIPC", true))
+
+	# set result
+	result := {
+		"evaluation": common.calculate_result(rule_evaluation),
+		"evidence": json.filter(data_adapter.pod, ["uid", "spec/hostIPC"]),
+	}
+}
+
+metadata = {
+	"name": "Minimize the admission of containers wishing to share the host process IPC namespace",
+	"description": "Do not generally permit containers to be run with the hostIPC flag set to true.",
+	"rationale": `A container running in the host's IPC namespace can use IPC to interact with processes outside the container.
+There should be at least one PodSecurityPolicy (PSP) defined which does not permit containers to share the host IPC namespace.
+If you have a requirement to containers which require hostIPC, this should be defined in a separate PSP and you should carefully check RBAC controls to ensure that only limited service accounts and users are given permission to access that PSP.`,
+	"impact": "Pods defined with spec.hostIPC: true will not be permitted unless they are run under a specific PSP.",
+	"remediation": "Create a PSP as described in the Kubernetes documentation, ensuring that the .spec.hostIPC field is omitted or set to false.",
+	"default_value": "By default, PodSecurityPolicies are not defined.",
+	"benchmark": cis_eks.benchmark_metadata,
+	"tags": array.concat(cis_eks.default_tags, ["CIS 4.2.3", "Pod Security Policies"]),
+}

--- a/compliance/cis_eks/rules/cis_4_2_3/test.rego
+++ b/compliance/cis_eks/rules/cis_4_2_3/test.rego
@@ -1,0 +1,37 @@
+package compliance.cis_eks.rules.cis_4_2_3
+
+import data.kubernetes_common.test_data
+import data.lib.test
+
+test_violation {
+	test.assert_fail(finding) with input as rule_input(violating_psp)
+}
+
+test_pass {
+	test.assert_pass(finding) with input as rule_input(non_violating_psp)
+	test.assert_pass(finding) with input as rule_input(non_violating_psp2)
+}
+
+test_not_evaluated {
+	not finding with input as {"type": "no-kube-api"}
+}
+
+rule_input(resource) = test_data.kube_api_input(resource)
+
+violating_psp = {
+	"kind": "Pod",
+	"uid": "00000aa0-0aa0-00aa-00aa-00aa000a0000",
+	"spec": {"hostIPC": true},
+}
+
+non_violating_psp = {
+	"kind": "Pod",
+	"uid": "00000aa0-0aa0-00aa-00aa-00aa000a0000",
+	"spec": {},
+}
+
+non_violating_psp2 = {
+	"kind": "Pod",
+	"uid": "00000aa0-0aa0-00aa-00aa-00aa000a0000",
+	"spec": {"hostIPC": false},
+}

--- a/compliance/cis_eks/rules/cis_4_2_4/rule.rego
+++ b/compliance/cis_eks/rules/cis_4_2_4/rule.rego
@@ -1,0 +1,34 @@
+package compliance.cis_eks.rules.cis_4_2_4
+
+import data.compliance.cis_eks
+import data.compliance.lib.assert
+import data.compliance.lib.common
+import data.compliance.lib.data_adapter
+
+# Minimize the admission of containers wishing to share the host network namespace (Automated)
+finding = result {
+	# filter
+	data_adapter.is_kube_api
+
+	# evaluate
+	rule_evaluation := assert.is_false(common.contains_key_with_value(data_adapter.pod.spec, "hostNetwork", true))
+
+	# set result
+	result := {
+		"evaluation": common.calculate_result(rule_evaluation),
+		"evidence": json.filter(data_adapter.pod, ["uid", "spec/hostNetwork"]),
+	}
+}
+
+metadata = {
+	"name": "Minimize the admission of containers wishing to share the host network namespace",
+	"description": "Do not generally permit containers to be run with the hostNetwork flag set to true.",
+	"rationale": `A container running in the host's network namespace could access the local loopback device, and could access network traffic to and from other pods.
+There should be at least one PodSecurityPolicy (PSP) defined which does not permit containers to share the host network namespace.
+If you have need to run containers which require hostNetwork, this should be defined in a separate PSP and you should carefully check RBAC controls to ensure that only limited service accounts and users are given permission to access that PSP.`,
+	"impact": "Pods defined with spec.hostNetwork: true will not be permitted unless they are run under a specific PSP.",
+	"remediation": "Create a PSP as described in the Kubernetes documentation, ensuring that the .spec.hostNetwork field is omitted or set to false.",
+	"default_value": "By default, PodSecurityPolicies are not defined.",
+	"benchmark": cis_eks.benchmark_metadata,
+	"tags": array.concat(cis_eks.default_tags, ["CIS 4.2.4", "Pod Security Policies"]),
+}

--- a/compliance/cis_eks/rules/cis_4_2_4/test.rego
+++ b/compliance/cis_eks/rules/cis_4_2_4/test.rego
@@ -1,0 +1,37 @@
+package compliance.cis_eks.rules.cis_4_2_4
+
+import data.kubernetes_common.test_data
+import data.lib.test
+
+test_violation {
+	test.assert_fail(finding) with input as rule_input(violating_psp)
+}
+
+test_pass {
+	test.assert_pass(finding) with input as rule_input(non_violating_psp)
+	test.assert_pass(finding) with input as rule_input(non_violating_psp2)
+}
+
+test_not_evaluated {
+	not finding with input as {"type": "no-kube-api"}
+}
+
+rule_input(resource) = test_data.kube_api_input(resource)
+
+violating_psp = {
+	"kind": "Pod",
+	"uid": "00000aa0-0aa0-00aa-00aa-00aa000a0000",
+	"spec": {"hostNetwork": true},
+}
+
+non_violating_psp = {
+	"kind": "Pod",
+	"uid": "00000aa0-0aa0-00aa-00aa-00aa000a0000",
+	"spec": {},
+}
+
+non_violating_psp2 = {
+	"kind": "Pod",
+	"uid": "00000aa0-0aa0-00aa-00aa-00aa000a0000",
+	"spec": {"hostNetwork": false},
+}

--- a/compliance/cis_eks/rules/cis_4_2_5/rule.rego
+++ b/compliance/cis_eks/rules/cis_4_2_5/rule.rego
@@ -1,0 +1,45 @@
+package compliance.cis_eks.rules.cis_4_2_5
+
+import data.compliance.cis_eks
+import data.compliance.lib.assert
+import data.compliance.lib.common
+import data.compliance.lib.data_adapter
+
+# Minimize the admission of containers with allowPrivilegeEscalation (Automated)
+
+# evaluate
+default rule_evaluation = true
+
+# Verify that there is at least one PSP which does not return true.
+rule_evaluation = false {
+	container := data_adapter.containers[_]
+	common.contains_key_with_value(container.securityContext, "allowPrivilegeEscalation", true)
+}
+
+finding = result {
+	# filter
+	data_adapter.is_kube_api
+
+	# set result
+	result := {
+		"evaluation": common.calculate_result(rule_evaluation),
+		"evidence": {
+			"uid": data_adapter.pod.uid,
+			"containers": {json.filter(c, ["name", "securityContext/allowPrivilegeEscalation"]) | c := data_adapter.containers[_]},
+		},
+	}
+}
+
+metadata = {
+	"name": "Minimize the admission of containers with allowPrivilegeEscalation",
+	"description": "Do not generally permit containers to be run with the allowPrivilegeEscalation flag set to true",
+	"rationale": `A container running with the allowPrivilegeEscalation flag set to true may have processes that can gain more privileges than their parent.
+There should be at least one PodSecurityPolicy (PSP) defined which does not permit containers to allow privilege escalation. The option exists (and is defaulted to true) to permit setuid binaries to run.
+If you have need to run containers which use setuid binaries or require privilege escalation,
+this should be defined in a separate PSP and you should carefully check RBAC controls to ensure that only limited service accounts and users are given permission to access that PSP.`,
+	"impact": "Pods defined with spec.allowPrivilegeEscalation: true will not be permitted unless they are run under a specific PSP.",
+	"remediation": "Create a PSP as described in the Kubernetes documentation, ensuring that the .spec.allowPrivilegeEscalation field is omitted or set to false.",
+	"default_value": "By default, PodSecurityPolicies are not defined.",
+	"benchmark": cis_eks.benchmark_metadata,
+	"tags": array.concat(cis_eks.default_tags, ["CIS 4.2.5", "Pod Security Policies"]),
+}

--- a/compliance/cis_eks/rules/cis_4_2_5/test.rego
+++ b/compliance/cis_eks/rules/cis_4_2_5/test.rego
@@ -1,0 +1,68 @@
+package compliance.cis_eks.rules.cis_4_2_5
+
+import data.kubernetes_common.test_data
+import data.lib.test
+
+test_violation {
+	test.assert_fail(finding) with input as rule_input(violating_psp)
+	test.assert_fail(finding) with input as rule_input(violating_psp2)
+	test.assert_fail(finding) with input as rule_input(violating_psp3)
+	test.assert_fail(finding) with input as rule_input(violating_psp4)
+}
+
+test_pass {
+	test.assert_pass(finding) with input as rule_input(non_violating_psp)
+	test.assert_pass(finding) with input as rule_input(non_violating_psp2)
+}
+
+test_not_evaluated {
+	not finding with input as {"type": "no-kube-api"}
+}
+
+rule_input(resource) = test_data.kube_api_input(resource)
+
+violating_psp = {
+	"kind": "Pod",
+	"uid": "00000aa0-0aa0-00aa-00aa-00aa000a0000",
+	"spec": {"containers": [{"name": "container_1", "securityContext": {"allowPrivilegeEscalation": true}}]},
+}
+
+violating_psp2 = {
+	"kind": "Pod",
+	"uid": "00000aa0-0aa0-00aa-00aa-00aa000a0000",
+	"spec": {"containers": [
+		{"name": "container_1", "securityContext": {"allowPrivilegeEscalation": true}},
+		{"name": "container_2", "securityContext": {"allowPrivilegeEscalation": false}},
+	]},
+}
+
+violating_psp3 = {
+	"kind": "Pod",
+	"uid": "00000aa0-0aa0-00aa-00aa-00aa000a0000",
+	"spec": {"containers": [
+		{"name": "container_1", "securityContext": {"allowPrivilegeEscalation": true}},
+		{"name": "container_2", "securityContext": {}},
+	]},
+}
+
+violating_psp4 = {
+	"kind": "Pod",
+	"uid": "00000aa0-0aa0-00aa-00aa-00aa000a0000",
+	"spec": {"containers": [
+		{"name": "container_1", "securityContext": {"allowPrivilegeEscalation": true}},
+		{"name": "container_2", "securityContext": {}},
+		{"name": "container_3"},
+	]},
+}
+
+non_violating_psp = {
+	"kind": "Pod",
+	"uid": "00000aa0-0aa0-00aa-00aa-00aa000a0000",
+	"spec": {"containers": [{"name": "container_1", "securityContext": {"allowPrivilegeEscalation": false}}]},
+}
+
+non_violating_psp2 = {
+	"kind": "Pod",
+	"uid": "00000aa0-0aa0-00aa-00aa-00aa000a0000",
+	"spec": {"containers": [{"name": "container_1", "securityContext": {}}]},
+}

--- a/compliance/cis_eks/rules/cis_4_2_6/rule.rego
+++ b/compliance/cis_eks/rules/cis_4_2_6/rule.rego
@@ -1,0 +1,51 @@
+package compliance.cis_eks.rules.cis_4_2_6
+
+import data.compliance.cis_eks
+import data.compliance.lib.assert
+import data.compliance.lib.common
+import data.compliance.lib.data_adapter
+
+# Minimize the admission of root containers (Automated)
+
+# evaluate
+default rule_evaluation = true
+
+# Verify that there is at least one PSP which returns MustRunAsNonRoot or MustRunAs with the range of UIDs not including 0.
+rule_evaluation = false {
+	not common.contains_key_with_value(data_adapter.pod.spec.runAsUser, "rule", "MustRunAsNonRoot")
+	common.contains_key_with_value(data_adapter.pod.spec.runAsUser, "rule", "MustRunAs")
+	range := data_adapter.pod.spec.runAsUser.ranges[_]
+	range.min <= 0
+}
+
+rule_evaluation = false {
+	container := data_adapter.containers[_]
+	common.contains_key_with_value(container.securityContext, "runAsUser", 0)
+}
+
+finding = result {
+	# filter
+	data_adapter.is_kube_api
+
+	# set result
+	pod := json.filter(data_adapter.pod, ["uid", "spec/runAsUser"])
+	containers := {"containers": json.filter(c, ["name", "securityContext/runAsUser"]) | c := data_adapter.containers[_]}
+	result := {
+		"evaluation": common.calculate_result(rule_evaluation),
+		"evidence": object.union(pod, containers),
+	}
+}
+
+metadata = {
+	"name": "Minimize the admission of root containers",
+	"description": "Do not generally permit containers to be run as the root user.",
+	"rationale": `Containers may run as any Linux user. Containers which run as the root user, whilst constrained by Container Runtime security features still have a escalated likelihood of container breakout.
+Ideally, all containers should run as a defined non-UID 0 user.
+There should be at least one PodSecurityPolicy (PSP) defined which does not permit root users in a container.
+If you need to run root containers, this should be defined in a separate PSP and you should carefully check RBAC controls to ensure that only limited service accounts and users are given permission to access that PSP.`,
+	"impact": "Pods with containers which run as the root user will not be permitted.",
+	"remediation": "Create a PSP as described in the Kubernetes documentation, ensuring that the .spec.runAsUser.rule is set to either MustRunAsNonRoot or MustRunAs with the range of UIDs not including 0.",
+	"default_value": "By default, PodSecurityPolicies are not defined.",
+	"benchmark": cis_eks.benchmark_metadata,
+	"tags": array.concat(cis_eks.default_tags, ["CIS 4.2.6", "Pod Security Policies"]),
+}

--- a/compliance/cis_eks/rules/cis_4_2_6/test.rego
+++ b/compliance/cis_eks/rules/cis_4_2_6/test.rego
@@ -1,0 +1,72 @@
+package compliance.cis_eks.rules.cis_4_2_6
+
+import data.kubernetes_common.test_data
+import data.lib.test
+
+test_violation {
+	test.assert_fail(finding) with input as rule_input(violating_psp)
+	test.assert_fail(finding) with input as rule_input(violating_psp2)
+	test.assert_fail(finding) with input as rule_input(violating_psp3)
+}
+
+test_pass {
+	test.assert_pass(finding) with input as rule_input(non_violating_psp)
+	test.assert_pass(finding) with input as rule_input(non_violating_psp2)
+}
+
+test_not_evaluated {
+	not finding with input as {"type": "no-kube-api"}
+}
+
+rule_input(resource) = test_data.kube_api_input(resource)
+
+violating_psp = {
+	"kind": "Pod",
+	"uid": "00000aa0-0aa0-00aa-00aa-00aa000a0000",
+	"spec": {"runAsUser": {
+		"rule": "MustRunAs",
+		"ranges": [{
+			"min": 0,
+			"max": 65535,
+		}],
+	}},
+}
+
+violating_psp2 = {
+	"kind": "Pod",
+	"uid": "00000aa0-0aa0-00aa-00aa-00aa000a0000",
+	"spec": {"containers": [{"name": "container_1", "securityContext": {"runAsUser": 0}}]},
+}
+
+violating_psp3 = {
+	"kind": "Pod",
+	"uid": "00000aa0-0aa0-00aa-00aa-00aa000a0000",
+	"spec": {
+		"runAsUser": {
+			"rule": "MustRunAs",
+			"ranges": [{
+				"min": 1,
+				"max": 65535,
+			}],
+		},
+		"containers": [{"name": "container_1", "securityContext": {"runAsUser": 0}}],
+	},
+}
+
+non_violating_psp = {
+	"kind": "Pod",
+	"uid": "00000aa0-0aa0-00aa-00aa-00aa000a0000",
+	"spec": {"runAsUser": {
+		"rule": "MustRunAs",
+		"ranges": [{
+			"min": 1,
+			"max": 65535,
+		}],
+	}},
+}
+
+non_violating_psp2 = {
+	"kind": "Pod",
+	"uid": "00000aa0-0aa0-00aa-00aa-00aa000a0000",
+	"spec": {"runAsUser": {"rule": "MustRunAsNonRoot"}},
+}

--- a/compliance/cis_eks/rules/cis_4_2_7/rule.rego
+++ b/compliance/cis_eks/rules/cis_4_2_7/rule.rego
@@ -1,0 +1,51 @@
+package compliance.cis_eks.rules.cis_4_2_7
+
+import data.compliance.cis_eks
+import data.compliance.lib.assert
+import data.compliance.lib.common
+import data.compliance.lib.data_adapter
+
+# Minimize the admission of containers with the NET_RAW capability (Automated)
+
+# evaluate
+default rule_evaluation = false
+
+# Verify that there is at least one PSP which returns NET_RAW or ALL.
+rule_evaluation {
+	# Verify that there is at least one PSP which returns NET_RAW.
+	data_adapter.pod.spec.requiredDropCapabilities[_] == "NET_RAW"
+}
+
+# or 
+rule_evaluation {
+	# Verify that there is at least one PSP which returns ALL.
+	data_adapter.pod.spec.requiredDropCapabilities[_] == "ALL"
+}
+
+finding = result {
+	# filter
+	data_adapter.is_kube_api
+
+	# set result
+	result := {
+		"evaluation": common.calculate_result(rule_evaluation),
+		"evidence": json.filter(data_adapter.pod, ["uid", "spec/requiredDropCapabilities"]),
+	}
+}
+
+metadata = {
+	"name": "Minimize the admission of containers with the NET_RAW capability",
+	"description": "Do not generally permit containers with the potentially dangerous NET_RAW capability.",
+	"rationale": `Containers run with a default set of capabilities as assigned by the Container Runtime.
+By default this can include potentially dangerous capabilities.
+With Docker as the container runtime the NET_RAW capability is enabled which may be misused by malicious containers.
+Ideally, all containers should drop this capability.
+There should be at least one PodSecurityPolicy (PSP) defined which prevents containers with the NET_RAW capability from launching.
+If you need to run containers with this capability,
+this should be defined in a separate PSP and you should carefully check RBAC controls to ensure that only limited service accounts and users are given permission to access that PSP.`,
+	"impact": "Pods with containers which run with the NET_RAW capability will not be permitted.",
+	"remediation": "Create a PSP as described in the Kubernetes documentation, ensuring that the .spec.requiredDropCapabilities is set to include either NET_RAW or ALL.",
+	"default_value": "By default, PodSecurityPolicies are not defined.",
+	"benchmark": cis_eks.benchmark_metadata,
+	"tags": array.concat(cis_eks.default_tags, ["CIS 4.2.7", "Pod Security Policies"]),
+}

--- a/compliance/cis_eks/rules/cis_4_2_7/test.rego
+++ b/compliance/cis_eks/rules/cis_4_2_7/test.rego
@@ -1,0 +1,37 @@
+package compliance.cis_eks.rules.cis_4_2_7
+
+import data.kubernetes_common.test_data
+import data.lib.test
+
+test_violation {
+	test.assert_fail(finding) with input as rule_input(violating_psp)
+}
+
+test_pass {
+	test.assert_pass(finding) with input as rule_input(non_violating_psp)
+	test.assert_pass(finding) with input as rule_input(non_violating_psp2)
+}
+
+test_not_evaluated {
+	not finding with input as {"type": "no-kube-api"}
+}
+
+rule_input(resource) = test_data.kube_api_input(resource)
+
+violating_psp = {
+	"kind": "Pod",
+	"uid": "00000aa0-0aa0-00aa-00aa-00aa000a0000",
+	"spec": {"requiredDropCapabilities": []},
+}
+
+non_violating_psp = {
+	"kind": "Pod",
+	"uid": "00000aa0-0aa0-00aa-00aa-00aa000a0000",
+	"spec": {"requiredDropCapabilities": ["ALL"]},
+}
+
+non_violating_psp2 = {
+	"kind": "Pod",
+	"uid": "00000aa0-0aa0-00aa-00aa-00aa000a0000",
+	"spec": {"requiredDropCapabilities": ["NET_RAW"]},
+}

--- a/compliance/cis_eks/rules/cis_4_2_8/rule.rego
+++ b/compliance/cis_eks/rules/cis_4_2_8/rule.rego
@@ -1,0 +1,37 @@
+package compliance.cis_eks.rules.cis_4_2_8
+
+import data.compliance.cis_eks
+import data.compliance.lib.assert
+import data.compliance.lib.common
+import data.compliance.lib.data_adapter
+
+# Minimize the admission of containers with added capabilities (Automated)
+
+finding = result {
+	# filter
+	data_adapter.is_kube_api
+
+	# evaluate
+	allowedCapabilities := object.get(data_adapter.pod.spec, "allowedCapabilities", [])
+	rule_evaluation := assert.array_is_empty(allowedCapabilities)
+
+	# set result
+	result := {
+		"evaluation": common.calculate_result(rule_evaluation),
+		"evidence": json.filter(data_adapter.pod, ["uid", "spec/allowedCapabilities"]),
+	}
+}
+
+metadata = {
+	"name": "Minimize the admission of containers with added capabilities",
+	"description": "Do not generally permit containers with capabilities assigned beyond the default set.",
+	"rationale": `Containers run with a default set of capabilities as assigned by the Container Runtime.
+Capabilities outside this set can be added to containers which could expose them to risks of container breakout attacks.
+There should be at least one PodSecurityPolicy (PSP) defined which prevents containers with capabilities beyond the default set from launching.
+If you need to run containers with additional capabilities, this should be defined in a separate PSP and you should carefully check RBAC controls to ensure that only limited service accounts and users are given permission to access that PSP.`,
+	"impact": "Pods with containers which require capabilities outwith the default set will not be permitted.",
+	"remediation": "Ensure that allowedCapabilities is not present in PSPs for the cluster unless it is set to an empty array.",
+	"default_value": "By default, PodSecurityPolicies are not defined.",
+	"benchmark": cis_eks.benchmark_metadata,
+	"tags": array.concat(cis_eks.default_tags, ["CIS 4.2.8", "Pod Security Policies"]),
+}

--- a/compliance/cis_eks/rules/cis_4_2_8/test.rego
+++ b/compliance/cis_eks/rules/cis_4_2_8/test.rego
@@ -1,0 +1,37 @@
+package compliance.cis_eks.rules.cis_4_2_8
+
+import data.kubernetes_common.test_data
+import data.lib.test
+
+test_violation {
+	test.assert_fail(finding) with input as rule_input(violating_psp)
+}
+
+test_pass {
+	test.assert_pass(finding) with input as rule_input(non_violating_psp)
+	test.assert_pass(finding) with input as rule_input(non_violating_psp2)
+}
+
+test_not_evaluated {
+	not finding with input as {"type": "no-kube-api"}
+}
+
+rule_input(resource) = test_data.kube_api_input(resource)
+
+violating_psp = {
+	"kind": "Pod",
+	"uid": "00000aa0-0aa0-00aa-00aa-00aa000a0000",
+	"spec": {"allowedCapabilities": ["ALL"]},
+}
+
+non_violating_psp = {
+	"kind": "Pod",
+	"uid": "00000aa0-0aa0-00aa-00aa-00aa000a0000",
+	"spec": {},
+}
+
+non_violating_psp2 = {
+	"kind": "Pod",
+	"uid": "00000aa0-0aa0-00aa-00aa-00aa000a0000",
+	"spec": {"allowedCapabilities": []},
+}

--- a/compliance/cis_eks/rules/cis_4_2_9/rule.rego
+++ b/compliance/cis_eks/rules/cis_4_2_9/rule.rego
@@ -1,0 +1,42 @@
+package compliance.cis_eks.rules.cis_4_2_9
+
+import data.compliance.cis_eks
+import data.compliance.lib.assert
+import data.compliance.lib.common
+import data.compliance.lib.data_adapter
+
+# Minimize the admission of containers with capabilities assigned (Manual)
+# evaluate
+default rule_evaluation = true
+
+rule_evaluation = false {
+	container := data_adapter.containers[_]
+	capabilities := object.get(container.securityContext, "capabilities", [])
+	not assert.array_is_empty(capabilities)
+}
+
+finding = result {
+	# filter
+	data_adapter.is_kube_api
+
+	# set result
+	result := {
+		"evaluation": common.calculate_result(rule_evaluation),
+		"containers": {json.filter(c, ["name", "securityContext/capabilities"]) | c := data_adapter.containers[_]},
+	}
+}
+
+metadata = {
+	"name": "Minimize the admission of containers with capabilities assigned",
+	"description": "Do not generally permit containers with capabilities",
+	"rationale": `Containers run with a default set of capabilities as assigned by the Container Runtime.
+Capabilities are parts of the rights generally granted on a Linux system to the root user.
+In many cases applications running in containers do not require any capabilities to operate,
+so from the perspective of the principal of least privilege use of capabilities should be minimized.`,
+	"impact": "Pods with containers require capabilities to operate will not be permitted.",
+	"remediation": `Review the use of capabilites in applications runnning on your cluster.
+Where a namespace contains applicaions which do not require any Linux capabities to operate consider adding a PSP which forbids the admission of containers which do not drop all capabilities.`,
+	"default_value": "By default, PodSecurityPolicies are not defined.",
+	"benchmark": cis_eks.benchmark_metadata,
+	"tags": array.concat(cis_eks.default_tags, ["CIS 4.2.9", "Pod Security Policies"]),
+}

--- a/compliance/cis_eks/rules/cis_4_2_9/test.rego
+++ b/compliance/cis_eks/rules/cis_4_2_9/test.rego
@@ -1,0 +1,37 @@
+package compliance.cis_eks.rules.cis_4_2_9
+
+import data.kubernetes_common.test_data
+import data.lib.test
+
+test_violation {
+	test.assert_fail(finding) with input as rule_input(violating_psp)
+}
+
+test_pass {
+	test.assert_pass(finding) with input as rule_input(non_violating_psp)
+	test.assert_pass(finding) with input as rule_input(non_violating_psp2)
+}
+
+test_not_evaluated {
+	not finding with input as {"type": "no-kube-api"}
+}
+
+rule_input(resource) = test_data.kube_api_input(resource)
+
+violating_psp = {
+	"kind": "Pod",
+	"uid": "00000aa0-0aa0-00aa-00aa-00aa000a0000",
+	"spec": {"containers": [{"securityContext": {"capabilities": ["NET_RAW"]}}]},
+}
+
+non_violating_psp = {
+	"kind": "Pod",
+	"uid": "00000aa0-0aa0-00aa-00aa-00aa000a0000",
+	"spec": {"containers": [{"securityContext": {}}]},
+}
+
+non_violating_psp2 = {
+	"kind": "Pod",
+	"uid": "00000aa0-0aa0-00aa-00aa-00aa000a0000",
+	"spec": {"containers": [{"securityContext": {"capabilities": []}}]},
+}


### PR DESCRIPTION
This PR is related to - https://github.com/elastic/security-team/issues/3002.

In this PR we implemented the Kubernetes pod security policy rules.

Since they are almost identical to the vanilla one, almost no change was required.

- Closes: https://github.com/elastic/security-team/issues/3002