### PR TITLE
Avoid rule version parsing to integer

### DIFF
--- a/compliance/cis_k8s/rules/cis_1_1_1/data.yaml
+++ b/compliance/cis_k8s/rules/cis_1_1_1/data.yaml
@@ -34,7 +34,7 @@ metadata:
   references: |
     1. [https://kubernetes.io/docs/admin/kube-apiserver/](https://kubernetes.io/docs/admin/kube-apiserver/)
   section: Master Node Configuration Files
-  version: 1.0
+  version: "1.0"
   tags:
     - CIS
     - Kubernetes

--- a/compliance/cis_k8s/rules/cis_1_1_11/data.yaml
+++ b/compliance/cis_k8s/rules/cis_1_1_11/data.yaml
@@ -43,7 +43,7 @@ metadata:
     1. [https://coreos.com/etcd/docs/latest/op-guide/configuration.html#data-dir](https://coreos.com/etcd/docs/latest/op-guide/configuration.html#data-dir)
     2. [https://kubernetes.io/docs/admin/etcd/](https://kubernetes.io/docs/admin/etcd/)
   section: Master Node Configuration Files
-  version: 1.0
+  version: "1.0"
   tags:
     - CIS
     - Kubernetes

--- a/compliance/cis_k8s/rules/cis_1_1_12/data.yaml
+++ b/compliance/cis_k8s/rules/cis_1_1_12/data.yaml
@@ -41,7 +41,7 @@ metadata:
     1. [https://coreos.com/etcd/docs/latest/op-guide/configuration.html#data-dir](https://coreos.com/etcd/docs/latest/op-guide/configuration.html#data-dir)
     2. [https://kubernetes.io/docs/admin/etcd/](https://kubernetes.io/docs/admin/etcd/)
   section: Master Node Configuration Files
-  version: 1.0
+  version: "1.0"
   tags:
     - CIS
     - Kubernetes

--- a/compliance/cis_k8s/rules/cis_1_1_13/data.yaml
+++ b/compliance/cis_k8s/rules/cis_1_1_13/data.yaml
@@ -33,7 +33,7 @@ metadata:
   references: |
     1. [https://kubernetes.io/docs/setup/independent/create-cluster-kubeadm/](https://kubernetes.io/docs/setup/independent/create-cluster-kubeadm/)
   section: Master Node Configuration Files
-  version: 1.0
+  version: "1.0"
   tags:
     - CIS
     - Kubernetes

--- a/compliance/cis_k8s/rules/cis_1_1_14/data.yaml
+++ b/compliance/cis_k8s/rules/cis_1_1_14/data.yaml
@@ -31,7 +31,7 @@ metadata:
   references: |
     1. [https://kubernetes.io/docs/admin/kubeadm/](https://kubernetes.io/docs/admin/kubeadm/)
   section: Master Node Configuration Files
-  version: 1.0
+  version: "1.0"
   tags:
     - CIS
     - Kubernetes

--- a/compliance/cis_k8s/rules/cis_1_1_15/data.yaml
+++ b/compliance/cis_k8s/rules/cis_1_1_15/data.yaml
@@ -32,7 +32,7 @@ metadata:
   references: |
     1. [https://kubernetes.io/docs/setup/independent/create-cluster-kubeadm/](https://kubernetes.io/docs/setup/independent/create-cluster-kubeadm/)
   section: Master Node Configuration Files
-  version: 1.0
+  version: "1.0"
   tags:
     - CIS
     - Kubernetes

--- a/compliance/cis_k8s/rules/cis_1_1_16/data.yaml
+++ b/compliance/cis_k8s/rules/cis_1_1_16/data.yaml
@@ -31,7 +31,7 @@ metadata:
   references: |
     1. [https://kubernetes.io/docs/admin/kubeadm/](https://kubernetes.io/docs/admin/kubeadm/)
   section: Master Node Configuration Files
-  version: 1.0
+  version: "1.0"
   tags:
     - CIS
     - Kubernetes

--- a/compliance/cis_k8s/rules/cis_1_1_17/data.yaml
+++ b/compliance/cis_k8s/rules/cis_1_1_17/data.yaml
@@ -34,7 +34,7 @@ metadata:
   references: |
     1. [https://kubernetes.io/docs/admin/kube-controller-manager/](https://kubernetes.io/docs/admin/kube-controller-manager/)
   section: Master Node Configuration Files
-  version: 1.0
+  version: "1.0"
   tags:
     - CIS
     - Kubernetes

--- a/compliance/cis_k8s/rules/cis_1_1_18/data.yaml
+++ b/compliance/cis_k8s/rules/cis_1_1_18/data.yaml
@@ -34,7 +34,7 @@ metadata:
   references: |
     1. [https://kubernetes.io/docs/admin/kube-controller-manager/](https://kubernetes.io/docs/admin/kube-controller-manager/)
   section: Master Node Configuration Files
-  version: 1.0
+  version: "1.0"
   tags:
     - CIS
     - Kubernetes

--- a/compliance/cis_k8s/rules/cis_1_1_19/data.yaml
+++ b/compliance/cis_k8s/rules/cis_1_1_19/data.yaml
@@ -35,7 +35,7 @@ metadata:
   references: |
     1. [https://kubernetes.io/docs/admin/kube-apiserver/](https://kubernetes.io/docs/admin/kube-apiserver/)
   section: Master Node Configuration Files
-  version: 1.0
+  version: "1.0"
   tags:
     - CIS
     - Kubernetes

--- a/compliance/cis_k8s/rules/cis_1_1_2/data.yaml
+++ b/compliance/cis_k8s/rules/cis_1_1_2/data.yaml
@@ -33,7 +33,7 @@ metadata:
   references: |
     1. [https://kubernetes.io/docs/admin/kube-apiserver/](https://kubernetes.io/docs/admin/kube-apiserver/)
   section: Master Node Configuration Files
-  version: 1.0
+  version: "1.0"
   tags:
     - CIS
     - Kubernetes

--- a/compliance/cis_k8s/rules/cis_1_1_3/data.yaml
+++ b/compliance/cis_k8s/rules/cis_1_1_3/data.yaml
@@ -35,7 +35,7 @@ metadata:
   references: |
     1. [https://kubernetes.io/docs/admin/kube-apiserver/](https://kubernetes.io/docs/admin/kube-apiserver/)
   section: Master Node Configuration Files
-  version: 1.0
+  version: "1.0"
   tags:
     - CIS
     - Kubernetes

--- a/compliance/cis_k8s/rules/cis_1_1_4/data.yaml
+++ b/compliance/cis_k8s/rules/cis_1_1_4/data.yaml
@@ -36,7 +36,7 @@ metadata:
   references: |
     1. [https://kubernetes.io/docs/admin/kube-controller-manager](https://kubernetes.io/docs/admin/kube-controller-manager)
   section: Master Node Configuration Files
-  version: 1.0
+  version: "1.0"
   tags:
     - CIS
     - Kubernetes

--- a/compliance/cis_k8s/rules/cis_1_1_5/data.yaml
+++ b/compliance/cis_k8s/rules/cis_1_1_5/data.yaml
@@ -34,7 +34,7 @@ metadata:
   references: |
     1. [https://kubernetes.io/docs/admin/kube-scheduler/](https://kubernetes.io/docs/admin/kube-scheduler/)
   section: Master Node Configuration Files
-  version: 1.0
+  version: "1.0"
   tags:
     - CIS
     - Kubernetes

--- a/compliance/cis_k8s/rules/cis_1_1_6/data.yaml
+++ b/compliance/cis_k8s/rules/cis_1_1_6/data.yaml
@@ -34,7 +34,7 @@ metadata:
   references: |
     1. [https://kubernetes.io/docs/admin/kube-scheduler/](https://kubernetes.io/docs/admin/kube-scheduler/)
   section: Master Node Configuration Files
-  version: 1.0
+  version: "1.0"
   tags:
     - CIS
     - Kubernetes

--- a/compliance/cis_k8s/rules/cis_1_1_7/data.yaml
+++ b/compliance/cis_k8s/rules/cis_1_1_7/data.yaml
@@ -39,7 +39,7 @@ metadata:
     1. [https://coreos.com/etcd](https://coreos.com/etcd)
     2. [https://kubernetes.io/docs/admin/etcd/](https://kubernetes.io/docs/admin/etcd/)
   section: Master Node Configuration Files
-  version: 1.0
+  version: "1.0"
   tags:
     - CIS
     - Kubernetes

--- a/compliance/cis_k8s/rules/cis_1_1_8/data.yaml
+++ b/compliance/cis_k8s/rules/cis_1_1_8/data.yaml
@@ -40,7 +40,7 @@ metadata:
     1. [https://coreos.com/etcd](https://coreos.com/etcd)
     2. [https://kubernetes.io/docs/admin/etcd/](https://kubernetes.io/docs/admin/etcd/)
   section: Master Node Configuration Files
-  version: 1.0
+  version: "1.0"
   tags:
     - CIS
     - Kubernetes

--- a/compliance/cis_k8s/rules/cis_1_2_10/data.yaml
+++ b/compliance/cis_k8s/rules/cis_1_2_10/data.yaml
@@ -31,7 +31,7 @@ metadata:
     1. [https://kubernetes.io/docs/admin/kube-apiserver/](https://kubernetes.io/docs/admin/kube-apiserver/)
     2. [https://kubernetes.io/docs/admin/admission-controllers/#alwaysadmit](https://kubernetes.io/docs/admin/admission-controllers/#alwaysadmit)
   section: API Server
-  version: 1.0
+  version: "1.0"
   tags:
     - CIS
     - Kubernetes

--- a/compliance/cis_k8s/rules/cis_1_2_13/data.yaml
+++ b/compliance/cis_k8s/rules/cis_1_2_13/data.yaml
@@ -38,7 +38,7 @@ metadata:
     2. [https://kubernetes.io/docs/admin/admission-controllers/#securitycontextdeny](https://kubernetes.io/docs/admin/admission-controllers/#securitycontextdeny)
     3. [https://kubernetes.io/docs/user-guide/pod-security-policy/#working-with-rbac](https://kubernetes.io/docs/user-guide/pod-security-policy/#working-with-rbac)
   section: API Server
-  version: 1.0
+  version: "1.0"
   tags:
     - CIS
     - Kubernetes

--- a/compliance/cis_k8s/rules/cis_1_2_14/data.yaml
+++ b/compliance/cis_k8s/rules/cis_1_2_14/data.yaml
@@ -32,7 +32,7 @@ metadata:
     2. [https://kubernetes.io/docs/admin/admission-controllers/#serviceaccount](https://kubernetes.io/docs/admin/admission-controllers/#serviceaccount)
     3. [https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/](https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/)
   section: API Server
-  version: 1.0
+  version: "1.0"
   tags:
     - CIS
     - Kubernetes

--- a/compliance/cis_k8s/rules/cis_1_2_15/data.yaml
+++ b/compliance/cis_k8s/rules/cis_1_2_15/data.yaml
@@ -32,7 +32,7 @@ metadata:
     1. [https://kubernetes.io/docs/admin/kube-apiserver/](https://kubernetes.io/docs/admin/kube-apiserver/)
     2. [https://kubernetes.io/docs/admin/admission-controllers/#namespacelifecycle](https://kubernetes.io/docs/admin/admission-controllers/#namespacelifecycle)
   section: API Server
-  version: 1.0
+  version: "1.0"
   tags:
     - CIS
     - Kubernetes

--- a/compliance/cis_k8s/rules/cis_1_2_16/data.yaml
+++ b/compliance/cis_k8s/rules/cis_1_2_16/data.yaml
@@ -44,7 +44,7 @@ metadata:
     2. [https://kubernetes.io/docs/admin/admission-controllers/#podsecuritypolicy](https://kubernetes.io/docs/admin/admission-controllers/#podsecuritypolicy)
     3. [https://kubernetes.io/docs/concepts/policy/pod-security-policy/#enabling-pod-security-policies](https://kubernetes.io/docs/concepts/policy/pod-security-policy/#enabling-pod-security-policies)
   section: API Server
-  version: 1.0
+  version: "1.0"
   tags:
     - CIS
     - Kubernetes

--- a/compliance/cis_k8s/rules/cis_1_2_17/data.yaml
+++ b/compliance/cis_k8s/rules/cis_1_2_17/data.yaml
@@ -37,7 +37,7 @@ metadata:
     3. [https://kubernetes.io/docs/admin/authorization/node/](https://kubernetes.io/docs/admin/authorization/node/)
     4. [https://acotten.com/post/kube17-security](https://acotten.com/post/kube17-security)
   section: API Server
-  version: 1.0
+  version: "1.0"
   tags:
     - CIS
     - Kubernetes

--- a/compliance/cis_k8s/rules/cis_1_2_18/data.yaml
+++ b/compliance/cis_k8s/rules/cis_1_2_18/data.yaml
@@ -30,7 +30,7 @@ metadata:
   references: |
     1. [https://kubernetes.io/docs/admin/kube-apiserver/](https://kubernetes.io/docs/admin/kube-apiserver/)
   section: API Server
-  version: 1.0
+  version: "1.0"
   tags:
     - CIS
     - Kubernetes

--- a/compliance/cis_k8s/rules/cis_1_2_19/data.yaml
+++ b/compliance/cis_k8s/rules/cis_1_2_19/data.yaml
@@ -34,7 +34,7 @@ metadata:
   references: |
     1. [https://kubernetes.io/docs/admin/kube-apiserver/](https://kubernetes.io/docs/admin/kube-apiserver/)
   section: API Server
-  version: 1.0
+  version: "1.0"
   tags:
     - CIS
     - Kubernetes

--- a/compliance/cis_k8s/rules/cis_1_2_2/data.yaml
+++ b/compliance/cis_k8s/rules/cis_1_2_2/data.yaml
@@ -33,7 +33,7 @@ metadata:
     1. [https://kubernetes.io/docs/admin/kube-apiserver/](https://kubernetes.io/docs/admin/kube-apiserver/)
     2. [https://kubernetes.io/docs/admin/authentication/#static-password-file](https://kubernetes.io/docs/admin/authentication/#static-password-file)
   section: API Server
-  version: 1.0
+  version: "1.0"
   tags:
     - CIS
     - Kubernetes

--- a/compliance/cis_k8s/rules/cis_1_2_20/data.yaml
+++ b/compliance/cis_k8s/rules/cis_1_2_20/data.yaml
@@ -28,7 +28,7 @@ metadata:
   references: |
     1. [https://kubernetes.io/docs/admin/kube-apiserver/](https://kubernetes.io/docs/admin/kube-apiserver/)
   section: API Server
-  version: 1.0
+  version: "1.0"
   tags:
     - CIS
     - Kubernetes

--- a/compliance/cis_k8s/rules/cis_1_2_21/data.yaml
+++ b/compliance/cis_k8s/rules/cis_1_2_21/data.yaml
@@ -32,7 +32,7 @@ metadata:
     1. [https://kubernetes.io/docs/admin/kube-apiserver/](https://kubernetes.io/docs/admin/kube-apiserver/)
     2. [https://github.com/kubernetes/community/blob/master/contributors/devel/profiling.md](https://github.com/kubernetes/community/blob/master/contributors/devel/profiling.md)
   section: API Server
-  version: 1.0
+  version: "1.0"
   tags:
     - CIS
     - Kubernetes

--- a/compliance/cis_k8s/rules/cis_1_2_22/data.yaml
+++ b/compliance/cis_k8s/rules/cis_1_2_22/data.yaml
@@ -36,7 +36,7 @@ metadata:
     2. [https://kubernetes.io/docs/concepts/cluster-administration/audit/](https://kubernetes.io/docs/concepts/cluster-administration/audit/)
     3. [https://github.com/kubernetes/features/issues/22](https://github.com/kubernetes/features/issues/22)
   section: API Server
-  version: 1.0
+  version: "1.0"
   tags:
     - CIS
     - Kubernetes

--- a/compliance/cis_k8s/rules/cis_1_2_23/data.yaml
+++ b/compliance/cis_k8s/rules/cis_1_2_23/data.yaml
@@ -35,7 +35,7 @@ metadata:
     2. [https://kubernetes.io/docs/concepts/cluster-administration/audit/](https://kubernetes.io/docs/concepts/cluster-administration/audit/)
     3. [https://github.com/kubernetes/features/issues/22](https://github.com/kubernetes/features/issues/22)
   section: API Server
-  version: 1.0
+  version: "1.0"
   tags:
     - CIS
     - Kubernetes

--- a/compliance/cis_k8s/rules/cis_1_2_24/data.yaml
+++ b/compliance/cis_k8s/rules/cis_1_2_24/data.yaml
@@ -35,7 +35,7 @@ metadata:
     2. [https://kubernetes.io/docs/concepts/cluster-administration/audit/](https://kubernetes.io/docs/concepts/cluster-administration/audit/)
     3. [https://github.com/kubernetes/features/issues/22](https://github.com/kubernetes/features/issues/22)
   section: API Server
-  version: 1.0
+  version: "1.0"
   tags:
     - CIS
     - Kubernetes

--- a/compliance/cis_k8s/rules/cis_1_2_25/data.yaml
+++ b/compliance/cis_k8s/rules/cis_1_2_25/data.yaml
@@ -35,7 +35,7 @@ metadata:
     2. [https://kubernetes.io/docs/concepts/cluster-administration/audit/](https://kubernetes.io/docs/concepts/cluster-administration/audit/)
     3. [https://github.com/kubernetes/features/issues/22](https://github.com/kubernetes/features/issues/22)
   section: API Server
-  version: 1.0
+  version: "1.0"
   tags:
     - CIS
     - Kubernetes

--- a/compliance/cis_k8s/rules/cis_1_2_26/data.yaml
+++ b/compliance/cis_k8s/rules/cis_1_2_26/data.yaml
@@ -37,7 +37,7 @@ metadata:
     1. [https://kubernetes.io/docs/admin/kube-apiserver/](https://kubernetes.io/docs/admin/kube-apiserver/)
     2. [https://github.com/kubernetes/kubernetes/pull/51415](https://github.com/kubernetes/kubernetes/pull/51415)
   section: API Server
-  version: 1.0
+  version: "1.0"
   tags:
     - CIS
     - Kubernetes

--- a/compliance/cis_k8s/rules/cis_1_2_27/data.yaml
+++ b/compliance/cis_k8s/rules/cis_1_2_27/data.yaml
@@ -36,7 +36,7 @@ metadata:
     2. [https://github.com/kubernetes/kubernetes/issues/24167](https://github.com/kubernetes/kubernetes/issues/24167)
     3. [https://en.wikipedia.org/wiki/Time_of_check_to_time_of_use](https://en.wikipedia.org/wiki/Time_of_check_to_time_of_use)
   section: API Server
-  version: 1.0
+  version: "1.0"
   tags:
     - CIS
     - Kubernetes

--- a/compliance/cis_k8s/rules/cis_1_2_28/data.yaml
+++ b/compliance/cis_k8s/rules/cis_1_2_28/data.yaml
@@ -39,7 +39,7 @@ metadata:
     1. [https://kubernetes.io/docs/admin/kube-apiserver/](https://kubernetes.io/docs/admin/kube-apiserver/)
     2. [https://github.com/kubernetes/kubernetes/issues/24167](https://github.com/kubernetes/kubernetes/issues/24167)
   section: API Server
-  version: 1.0
+  version: "1.0"
   tags:
     - CIS
     - Kubernetes

--- a/compliance/cis_k8s/rules/cis_1_2_29/data.yaml
+++ b/compliance/cis_k8s/rules/cis_1_2_29/data.yaml
@@ -38,7 +38,7 @@ metadata:
     1. [https://kubernetes.io/docs/admin/kube-apiserver/](https://kubernetes.io/docs/admin/kube-apiserver/)
     2. [https://coreos.com/etcd/docs/latest/op-guide/security.html](https://coreos.com/etcd/docs/latest/op-guide/security.html)
   section: API Server
-  version: 1.0
+  version: "1.0"
   tags:
     - CIS
     - Kubernetes

--- a/compliance/cis_k8s/rules/cis_1_2_3/data.yaml
+++ b/compliance/cis_k8s/rules/cis_1_2_3/data.yaml
@@ -32,7 +32,7 @@ metadata:
     1. [https://kubernetes.io/docs/admin/authentication/#static-token-file](https://kubernetes.io/docs/admin/authentication/#static-token-file)
     2. [https://kubernetes.io/docs/admin/kube-apiserver/](https://kubernetes.io/docs/admin/kube-apiserver/)
   section: API Server
-  version: 1.0
+  version: "1.0"
   tags:
     - CIS
     - Kubernetes

--- a/compliance/cis_k8s/rules/cis_1_2_30/data.yaml
+++ b/compliance/cis_k8s/rules/cis_1_2_30/data.yaml
@@ -37,7 +37,7 @@ metadata:
     2. [http://rootsquash.com/2016/05/10/securing-the-kubernetes-api/](http://rootsquash.com/2016/05/10/securing-the-kubernetes-api/)
     3. [https://github.com/kelseyhightower/docker-kubernetes-tls-guide](https://github.com/kelseyhightower/docker-kubernetes-tls-guide)
   section: API Server
-  version: 1.0
+  version: "1.0"
   tags:
     - CIS
     - Kubernetes

--- a/compliance/cis_k8s/rules/cis_1_2_31/data.yaml
+++ b/compliance/cis_k8s/rules/cis_1_2_31/data.yaml
@@ -36,7 +36,7 @@ metadata:
     2. [http://rootsquash.com/2016/05/10/securing-the-kubernetes-api/](http://rootsquash.com/2016/05/10/securing-the-kubernetes-api/)
     3. [https://github.com/kelseyhightower/docker-kubernetes-tls-guide](https://github.com/kelseyhightower/docker-kubernetes-tls-guide)
   section: API Server
-  version: 1.0
+  version: "1.0"
   tags:
     - CIS
     - Kubernetes

--- a/compliance/cis_k8s/rules/cis_1_2_4/data.yaml
+++ b/compliance/cis_k8s/rules/cis_1_2_4/data.yaml
@@ -27,7 +27,7 @@ metadata:
     1. [https://kubernetes.io/docs/admin/kube-apiserver/](https://kubernetes.io/docs/admin/kube-apiserver/)
     2. [https://kubernetes.io/docs/admin/kubelet-authentication-authorization/](https://kubernetes.io/docs/admin/kubelet-authentication-authorization/)
   section: API Server
-  version: 1.0
+  version: "1.0"
   tags:
     - CIS
     - Kubernetes

--- a/compliance/cis_k8s/rules/cis_1_2_5/data.yaml
+++ b/compliance/cis_k8s/rules/cis_1_2_5/data.yaml
@@ -37,7 +37,7 @@ metadata:
     2. [https://kubernetes.io/docs/admin/kubelet-authentication-authorization/](https://kubernetes.io/docs/admin/kubelet-authentication-authorization/)
     3. [https://kubernetes.io/docs/concepts/cluster-administration/master-node-communication/#apiserver---kubelet](https://kubernetes.io/docs/concepts/cluster-administration/master-node-communication/#apiserver---kubelet)
   section: API Server
-  version: 1.0
+  version: "1.0"
   tags:
     - CIS
     - Kubernetes

--- a/compliance/cis_k8s/rules/cis_1_2_6/data.yaml
+++ b/compliance/cis_k8s/rules/cis_1_2_6/data.yaml
@@ -40,7 +40,7 @@ metadata:
     2. [https://kubernetes.io/docs/admin/kubelet-authentication-authorization/](https://kubernetes.io/docs/admin/kubelet-authentication-authorization/)
     3. [https://kubernetes.io/docs/concepts/cluster-administration/master-node-communication/#apiserver---kubelet](https://kubernetes.io/docs/concepts/cluster-administration/master-node-communication/#apiserver---kubelet)
   section: API Server
-  version: 1.0
+  version: "1.0"
   tags:
     - CIS
     - Kubernetes

--- a/compliance/cis_k8s/rules/cis_1_2_7/data.yaml
+++ b/compliance/cis_k8s/rules/cis_1_2_7/data.yaml
@@ -31,7 +31,7 @@ metadata:
     1. [https://kubernetes.io/docs/admin/kube-apiserver/](https://kubernetes.io/docs/admin/kube-apiserver/)
     2. [https://kubernetes.io/docs/admin/authorization/](https://kubernetes.io/docs/admin/authorization/)
   section: API Server
-  version: 1.0
+  version: "1.0"
   tags:
     - CIS
     - Kubernetes

--- a/compliance/cis_k8s/rules/cis_1_2_8/data.yaml
+++ b/compliance/cis_k8s/rules/cis_1_2_8/data.yaml
@@ -33,7 +33,7 @@ metadata:
     3. [https://github.com/kubernetes/kubernetes/pull/46076](https://github.com/kubernetes/kubernetes/pull/46076)
     4. [https://acotten.com/post/kube17-security](https://acotten.com/post/kube17-security)
   section: API Server
-  version: 1.0
+  version: "1.0"
   tags:
     - CIS
     - Kubernetes

--- a/compliance/cis_k8s/rules/cis_1_3_2/data.yaml
+++ b/compliance/cis_k8s/rules/cis_1_3_2/data.yaml
@@ -31,7 +31,7 @@ metadata:
     1. [https://kubernetes.io/docs/admin/kube-controller-manager/](https://kubernetes.io/docs/admin/kube-controller-manager/)
     2. [https://github.com/kubernetes/community/blob/master/contributors/devel/profiling.md](https://github.com/kubernetes/community/blob/master/contributors/devel/profiling.md)
   section: Controller Manager
-  version: 1.0
+  version: "1.0"
   tags:
     - CIS
     - Kubernetes

--- a/compliance/cis_k8s/rules/cis_1_3_3/data.yaml
+++ b/compliance/cis_k8s/rules/cis_1_3_3/data.yaml
@@ -49,7 +49,7 @@ metadata:
     4. [https://github.com/kubernetes/kubernetes/blob/release-1.6/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/testdata/controller-role-bindings.yaml](https://github.com/kubernetes/kubernetes/blob/release-1.6/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/testdata/controller-role-bindings.yaml)
     5. [https://kubernetes.io/docs/admin/authorization/rbac/#controller-roles](https://kubernetes.io/docs/admin/authorization/rbac/#controller-roles)
   section: Controller Manager
-  version: 1.0
+  version: "1.0"
   tags:
     - CIS
     - Kubernetes

--- a/compliance/cis_k8s/rules/cis_1_3_4/data.yaml
+++ b/compliance/cis_k8s/rules/cis_1_3_4/data.yaml
@@ -34,7 +34,7 @@ metadata:
   references: |
     1. [https://kubernetes.io/docs/admin/kube-controller-manager/](https://kubernetes.io/docs/admin/kube-controller-manager/)
   section: Controller Manager
-  version: 1.0
+  version: "1.0"
   tags:
     - CIS
     - Kubernetes

--- a/compliance/cis_k8s/rules/cis_1_3_5/data.yaml
+++ b/compliance/cis_k8s/rules/cis_1_3_5/data.yaml
@@ -37,7 +37,7 @@ metadata:
     1. [https://kubernetes.io/docs/admin/kube-controller-manager/](https://kubernetes.io/docs/admin/kube-controller-manager/)
     2. [https://github.com/kubernetes/kubernetes/issues/11000](https://github.com/kubernetes/kubernetes/issues/11000)
   section: Controller Manager
-  version: 1.0
+  version: "1.0"
   tags:
     - CIS
     - Kubernetes

--- a/compliance/cis_k8s/rules/cis_1_3_6/data.yaml
+++ b/compliance/cis_k8s/rules/cis_1_3_6/data.yaml
@@ -40,7 +40,7 @@ metadata:
     3. [https://github.com/kubernetes/kubernetes/pull/45059](https://github.com/kubernetes/kubernetes/pull/45059)
     4. [https://kubernetes.io/docs/admin/kube-controller-manager/](https://kubernetes.io/docs/admin/kube-controller-manager/)
   section: Controller Manager
-  version: 1.0
+  version: "1.0"
   tags:
     - CIS
     - Kubernetes

--- a/compliance/cis_k8s/rules/cis_1_3_7/data.yaml
+++ b/compliance/cis_k8s/rules/cis_1_3_7/data.yaml
@@ -28,7 +28,7 @@ metadata:
   references: |
     1. [https://kubernetes.io/docs/reference/command-line-tools-reference/kube-controller-manager/](https://kubernetes.io/docs/reference/command-line-tools-reference/kube-controller-manager/)
   section: Controller Manager
-  version: 1.0
+  version: "1.0"
   tags:
     - CIS
     - Kubernetes

--- a/compliance/cis_k8s/rules/cis_1_4_1/data.yaml
+++ b/compliance/cis_k8s/rules/cis_1_4_1/data.yaml
@@ -32,7 +32,7 @@ metadata:
     1. [https://kubernetes.io/docs/admin/kube-scheduler/](https://kubernetes.io/docs/admin/kube-scheduler/)
     2. [https://github.com/kubernetes/community/blob/master/contributors/devel/profiling.md](https://github.com/kubernetes/community/blob/master/contributors/devel/profiling.md)
   section: Scheduler
-  version: 1.0
+  version: "1.0"
   tags:
     - CIS
     - Kubernetes

--- a/compliance/cis_k8s/rules/cis_1_4_2/data.yaml
+++ b/compliance/cis_k8s/rules/cis_1_4_2/data.yaml
@@ -28,7 +28,7 @@ metadata:
   references: |
     1. [https://kubernetes.io/docs/reference/command-line-tools-reference/kube-scheduler/](https://kubernetes.io/docs/reference/command-line-tools-reference/kube-scheduler/)
   section: Scheduler
-  version: 1.0
+  version: "1.0"
   tags:
     - CIS
     - Kubernetes

--- a/compliance/cis_k8s/rules/cis_2_1/data.yaml
+++ b/compliance/cis_k8s/rules/cis_2_1/data.yaml
@@ -32,7 +32,7 @@ metadata:
     1. [https://coreos.com/etcd/docs/latest/op-guide/security.html](https://coreos.com/etcd/docs/latest/op-guide/security.html)
     2. [https://kubernetes.io/docs/admin/etcd/](https://kubernetes.io/docs/admin/etcd/)
   section: etcd
-  version: 1.0
+  version: "1.0"
   tags:
     - CIS
     - Kubernetes

--- a/compliance/cis_k8s/rules/cis_2_2/data.yaml
+++ b/compliance/cis_k8s/rules/cis_2_2/data.yaml
@@ -35,7 +35,7 @@ metadata:
     2. [https://kubernetes.io/docs/admin/etcd/](https://kubernetes.io/docs/admin/etcd/)
     3. [https://coreos.com/etcd/docs/latest/op-guide/configuration.html#client-cert-auth](https://coreos.com/etcd/docs/latest/op-guide/configuration.html#client-cert-auth)
   section: etcd
-  version: 1.0
+  version: "1.0"
   tags:
     - CIS
     - Kubernetes

--- a/compliance/cis_k8s/rules/cis_2_3/data.yaml
+++ b/compliance/cis_k8s/rules/cis_2_3/data.yaml
@@ -34,7 +34,7 @@ metadata:
     2. [https://kubernetes.io/docs/admin/etcd/](https://kubernetes.io/docs/admin/etcd/)
     3. [https://coreos.com/etcd/docs/latest/op-guide/configuration.html#auto-tls](https://coreos.com/etcd/docs/latest/op-guide/configuration.html#auto-tls)
   section: etcd
-  version: 1.0
+  version: "1.0"
   tags:
     - CIS
     - Kubernetes

--- a/compliance/cis_k8s/rules/cis_2_4/data.yaml
+++ b/compliance/cis_k8s/rules/cis_2_4/data.yaml
@@ -41,7 +41,7 @@ metadata:
     1. [https://coreos.com/etcd/docs/latest/op-guide/security.html](https://coreos.com/etcd/docs/latest/op-guide/security.html)
     2. [https://kubernetes.io/docs/admin/etcd/](https://kubernetes.io/docs/admin/etcd/)
   section: etcd
-  version: 1.0
+  version: "1.0"
   tags:
     - CIS
     - Kubernetes

--- a/compliance/cis_k8s/rules/cis_2_5/data.yaml
+++ b/compliance/cis_k8s/rules/cis_2_5/data.yaml
@@ -39,7 +39,7 @@ metadata:
     2. [https://kubernetes.io/docs/admin/etcd/](https://kubernetes.io/docs/admin/etcd/)
     3. [https://coreos.com/etcd/docs/latest/op-guide/configuration.html#peer-client-cert-auth](https://coreos.com/etcd/docs/latest/op-guide/configuration.html#peer-client-cert-auth)
   section: etcd
-  version: 1.0
+  version: "1.0"
   tags:
     - CIS
     - Kubernetes

--- a/compliance/cis_k8s/rules/cis_2_6/data.yaml
+++ b/compliance/cis_k8s/rules/cis_2_6/data.yaml
@@ -40,7 +40,7 @@ metadata:
     2. [https://kubernetes.io/docs/admin/etcd/](https://kubernetes.io/docs/admin/etcd/)
     3. [https://coreos.com/etcd/docs/latest/op-guide/configuration.html#peer-auto-tls](https://coreos.com/etcd/docs/latest/op-guide/configuration.html#peer-auto-tls)
   section: etcd
-  version: 1.0
+  version: "1.0"
   tags:
     - CIS
     - Kubernetes

--- a/compliance/cis_k8s/rules/cis_4_1_1/data.yaml
+++ b/compliance/cis_k8s/rules/cis_4_1_1/data.yaml
@@ -46,7 +46,7 @@ metadata:
     2. [https://kubernetes.io/docs/setup/independent/create-cluster-kubeadm/#44-joining-your-nodes](https://kubernetes.io/docs/setup/independent/create-cluster-kubeadm/#44-joining-your-nodes)
     3. [https://kubernetes.io/docs/admin/kubeadm/#kubelet-drop-in](https://kubernetes.io/docs/admin/kubeadm/#kubelet-drop-in)
   section: Worker Node Configuration Files
-  version: 1.0
+  version: "1.0"
   tags:
     - CIS
     - Kubernetes

--- a/compliance/cis_k8s/rules/cis_4_1_10/data.yaml
+++ b/compliance/cis_k8s/rules/cis_4_1_10/data.yaml
@@ -44,7 +44,7 @@ metadata:
   references: |
     1. [https://kubernetes.io/docs/tasks/administer-cluster/kubelet-config-file/](https://kubernetes.io/docs/tasks/administer-cluster/kubelet-config-file/)
   section: Worker Node Configuration Files
-  version: 1.0
+  version: "1.0"
   tags:
     - CIS
     - Kubernetes

--- a/compliance/cis_k8s/rules/cis_4_1_2/data.yaml
+++ b/compliance/cis_k8s/rules/cis_4_1_2/data.yaml
@@ -45,7 +45,7 @@ metadata:
     2. [https://kubernetes.io/docs/setup/independent/create-cluster-kubeadm/#44-joining-your-nodes](https://kubernetes.io/docs/setup/independent/create-cluster-kubeadm/#44-joining-your-nodes)
     3. [https://kubernetes.io/docs/admin/kubeadm/#kubelet-drop-in](https://kubernetes.io/docs/admin/kubeadm/#kubelet-drop-in)
   section: Worker Node Configuration Files
-  version: 1.0
+  version: "1.0"
   tags:
     - CIS
     - Kubernetes

--- a/compliance/cis_k8s/rules/cis_4_1_5/data.yaml
+++ b/compliance/cis_k8s/rules/cis_4_1_5/data.yaml
@@ -46,7 +46,7 @@ metadata:
   references: |
     1. [https://kubernetes.io/docs/admin/kubelet/](https://kubernetes.io/docs/admin/kubelet/)
   section: Worker Node Configuration Files
-  version: 1.0
+  version: "1.0"
   tags:
     - CIS
     - Kubernetes

--- a/compliance/cis_k8s/rules/cis_4_1_9/data.yaml
+++ b/compliance/cis_k8s/rules/cis_4_1_9/data.yaml
@@ -44,7 +44,7 @@ metadata:
   references: |
     1. [https://kubernetes.io/docs/tasks/administer-cluster/kubelet-config-file/](https://kubernetes.io/docs/tasks/administer-cluster/kubelet-config-file/)
   section: Worker Node Configuration Files
-  version: 1.0
+  version: "1.0"
   tags:
     - CIS
     - Kubernetes

--- a/compliance/cis_k8s/rules/cis_4_2_1/data.yaml
+++ b/compliance/cis_k8s/rules/cis_4_2_1/data.yaml
@@ -44,7 +44,7 @@ metadata:
     1. [https://kubernetes.io/docs/admin/kubelet/](https://kubernetes.io/docs/admin/kubelet/)
     2. [https://kubernetes.io/docs/admin/kubelet-authentication-authorization/#kubelet-authentication](https://kubernetes.io/docs/admin/kubelet-authentication-authorization/#kubelet-authentication)
   section: Kubelet
-  version: 1.0
+  version: "1.0"
   tags:
     - CIS
     - Kubernetes

--- a/compliance/cis_k8s/rules/cis_4_2_2/data.yaml
+++ b/compliance/cis_k8s/rules/cis_4_2_2/data.yaml
@@ -44,7 +44,7 @@ metadata:
     1. [https://kubernetes.io/docs/admin/kubelet/](https://kubernetes.io/docs/admin/kubelet/)
     2. [https://kubernetes.io/docs/admin/kubelet-authentication-authorization/#kubelet-authentication](https://kubernetes.io/docs/admin/kubelet-authentication-authorization/#kubelet-authentication)
   section: Kubelet
-  version: 1.0
+  version: "1.0"
   tags:
     - CIS
     - Kubernetes

--- a/compliance/cis_k8s/rules/cis_4_2_3/data.yaml
+++ b/compliance/cis_k8s/rules/cis_4_2_3/data.yaml
@@ -48,7 +48,7 @@ metadata:
     1. [https://kubernetes.io/docs/admin/kubelet/](https://kubernetes.io/docs/admin/kubelet/)
     2. [https://kubernetes.io/docs/reference/command-line-tools-reference/kubelet-authentication-authorization/](https://kubernetes.io/docs/reference/command-line-tools-reference/kubelet-authentication-authorization/)
   section: Kubelet
-  version: 1.0
+  version: "1.0"
   tags:
     - CIS
     - Kubernetes

--- a/compliance/cis_k8s/rules/cis_4_2_6/data.yaml
+++ b/compliance/cis_k8s/rules/cis_4_2_6/data.yaml
@@ -42,7 +42,7 @@ metadata:
   references: |
     1. [https://kubernetes.io/docs/admin/kubelet/](https://kubernetes.io/docs/admin/kubelet/)
   section: Kubelet
-  version: 1.0
+  version: "1.0"
   tags:
     - CIS
     - Kubernetes

--- a/compliance/cis_k8s/rules/cis_4_2_7/data.yaml
+++ b/compliance/cis_k8s/rules/cis_4_2_7/data.yaml
@@ -44,7 +44,7 @@ metadata:
   references: |
     1. [https://kubernetes.io/docs/admin/kubelet/](https://kubernetes.io/docs/admin/kubelet/)
   section: Kubelet
-  version: 1.0
+  version: "1.0"
   tags:
     - CIS
     - Kubernetes

--- a/compliance/cis_k8s/rules/cis_5_1_3/data.yaml
+++ b/compliance/cis_k8s/rules/cis_5_1_3/data.yaml
@@ -35,7 +35,7 @@ metadata:
   default_value:
   references:
   section: RBAC and Service Accounts
-  version: 1.0
+  version: "1.0"
   tags:
     - CIS
     - Kubernetes

--- a/compliance/cis_k8s/rules/cis_5_1_5/data.yaml
+++ b/compliance/cis_k8s/rules/cis_5_1_5/data.yaml
@@ -40,7 +40,7 @@ metadata:
   references: |
     1. [https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/](https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/)
   section: RBAC and Service Accounts
-  version: 1.0
+  version: "1.0"
   tags:
     - CIS
     - Kubernetes

--- a/compliance/cis_k8s/rules/cis_5_1_6/data.yaml
+++ b/compliance/cis_k8s/rules/cis_5_1_6/data.yaml
@@ -32,7 +32,7 @@ metadata:
   references: |
     1. [https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/](https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/)
   section: RBAC and Service Accounts
-  version: 1.0
+  version: "1.0"
   tags:
     - CIS
     - Kubernetes

--- a/compliance/cis_k8s/rules/cis_5_2_1/data.yaml
+++ b/compliance/cis_k8s/rules/cis_5_2_1/data.yaml
@@ -37,7 +37,7 @@ metadata:
   references: |
     1. [https://kubernetes.io/docs/concepts/policy/pod-security-policy/#enabling-pod-security-policies](https://kubernetes.io/docs/concepts/policy/pod-security-policy/#enabling-pod-security-policies)
   section: Pod Security Policies
-  version: 1.0
+  version: "1.0"
   tags:
     - CIS
     - Kubernetes

--- a/compliance/cis_k8s/rules/cis_5_2_2/data.yaml
+++ b/compliance/cis_k8s/rules/cis_5_2_2/data.yaml
@@ -39,7 +39,7 @@ metadata:
   references: |
     1. [https://kubernetes.io/docs/concepts/policy/pod-security-policy](https://kubernetes.io/docs/concepts/policy/pod-security-policy)
   section: Pod Security Policies
-  version: 1.0
+  version: "1.0"
   tags:
     - CIS
     - Kubernetes

--- a/compliance/cis_k8s/rules/cis_5_2_3/data.yaml
+++ b/compliance/cis_k8s/rules/cis_5_2_3/data.yaml
@@ -37,7 +37,7 @@ metadata:
   references: |
     1. [https://kubernetes.io/docs/concepts/policy/pod-security-policy](https://kubernetes.io/docs/concepts/policy/pod-security-policy)
   section: Pod Security Policies
-  version: 1.0
+  version: "1.0"
   tags:
     - CIS
     - Kubernetes

--- a/compliance/cis_k8s/rules/cis_5_2_4/data.yaml
+++ b/compliance/cis_k8s/rules/cis_5_2_4/data.yaml
@@ -37,7 +37,7 @@ metadata:
   references: |
     1. [https://kubernetes.io/docs/concepts/policy/pod-security-policy](https://kubernetes.io/docs/concepts/policy/pod-security-policy)
   section: Pod Security Policies
-  version: 1.0
+  version: "1.0"
   tags:
     - CIS
     - Kubernetes

--- a/compliance/cis_k8s/rules/cis_5_2_5/data.yaml
+++ b/compliance/cis_k8s/rules/cis_5_2_5/data.yaml
@@ -37,7 +37,7 @@ metadata:
   references: |
     1. [https://kubernetes.io/docs/concepts/policy/pod-security-policy](https://kubernetes.io/docs/concepts/policy/pod-security-policy)
   section: Pod Security Policies
-  version: 1.0
+  version: "1.0"
   tags:
     - CIS
     - Kubernetes

--- a/compliance/cis_k8s/rules/cis_5_2_6/data.yaml
+++ b/compliance/cis_k8s/rules/cis_5_2_6/data.yaml
@@ -37,7 +37,7 @@ metadata:
   references: |
     1. [https://kubernetes.io/docs/concepts/policy/pod-security-policy/#enabling-pod-security-policies](https://kubernetes.io/docs/concepts/policy/pod-security-policy/#enabling-pod-security-policies)
   section: Pod Security Policies
-  version: 1.0
+  version: "1.0"
   tags:
     - CIS
     - Kubernetes

--- a/compliance/cis_k8s/rules/cis_5_2_7/data.yaml
+++ b/compliance/cis_k8s/rules/cis_5_2_7/data.yaml
@@ -39,7 +39,7 @@ metadata:
     1. [https://kubernetes.io/docs/concepts/policy/pod-security-policy/#enabling-pod-security-policies](https://kubernetes.io/docs/concepts/policy/pod-security-policy/#enabling-pod-security-policies)
     2. [https://www.nccgroup.trust/uk/our-research/abusing-privileged-and-unprivileged-linux-containers/](https://www.nccgroup.trust/uk/our-research/abusing-privileged-and-unprivileged-linux-containers/)
   section: Pod Security Policies
-  version: 1.0
+  version: "1.0"
   tags:
     - CIS
     - Kubernetes

--- a/compliance/cis_k8s/rules/cis_5_2_8/data.yaml
+++ b/compliance/cis_k8s/rules/cis_5_2_8/data.yaml
@@ -37,7 +37,7 @@ metadata:
     1. [https://kubernetes.io/docs/concepts/policy/pod-security-policy/#enabling-pod-security-policies](https://kubernetes.io/docs/concepts/policy/pod-security-policy/#enabling-pod-security-policies)
     2. [https://www.nccgroup.trust/uk/our-research/abusing-privileged-and-unprivileged-linux-containers/](https://www.nccgroup.trust/uk/our-research/abusing-privileged-and-unprivileged-linux-containers/)
   section: Pod Security Policies
-  version: 1.0
+  version: "1.0"
   tags:
     - CIS
     - Kubernetes

--- a/compliance/cis_k8s/rules/cis_5_2_9/data.yaml
+++ b/compliance/cis_k8s/rules/cis_5_2_9/data.yaml
@@ -35,7 +35,7 @@ metadata:
     1. [https://kubernetes.io/docs/concepts/policy/pod-security-policy/#enabling-pod-security-policies](https://kubernetes.io/docs/concepts/policy/pod-security-policy/#enabling-pod-security-policies)
     2. [https://www.nccgroup.trust/uk/our-research/abusing-privileged-and-unprivileged-linux-containers/](https://www.nccgroup.trust/uk/our-research/abusing-privileged-and-unprivileged-linux-containers/)
   section: Pod Security Policies
-  version: 1.0
+  version: "1.0"
   tags:
     - CIS
     - Kubernetes


### PR DESCRIPTION
The default parser looks at the values and attempts to recognize the type in order to convert the values to the intended type.
When encountering 1.0 it assumes that the value is a numeric type and converts it to integer 1.

There were several options on how to escape that behavior:
1. Explicitly state that the version is of type string, by adding "1.0"
2. Add another dot 1.0.0 (parser will not assume numeric type)
3. Add a prefix to the version number v1.0 (parser will not assume numeric type)

I've decided to go with option 1 due to this article https://www.elastic.co/guide/en/elasticsearch/reference/current/version.html
