### PR TITLE
Changing bundle build root directory

### DIFF
--- a/bundle/reader.go
+++ b/bundle/reader.go
@@ -35,7 +35,7 @@ func createPolicyMap(fsys fs.FS, filePrefixes []string) (map[string]string, erro
 			return err
 		}
 
-		policies[filePath] = string(data)
+		policies["compliance/" + filePath] = string(data)
 		return nil
 	})
 


### PR DESCRIPTION
Append the compliance to the packed resource in order to be able and import `data.yaml` files under rules and use them within the .rego files.
Currently, the behavior of building and packing the bundle differs from the behavior of how the bundle is being built by opa, this inconsistency causes problems when attempting to access packed `data.yaml` files from the .rego source code.