### PR TITLE
Addition of expected field to k8s rules

### DIFF
--- a/compliance/cis_k8s/rules/cis_1_1_1/rule.rego
+++ b/compliance/cis_k8s/rules/cis_1_1_1/rule.rego
@@ -13,6 +13,7 @@ finding = result {
 	# set result
 	result := {
 		"evaluation": common.calculate_result(rule_evaluation),
+		"expected": {"filemode": 644},
 		"evidence": {"filemode": filemode},
 	}
 }

--- a/compliance/cis_k8s/rules/cis_1_1_11/rule.rego
+++ b/compliance/cis_k8s/rules/cis_1_1_11/rule.rego
@@ -13,6 +13,7 @@ finding = result {
 	# set result
 	result := {
 		"evaluation": common.calculate_result(rule_evaluation),
+		"expected": {"filemode": 700},
 		"evidence": {"filemode": filemode},
 	}
 }

--- a/compliance/cis_k8s/rules/cis_1_1_12/rule.rego
+++ b/compliance/cis_k8s/rules/cis_1_1_12/rule.rego
@@ -14,6 +14,7 @@ finding = result {
 	# set result
 	result := {
 		"evaluation": common.calculate_result(rule_evaluation),
+		"expected": {"uid": "etcd", "gid": "etcd"},
 		"evidence": {"uid": uid, "gid": gid},
 	}
 }

--- a/compliance/cis_k8s/rules/cis_1_1_13/rule.rego
+++ b/compliance/cis_k8s/rules/cis_1_1_13/rule.rego
@@ -13,6 +13,7 @@ finding = result {
 	# set result
 	result := {
 		"evaluation": common.calculate_result(rule_evaluation),
+		"expected": {"filemode": 644},
 		"evidence": {"filemode": filemode},
 	}
 }

--- a/compliance/cis_k8s/rules/cis_1_1_14/rule.rego
+++ b/compliance/cis_k8s/rules/cis_1_1_14/rule.rego
@@ -14,6 +14,7 @@ finding = result {
 	# set result
 	result := {
 		"evaluation": common.calculate_result(rule_evaluation),
+		"expected": {"uid": "root", "gid": "root"},
 		"evidence": {"uid": uid, "gid": gid},
 	}
 }

--- a/compliance/cis_k8s/rules/cis_1_1_15/rule.rego
+++ b/compliance/cis_k8s/rules/cis_1_1_15/rule.rego
@@ -13,6 +13,7 @@ finding = result {
 	# set result
 	result := {
 		"evaluation": common.calculate_result(rule_evaluation),
+		"expected": {"filemode": 644},
 		"evidence": {"filemode": filemode},
 	}
 }

--- a/compliance/cis_k8s/rules/cis_1_1_16/rule.rego
+++ b/compliance/cis_k8s/rules/cis_1_1_16/rule.rego
@@ -14,6 +14,7 @@ finding = result {
 	# set result
 	result := {
 		"evaluation": common.calculate_result(rule_evaluation),
+		"expected": {"uid": "root", "gid": "root"},
 		"evidence": {"uid": uid, "gid": gid},
 	}
 }

--- a/compliance/cis_k8s/rules/cis_1_1_17/rule.rego
+++ b/compliance/cis_k8s/rules/cis_1_1_17/rule.rego
@@ -13,6 +13,7 @@ finding = result {
 	# set result
 	result := {
 		"evaluation": common.calculate_result(rule_evaluation),
+		"expected": {"filemode": 644},
 		"evidence": {"filemode": filemode},
 	}
 }

--- a/compliance/cis_k8s/rules/cis_1_1_18/rule.rego
+++ b/compliance/cis_k8s/rules/cis_1_1_18/rule.rego
@@ -14,6 +14,7 @@ finding = result {
 	# set result
 	result := {
 		"evaluation": common.calculate_result(rule_evaluation),
+		"expected": {"uid": "root", "gid": "root"},
 		"evidence": {"uid": uid, "gid": gid},
 	}
 }

--- a/compliance/cis_k8s/rules/cis_1_1_19/rule.rego
+++ b/compliance/cis_k8s/rules/cis_1_1_19/rule.rego
@@ -15,6 +15,7 @@ finding = result {
 	# set result
 	result := {
 		"evaluation": common.calculate_result(rule_evaluation),
+		"expected": {"uid": "root", "gid": "root"},
 		"evidence": {"uid": uid, "gid": gid},
 	}
 }

--- a/compliance/cis_k8s/rules/cis_1_1_2/rule.rego
+++ b/compliance/cis_k8s/rules/cis_1_1_2/rule.rego
@@ -14,6 +14,7 @@ finding = result {
 	# set result
 	result := {
 		"evaluation": common.calculate_result(rule_evaluation),
+		"expected": {"uid": "root", "gid": "root"},
 		"evidence": {"uid": uid, "gid": gid},
 	}
 }

