### PR TITLE
Rule expected permissions as string instead of number

### DIFF
--- a/compliance/cis_k8s/rules/cis_1_1_1/rule.rego
+++ b/compliance/cis_k8s/rules/cis_1_1_1/rule.rego
@@ -12,7 +12,7 @@ finding = result {
 	# set result
 	result := {
 		"evaluation": common.calculate_result(rule_evaluation),
-		"expected": {"filemode": 644},
+		"expected": {"filemode": "644"},
 		"evidence": {"filemode": filemode},
 	}
 }

--- a/compliance/cis_k8s/rules/cis_1_1_11/rule.rego
+++ b/compliance/cis_k8s/rules/cis_1_1_11/rule.rego
@@ -12,7 +12,7 @@ finding = result {
 	# set result
 	result := {
 		"evaluation": common.calculate_result(rule_evaluation),
-		"expected": {"filemode": 700},
+		"expected": {"filemode": "700"},
 		"evidence": {"filemode": filemode},
 	}
 }

--- a/compliance/cis_k8s/rules/cis_1_1_13/rule.rego
+++ b/compliance/cis_k8s/rules/cis_1_1_13/rule.rego
@@ -12,7 +12,7 @@ finding = result {
 	# set result
 	result := {
 		"evaluation": common.calculate_result(rule_evaluation),
-		"expected": {"filemode": 644},
+		"expected": {"filemode": "644"},
 		"evidence": {"filemode": filemode},
 	}
 }

--- a/compliance/cis_k8s/rules/cis_1_1_15/rule.rego
+++ b/compliance/cis_k8s/rules/cis_1_1_15/rule.rego
@@ -12,7 +12,7 @@ finding = result {
 	# set result
 	result := {
 		"evaluation": common.calculate_result(rule_evaluation),
-		"expected": {"filemode": 644},
+		"expected": {"filemode": "644"},
 		"evidence": {"filemode": filemode},
 	}
 }

--- a/compliance/cis_k8s/rules/cis_1_1_17/rule.rego
+++ b/compliance/cis_k8s/rules/cis_1_1_17/rule.rego
@@ -12,7 +12,7 @@ finding = result {
 	# set result
 	result := {
 		"evaluation": common.calculate_result(rule_evaluation),
-		"expected": {"filemode": 644},
+		"expected": {"filemode": "644"},
 		"evidence": {"filemode": filemode},
 	}
 }

--- a/compliance/cis_k8s/rules/cis_1_1_3/rule.rego
+++ b/compliance/cis_k8s/rules/cis_1_1_3/rule.rego
@@ -12,7 +12,7 @@ finding = result {
 	# set result
 	result := {
 		"evaluation": common.calculate_result(rule_evaluation),
-		"expected": {"filemode": 644},
+		"expected": {"filemode": "644"},
 		"evidence": {"filemode": filemode},
 	}
 }

--- a/compliance/cis_k8s/rules/cis_1_1_5/rule.rego
+++ b/compliance/cis_k8s/rules/cis_1_1_5/rule.rego
@@ -12,7 +12,7 @@ finding = result {
 	# set result
 	result := {
 		"evaluation": common.calculate_result(rule_evaluation),
-		"expected": {"filemode": 644},
+		"expected": {"filemode": "644"},
 		"evidence": {"filemode": filemode},
 	}
 }

--- a/compliance/cis_k8s/rules/cis_1_1_7/rule.rego
+++ b/compliance/cis_k8s/rules/cis_1_1_7/rule.rego
@@ -12,7 +12,7 @@ finding = result {
 	# set result
 	result := {
 		"evaluation": common.calculate_result(rule_evaluation),
-		"expected": {"filemode": 644},
+		"expected": {"filemode": "644"},
 		"evidence": {"filemode": filemode},
 	}
 }

--- a/compliance/cis_k8s/rules/cis_4_1_1/rule.rego
+++ b/compliance/cis_k8s/rules/cis_4_1_1/rule.rego
@@ -12,7 +12,7 @@ finding = result {
 	# set result
 	result := {
 		"evaluation": common.calculate_result(rule_evaluation),
-		"expected": {"filemode": 644},
+		"expected": {"filemode": "644"},
 		"evidence": {"filemode": filemode},
 	}
 }

--- a/compliance/cis_k8s/rules/cis_4_1_5/rule.rego
+++ b/compliance/cis_k8s/rules/cis_4_1_5/rule.rego
@@ -12,7 +12,7 @@ finding = result {
 	# set result
 	result := {
 		"evaluation": common.calculate_result(rule_evaluation),
-		"expected": {"filemode": 644},
+		"expected": {"filemode": "644"},
 		"evidence": {"filemode": filemode},
 	}
 }

--- a/compliance/cis_k8s/rules/cis_4_1_9/rule.rego
+++ b/compliance/cis_k8s/rules/cis_4_1_9/rule.rego
@@ -12,7 +12,7 @@ finding = result {
 	# set result
 	result := {
 		"evaluation": common.calculate_result(rule_evaluation),
-		"expected": {"filemode": 644},
+		"expected": {"filemode": "644"},
 		"evidence": {"filemode": filemode},
 	}
 }


### PR DESCRIPTION
Making sure that expected is aligned to evidence and returns the permissions as strings and not numbers