### PR TITLE
Feature/vanilla-CSP-process -rules

### DIFF
--- a/compliance/cis_k8s/rules/cis_4_2_1/rule.rego
+++ b/compliance/cis_k8s/rules/cis_4_2_1/rule.rego
@@ -16,7 +16,7 @@ rule_evaluation {
 # In case both flags and configuration file are specified, the executable argument takes precedence.
 # Checks that the entry for authentication:anonymous: enabled set to false.
 rule_evaluation {
-	not common.contains_key_with_value(process_args, "--anonymous-auth", "true")
+	not process_args["--anonymous-auth"]
 	assert.is_false(data_adapter.process_config.config.authentication.anonymous.enabled)
 }
 

--- a/compliance/cis_k8s/rules/cis_4_2_1/rule.rego
+++ b/compliance/cis_k8s/rules/cis_4_2_1/rule.rego
@@ -1,22 +1,37 @@
 package compliance.cis_k8s.rules.cis_4_2_1
 
 import data.compliance.cis_k8s
+import data.compliance.lib.assert
 import data.compliance.lib.common
 import data.compliance.lib.data_adapter
+
+default rule_evaluation = false
+
+process_args := data_adapter.process_args
+
+rule_evaluation {
+	common.contains_key_with_value(process_args, "--anonymous-auth", "false")
+}
+
+# In case both flags and configuration file are specified, the executable argument takes precedence.
+# Checks that the entry for authentication:anonymous: enabled set to false.
+rule_evaluation {
+	not common.contains_key_with_value(process_args, "--anonymous-auth", "true")
+	assert.is_false(data_adapter.process_config.config.authentication.anonymous.enabled)
+}
 
 # Ensure that the --anonymous-auth argument is set to false (Automated)
 finding = result {
 	# filter
 	data_adapter.is_kubelet
 
-	# evaluate
-	process_args := data_adapter.process_args
-	rule_evaluation = common.contains_key_with_value(process_args, "--anonymous-auth", "false")
-
 	# set result
 	result := {
 		"evaluation": common.calculate_result(rule_evaluation),
-		"evidence": {"process_args": process_args},
+		"evidence": {
+			"process_args": process_args,
+			"process_config": data_adapter.process_config,
+		},
 	}
 }
 
@@ -26,5 +41,6 @@ metadata = {
 	"impact": "Anonymous requests will be rejected.",
 	"tags": array.concat(cis_k8s.default_tags, ["CIS 4.2.1", "Kubelet"]),
 	"benchmark": cis_k8s.benchmark_metadata,
+	"default_value": "By default, anonymous access is enabled.",
 	"remediation": "If using a Kubelet config file, edit the file to set authentication: anonymous: enabled to false. If using executable arguments, edit the kubelet service file /etc/systemd/system/kubelet.service.d/10-kubeadm.conf on each worker node and set the below parameter in KUBELET_SYSTEM_PODS_ARGS variable. --anonymous-auth=false Based on your system, restart the kubelet service.",
 }

--- a/compliance/cis_k8s/rules/cis_4_2_1/test.rego
+++ b/compliance/cis_k8s/rules/cis_4_2_1/test.rego
@@ -6,14 +6,31 @@ import data.lib.test
 test_violation {
 	test.assert_fail(finding) with input as rule_input("")
 	test.assert_fail(finding) with input as rule_input("--anonymous-auth=true")
+	test.assert_fail(finding) with input as rule_input_with_external("--anonymous-auth=true", create_process_config(true))
+	test.assert_fail(finding) with input as rule_input_with_external("--anonymous-auth=true", create_process_config(false))
+	test.assert_fail(finding) with input as rule_input_with_external("", create_process_config(true))
 }
 
 test_pass {
 	test.assert_pass(finding) with input as rule_input("--anonymous-auth=false")
+	test.assert_pass(finding) with input as rule_input_with_external("--anonymous-auth=false", create_process_config(true))
+	test.assert_pass(finding) with input as rule_input_with_external("--anonymous-auth=false", create_process_config(false))
+	test.assert_pass(finding) with input as rule_input_with_external("", create_process_config(false))
 }
 
 test_not_evaluated {
 	not finding with input as test_data.process_input("some_process", [])
 }
 
-rule_input(argument) = test_data.process_input("kubelet", [argument])
+rule_input(argument) = test_data.process_input_with_external_data("kubelet", [argument], {})
+
+rule_input_with_external(argument, external_data) = test_data.process_input_with_external_data("kubelet", [argument], external_data)
+
+create_process_config(anonymous_enabled) = {"config": {"authentication": {
+	"x509": {"clientCAFile": "/etc/kubernetes/pki/ca.crt"},
+	"anonymous": {"enabled": anonymous_enabled},
+	"webhook": {
+		"cacheTTL": "0s",
+		"enabled": true,
+	},
+}}}

--- a/compliance/cis_k8s/rules/cis_4_2_2/rule.rego
+++ b/compliance/cis_k8s/rules/cis_4_2_2/rule.rego
@@ -23,7 +23,7 @@ is_authorization_allow_all {
 }
 
 # In case both flags and configuration file are specified, the executable argument takes precedence.
-# Checks that the entry for authentication:anonymous: enabled set to false.
+# Checks that the entry for authorization:mode is not set to AlwaysAllow.
 rule_evaluation {
 	not is_authorization_allow_all
 	data_adapter.process_config.config.authorization.mode
@@ -37,7 +37,10 @@ finding = result {
 	# set result
 	result := {
 		"evaluation": common.calculate_result(rule_evaluation),
-		"evidence": {"process_args": process_args},
+		"evidence": {
+			"process_args": process_args,
+			"process_config": data_adapter.process_config,
+		},
 	}
 }
 

--- a/compliance/cis_k8s/rules/cis_4_2_2/rule.rego
+++ b/compliance/cis_k8s/rules/cis_4_2_2/rule.rego
@@ -6,20 +6,29 @@ import data.compliance.lib.common
 import data.compliance.lib.data_adapter
 
 # Ensure that the --authorization-mode argument is not set to AlwaysAllow (Automated)
-
 # If the --authorization-mode argument is present check that it is not set to AlwaysAllow.
+
+default rule_evaluation = false
 
 # evaluate
 process_args := data_adapter.process_args
 
-default rule_evaluation = false
-
 rule_evaluation {
-	process_args["--authorization-mode"]
-	assert.is_false(common.arg_values_contains(process_args, "--authorization-mode", "AlwaysAllow"))
+	is_authorization_allow_all
 }
 
-# todo: If it is not present check that there is a Kubelet config file specified by --config, and that file sets authorization: mode to something other than AlwaysAllow.
+is_authorization_allow_all {
+	process_args["--authorization-mode"]
+	not common.contains_key_with_value(process_args, "--authorization-mode", "AlwaysAllow")
+}
+
+# In case both flags and configuration file are specified, the executable argument takes precedence.
+# Checks that the entry for authentication:anonymous: enabled set to false.
+rule_evaluation {
+	not is_authorization_allow_all
+	data_adapter.process_config.config.authorization.mode
+	not data_adapter.process_config.config.authorization.mode == "AlwaysAllow"
+}
 
 finding = result {
 	# filter
@@ -37,6 +46,7 @@ metadata = {
 	"description": "Do not allow all requests. Enable explicit authorization.",
 	"impact": "Unauthorized requests will be denied.",
 	"tags": array.concat(cis_k8s.default_tags, ["CIS 4.2.2", "Kubelet"]),
+	"default_value": "By default, --authorization-mode argument is set to AlwaysAllow.",
 	"benchmark": cis_k8s.benchmark_metadata,
 	"remediation": "If using a Kubelet config file, edit the file to set authorization: mode to Webhook. If using executable arguments, edit the kubelet service file /etc/systemd/system/kubelet.service.d/10-kubeadm.conf on each worker node and set the below parameter in KUBELET_AUTHZ_ARGS variable. --authorization-mode=Webhook Based on your system, restart the kubelet service",
 }

--- a/compliance/cis_k8s/rules/cis_4_2_2/test.rego
+++ b/compliance/cis_k8s/rules/cis_4_2_2/test.rego
@@ -6,11 +6,14 @@ import data.lib.test
 test_violation {
 	test.assert_fail(finding) with input as rule_input("")
 	test.assert_fail(finding) with input as rule_input("--authorization-mode=AlwaysAllow")
-	test.assert_fail(finding) with input as rule_input("--authorization-mode=RBAC,AlwaysAllow")
+	test.assert_fail(finding) with input as rule_input_with_external("--authorization-mode=AlwaysAllow", create_process_config("AlwaysAllow"))
+	test.assert_fail(finding) with input as rule_input_with_external("", create_process_config("AlwaysAllow"))
 }
 
 test_pass {
-	test.assert_pass(finding) with input as rule_input("--authorization-mode=RBAC")
+	test.assert_pass(finding) with input as rule_input("--authorization-mode=Webhook")
+	test.assert_pass(finding) with input as rule_input_with_external("--authorization-mode=Webhook", create_process_config("AlwaysAllow"))
+	test.assert_pass(finding) with input as rule_input_with_external("", create_process_config("Webhook"))
 }
 
 test_not_evaluated {
@@ -18,3 +21,13 @@ test_not_evaluated {
 }
 
 rule_input(argument) = test_data.process_input("kubelet", [argument])
+
+rule_input_with_external(argument, external_data) = test_data.process_input_with_external_data("kubelet", [argument], external_data)
+
+create_process_config(authz_mode) = {"config": {"authorization": {
+	"mode": authz_mode,
+	"webhook": {
+		"cacheAuthorizedTTL": "0s",
+		"cacheUnauthorizedTTL": "0s",
+	},
+}}}

--- a/compliance/cis_k8s/rules/cis_4_2_3/rule.rego
+++ b/compliance/cis_k8s/rules/cis_4_2_3/rule.rego
@@ -8,18 +8,13 @@ default rule_evaluation = false
 
 process_args := data_adapter.process_args
 
-contains_ca_file {
-	common.contains_key(process_args, "--client-ca-file")
-}
-
 rule_evaluation {
-	contains_ca_file
+	common.contains_key(process_args, "--client-ca-file")
 }
 
 # In case both flags and configuration file are specified, the executable argument takes precedence.
 # Checks that the entry for authentication:x509:clientCAFile: set to a valid path.
 rule_evaluation {
-	not contains_ca_file
 	data_adapter.process_config.config.authentication.x509.clientCAFile
 	not data_adapter.process_config.config.authentication.x509.clientCAFile == ""
 }

--- a/compliance/cis_k8s/rules/cis_4_2_3/rule.rego
+++ b/compliance/cis_k8s/rules/cis_4_2_3/rule.rego
@@ -4,6 +4,26 @@ import data.compliance.cis_k8s
 import data.compliance.lib.common
 import data.compliance.lib.data_adapter
 
+default rule_evaluation = false
+
+process_args := data_adapter.process_args
+
+contains_ca_file {
+	common.contains_key(process_args, "--client-ca-file")
+}
+
+rule_evaluation {
+	contains_ca_file
+}
+
+# In case both flags and configuration file are specified, the executable argument takes precedence.
+# Checks that the entry for authentication:x509:clientCAFile: set to a valid path.
+rule_evaluation {
+	not contains_ca_file
+	data_adapter.process_config.config.authentication.x509.clientCAFile
+	not data_adapter.process_config.config.authentication.x509.clientCAFile == ""
+}
+
 # Ensure that the --client-ca-file argument is set as appropriate (Automated)
 finding = result {
 	# filter
@@ -11,12 +31,14 @@ finding = result {
 
 	# evaluate
 	process_args := data_adapter.process_args
-	rule_evaluation = common.contains_key(process_args, "--client-ca-file")
 
 	# set result
 	result := {
 		"evaluation": common.calculate_result(rule_evaluation),
-		"evidence": {"process_args": process_args},
+		"evidence": {
+			"process_args": process_args,
+			"process_config": data_adapter.process_config,
+		},
 	}
 }
 
@@ -27,4 +49,5 @@ metadata = {
 	"tags": array.concat(cis_k8s.default_tags, ["CIS 4.2.3", "Kubelet"]),
 	"benchmark": cis_k8s.benchmark_metadata,
 	"remediation": "If using a Kubelet config file, edit the file to set authentication: x509: clientCAFile to the location of the client CA file. If using command line arguments, edit the kubelet service file /etc/systemd/system/kubelet.service.d/10-kubeadm.conf on each worker node and set the below parameter in KUBELET_AUTHZ_ARGS variable. --client-ca-file=<path/to/client-ca-file> Based on your system, restart the kubelet service.",
+	"default_value": "By default, --client-ca-file argument is not set.",
 }

--- a/compliance/cis_k8s/rules/cis_4_2_3/test.rego
+++ b/compliance/cis_k8s/rules/cis_4_2_3/test.rego
@@ -5,10 +5,13 @@ import data.lib.test
 
 test_violation {
 	test.assert_fail(finding) with input as rule_input("")
+	test.assert_fail(finding) with input as rule_input_with_external("", create_process_config(""))
 }
 
 test_pass {
 	test.assert_pass(finding) with input as rule_input("--client-ca-file=<path/to/client-ca-file>")
+	test.assert_pass(finding) with input as rule_input_with_external("--client-ca-file=<path/to/client-ca-file>", create_process_config("<path/to/client-ca-file>"))
+	test.assert_pass(finding) with input as rule_input_with_external("", create_process_config("<path/to/client-ca-file>"))
 }
 
 test_not_evaluated {
@@ -16,3 +19,14 @@ test_not_evaluated {
 }
 
 rule_input(argument) = test_data.process_input("kubelet", [argument])
+
+rule_input_with_external(argument, external_data) = test_data.process_input_with_external_data("kubelet", [argument], external_data)
+
+create_process_config(client_CA_path) = {"config": {"authentication": {
+	"x509": {"clientCAFile": client_CA_path},
+	"anonymous": {"enabled": false},
+	"webhook": {
+		"cacheTTL": "0s",
+		"enabled": true,
+	},
+}}}

--- a/compliance/cis_k8s/rules/cis_4_2_6/rule.rego
+++ b/compliance/cis_k8s/rules/cis_4_2_6/rule.rego
@@ -4,20 +4,37 @@ import data.compliance.cis_k8s
 import data.compliance.lib.common
 import data.compliance.lib.data_adapter
 
-# Ensure that the --protect-kernel-defaults argument is set to true (Automated)
-# todo: If the --protect-kernel-defaults argument is not present, check that there is a Kubelet config file specified by --config, and that the file sets protectKernelDefaults to true.
+default rule_evaluation = false
+
+process_args := data_adapter.process_args
+
+is_kernel_protected {
+	common.contains_key_with_value(process_args, "--protect-kernel-defaults", "true")
+}
+
+# Ensure that the --protect-kernel-defaults argument is set to true
+rule_evaluation {
+	is_kernel_protected
+}
+
+# In case both flags and configuration file are specified, the executable argument takes precedence.
+# Ensure that the protectKernelDefaults argument is set to true
+rule_evaluation {
+	not process_args["--protect-kernel-defaults"]
+	data_adapter.process_config.config.protectKernelDefaults
+}
+
 finding = result {
 	# filter
 	data_adapter.is_kubelet
 
-	# evaluate
-	process_args := data_adapter.process_args
-	rule_evaluation = common.contains_key_with_value(process_args, "--protect-kernel-defaults", "true")
-
 	# set result
 	result := {
 		"evaluation": common.calculate_result(rule_evaluation),
-		"evidence": {"process_args": process_args},
+		"evidence": {
+			"process_args": process_args,
+			"process_config": data_adapter.process_config,
+		},
 	}
 }
 
@@ -27,5 +44,6 @@ metadata = {
 	"impact": "You would have to re-tune kernel parameters to match kubelet parameters.",
 	"tags": array.concat(cis_k8s.default_tags, ["CIS 4.2.6", "Kubelet"]),
 	"benchmark": cis_k8s.benchmark_metadata,
+	"default_value": "By default, --protect-kernel-defaults is not set.",
 	"remediation": "If using a Kubelet config file, edit the file to set protectKernelDefaults: true. If using command line arguments, edit the kubelet service file /etc/systemd/system/kubelet.service.d/10-kubeadm.conf on each worker node and set the below parameter in KUBELET_SYSTEM_PODS_ARGS variable. --protect-kernel-defaults=true Based on your system, restart the kubelet service.",
 }

--- a/compliance/cis_k8s/rules/cis_4_2_6/test.rego
+++ b/compliance/cis_k8s/rules/cis_4_2_6/test.rego
@@ -5,10 +5,15 @@ import data.lib.test
 
 test_violation {
 	test.assert_fail(finding) with input as rule_input("")
+	test.assert_fail(finding) with input as rule_input("--protect-kernel-defaults=false")
+	test.assert_fail(finding) with input as rule_input_with_external("--protect-kernel-defaults=false", create_process_config(true))
 }
 
 test_pass {
 	test.assert_pass(finding) with input as rule_input("--protect-kernel-defaults=true")
+	test.assert_pass(finding) with input as rule_input_with_external("--protect-kernel-defaults=true", create_process_config(false))
+	test.assert_pass(finding) with input as rule_input_with_external("--protect-kernel-defaults=true", create_process_config(false))
+	test.assert_pass(finding) with input as rule_input_with_external("", create_process_config(true))
 }
 
 test_not_evaluated {
@@ -16,3 +21,7 @@ test_not_evaluated {
 }
 
 rule_input(argument) = test_data.process_input("kubelet", [argument])
+
+rule_input_with_external(argument, external_data) = test_data.process_input_with_external_data("kubelet", [argument], external_data)
+
+create_process_config(kernel_protection_enabled) = {"config": {"protectKernelDefaults": kernel_protection_enabled}}

--- a/compliance/cis_k8s/rules/cis_4_2_7/rule.rego
+++ b/compliance/cis_k8s/rules/cis_4_2_7/rule.rego
@@ -5,21 +5,33 @@ import data.compliance.lib.assert
 import data.compliance.lib.common
 import data.compliance.lib.data_adapter
 
-# Ensure that the --make-iptables-util-chains argument is set to true (Automated)
+default rule_evaluation = false
 
-# todo: If the --make-iptables-util-chains argument does not exist, and there is a Kubelet config file specified by --config, verify that the file does not set makeIPTablesUtilChains to false.
+process_args := data_adapter.process_args
+
+# Ensure that the --make-iptables-util-chains argument is set to true (Automated)
+rule_evaluation {
+	common.contains_key_with_value(process_args, "--make-iptables-util-chains", "true")
+}
+
+# In case both flags and configuration file are specified, the executable argument takes precedence.
+# Checks that the entry for makeIPTablesUtilChains does not set to true.
+rule_evaluation {
+	not process_args["--make-iptables-util-chains"]
+	data_adapter.process_config.config.makeIPTablesUtilChains
+}
+
 finding = result {
 	# filter
 	data_adapter.is_kubelet
 
-	# evaluate
-	process_args := data_adapter.process_args
-	rule_evaluation = assert.is_false(common.contains_key_with_value(process_args, "--make-iptables-util-chains", "false"))
-
 	# set result
 	result := {
 		"evaluation": common.calculate_result(rule_evaluation),
-		"evidence": {"process_args": process_args},
+		"evidence": {
+			"process_args": process_args,
+			"process_config": data_adapter.process_config,
+		},
 	}
 }
 
@@ -30,4 +42,5 @@ metadata = {
 	"tags": array.concat(cis_k8s.default_tags, ["CIS 4.2.7", "Kubelet"]),
 	"benchmark": cis_k8s.benchmark_metadata,
 	"remediation": "If using a Kubelet config file, edit the file to set makeIPTablesUtilChains: true. If using command line arguments, edit the kubelet service file /etc/systemd/system/kubelet.service.d/10-kubeadm.conf on each worker node and remove the --make-iptables-util-chains argument from the KUBELET_SYSTEM_PODS_ARGS variable. Based on your system, restart the kubelet service.",
+	"deafult_value": "By default, --make-iptables-util-chains argument is set to true.",
 }

--- a/compliance/cis_k8s/rules/cis_4_2_7/test.rego
+++ b/compliance/cis_k8s/rules/cis_4_2_7/test.rego
@@ -4,12 +4,17 @@ import data.kubernetes_common.test_data
 import data.lib.test
 
 test_violation {
+	test.assert_fail(finding) with input as rule_input("")
 	test.assert_fail(finding) with input as rule_input("--make-iptables-util-chains=false")
+	test.assert_fail(finding) with input as rule_input_with_external("", create_process_config(false))
+	test.assert_fail(finding) with input as rule_input_with_external("--make-iptables-util-chains=false", create_process_config(true))
 }
 
 test_pass {
-	test.assert_pass(finding) with input as rule_input("")
 	test.assert_pass(finding) with input as rule_input("--make-iptables-util-chains=true")
+	test.assert_pass(finding) with input as rule_input_with_external("--make-iptables-util-chains=true", create_process_config(false))
+	test.assert_pass(finding) with input as rule_input_with_external("--make-iptables-util-chains=true", create_process_config(true))
+	test.assert_pass(finding) with input as rule_input_with_external("", create_process_config(true))
 }
 
 test_not_evaluated {
@@ -17,3 +22,7 @@ test_not_evaluated {
 }
 
 rule_input(argument) = test_data.process_input("kubelet", [argument])
+
+rule_input_with_external(argument, external_data) = test_data.process_input_with_external_data("kubelet", [argument], external_data)
+
+create_process_config(makeIPTablesUtilChains) = {"config": {"makeIPTablesUtilChains": makeIPTablesUtilChains}}

--- a/compliance/kubernetes_common/test_data.rego
+++ b/compliance/kubernetes_common/test_data.rego
@@ -15,11 +15,17 @@ filesystem_input(filename, mode, uid, gid) = {
 }
 
 # genrates `process` type input data
-process_input(process_name, arguments) = {
+process_input(process_name, arguments) = result {
+	result = process_input_with_external_data(process_name, arguments, {})
+}
+
+# genrates `process` type input data
+process_input_with_external_data(process_name, arguments, external_data) = {
 	"type": "process",
 	"resource": {
 		"command": concat(" ", array.concat([process_name], arguments)),
 		"stat": {"Name": process_name},
+		"external_data": external_data,
 	},
 }
 

--- a/compliance/kubernetes_common/test_data.rego
+++ b/compliance/kubernetes_common/test_data.rego
@@ -15,9 +15,7 @@ filesystem_input(filename, mode, uid, gid) = {
 }
 
 # genrates `process` type input data
-process_input(process_name, arguments) = result {
-	result = process_input_with_external_data(process_name, arguments, {})
-}
+process_input(process_name, arguments) = process_input_with_external_data(process_name, arguments, {})
 
 # genrates `process` type input data
 process_input_with_external_data(process_name, arguments, external_data) = {

--- a/compliance/lib/data_adapter.rego
+++ b/compliance/lib/data_adapter.rego
@@ -49,6 +49,11 @@ process_args = args {
 	args := {arg: value | [arg, value] = common.split_key_value(process_args_list[_])}
 }
 
+process_config = config {
+	is_process
+    config := { key: value | value = input.resource.external_data[key]}
+}
+
 is_kube_apiserver {
 	process_name == "kube-apiserver"
 }


### PR DESCRIPTION
This PR enables our Kubelet process rules, to support configuration file as an input.

Closes: https://github.com/elastic/security-team/issues/3279