--- a/compliance/cis_k8s/rules/cis_1_1_3/rule.rego
+++ b/compliance/cis_k8s/rules/cis_1_1_3/rule.rego
@@ -13,6 +13,7 @@ finding = result {
 	# set result
 	result := {
 		"evaluation": common.calculate_result(rule_evaluation),
+		"expected": {"filemode": 644},
 		"evidence": {"filemode": filemode},
 	}
 }

--- a/compliance/cis_k8s/rules/cis_1_1_4/rule.rego
+++ b/compliance/cis_k8s/rules/cis_1_1_4/rule.rego
@@ -14,6 +14,7 @@ finding = result {
 	# set result
 	result := {
 		"evaluation": common.calculate_result(rule_evaluation),
+		"expected": {"uid": "root", "gid": "root"},
 		"evidence": {"uid": uid, "gid": gid},
 	}
 }

--- a/compliance/cis_k8s/rules/cis_1_1_5/rule.rego
+++ b/compliance/cis_k8s/rules/cis_1_1_5/rule.rego
@@ -13,6 +13,7 @@ finding = result {
 	# set result
 	result := {
 		"evaluation": common.calculate_result(rule_evaluation),
+		"expected": {"filemode": 644},
 		"evidence": {"filemode": filemode},
 	}
 }

--- a/compliance/cis_k8s/rules/cis_1_1_6/rule.rego
+++ b/compliance/cis_k8s/rules/cis_1_1_6/rule.rego
@@ -14,6 +14,7 @@ finding = result {
 	# set result
 	result := {
 		"evaluation": common.calculate_result(rule_evaluation),
+		"expected": {"uid": "root", "gid": "root"},
 		"evidence": {"uid": uid, "gid": gid},
 	}
 }

--- a/compliance/cis_k8s/rules/cis_1_1_7/rule.rego
+++ b/compliance/cis_k8s/rules/cis_1_1_7/rule.rego
@@ -13,6 +13,7 @@ finding = result {
 	# set result
 	result := {
 		"evaluation": common.calculate_result(rule_evaluation),
+		"expected": {"filemode": 644},
 		"evidence": {"filemode": filemode},
 	}
 }

--- a/compliance/cis_k8s/rules/cis_1_1_8/rule.rego
+++ b/compliance/cis_k8s/rules/cis_1_1_8/rule.rego
@@ -14,6 +14,7 @@ finding = result {
 	# set result
 	result := {
 		"evaluation": common.calculate_result(rule_evaluation),
+		"expected": {"uid": "root", "gid": "root"},
 		"evidence": {"uid": uid, "gid": gid},
 	}
 }

--- a/compliance/cis_k8s/rules/cis_4_1_1/rule.rego
+++ b/compliance/cis_k8s/rules/cis_4_1_1/rule.rego
@@ -13,6 +13,7 @@ finding = result {
 	# set result
 	result := {
 		"evaluation": common.calculate_result(rule_evaluation),
+		"expected": {"filemode": 644},
 		"evidence": {"filemode": filemode},
 	}
 }

--- a/compliance/cis_k8s/rules/cis_4_1_10/rule.rego
+++ b/compliance/cis_k8s/rules/cis_4_1_10/rule.rego
@@ -14,6 +14,7 @@ finding = result {
 	# set result
 	result := {
 		"evaluation": common.calculate_result(rule_evaluation),
+		"expected": {"uid": "root", "gid": "root"},
 		"evidence": {"uid": uid, "gid": gid},
 	}
 }

--- a/compliance/cis_k8s/rules/cis_4_1_2/rule.rego
+++ b/compliance/cis_k8s/rules/cis_4_1_2/rule.rego
@@ -14,6 +14,7 @@ finding = result {
 	# set result
 	result := {
 		"evaluation": common.calculate_result(rule_evaluation),
+		"expected": {"uid": "root", "gid": "root"},
 		"evidence": {"uid": uid, "gid": gid},
 	}
 }

--- a/compliance/cis_k8s/rules/cis_4_1_5/rule.rego
+++ b/compliance/cis_k8s/rules/cis_4_1_5/rule.rego
@@ -13,6 +13,7 @@ finding = result {
 	# set result
 	result := {
 		"evaluation": common.calculate_result(rule_evaluation),
+		"expected": {"filemode": 644},
 		"evidence": {"filemode": filemode},
 	}
 }

--- a/compliance/cis_k8s/rules/cis_4_1_9/rule.rego
+++ b/compliance/cis_k8s/rules/cis_4_1_9/rule.rego
@@ -13,6 +13,7 @@ finding = result {
 	# set result
 	result := {
 		"evaluation": common.calculate_result(rule_evaluation),
+		"expected": {"filemode": 644},
 		"evidence": {"filemode": filemode},
 	}
 }


### PR DESCRIPTION
Adding the first drop of the expected field to k8s rules (includes trivial rules).
This covers the GID/UID and permissions rules which are trivial to code.

Partially covers https://github.com/elastic/security-team/issues/3383