### PR TITLE
csp-3473-enrich-eks-rules

### DIFF
--- a/compliance/cis_eks/rules/cis_2_1_1/data.yaml
+++ b/compliance/cis_eks/rules/cis_2_1_1/data.yaml
@@ -1,0 +1,108 @@
+metadata:
+  id: 2a7530ac-1a7b-5b64-91e2-6c1848d019bd
+  name: Enable audit Logs (Manual)
+  profile_applicability: |
+    • Level 1
+  description: |
+    The audit logs are part of the EKS managed Kubernetes control plane logs
+    that are managed
+
+    by Amazon EKS. Amazon EKS is integrated with AWS CloudTrail, a service that provides a
+
+    record of actions taken by a user, role, or an AWS service in Amazon EKS. CloudTrail
+
+    captures all API calls for Amazon EKS as events. The calls captured include calls from the
+
+    Amazon EKS console and code calls to the Amazon EKS API operations.
+  rationale: |
+    Exporting logs and metrics to a dedicated, persistent datastore such as
+    CloudTrail ensures
+
+    availability of audit data following a cluster security event, and provides a central location
+
+    for analysis of log and metric data collated from multiple sources.
+  audit: |
+    Perform the following to determine if CloudTrail is enabled for all regions:
+    **Via the Management Console**
+    1. Sign in to the AWS Management Console and open the EKS console at
+    https://console.aws.amazon.com/eks
+    2. Click on Cluster Name of the cluster you are auditing
+    3. Click Logging
+    You will see Control Plane Logging info
+    ```
+    API Server Enabled/Disabled
+    Audit Enabled/Disabled
+    Authenticator Enabled/Disabled
+    Controller Manager Enabled/Disabled 
+    Scheduler Enabled/Disabled
+    ```
+    4. Ensure all 5 choices are set to Enabled
+  remediation: |
+    Perform the following to determine if CloudTrail is enabled for all regions:
+
+    **Via The Management Console**
+
+    1. Sign in to the AWS Management Console and open the EKS console at
+
+    https://console.aws.amazon.com/eks
+
+    2. Click on Cluster Name of the cluster you are auditing
+
+    3. Click Logging
+
+    4. Select Manage Logging from the button on the right hand side
+
+    5. Toggle each selection to the Enabled position.
+
+    6. Click Save Changes
+
+    **Via CLI**
+    ```
+    aws --region "${REGION_CODE}" eks describe-cluster --name "${CLUSTER_NAME}" -
+
+    -query 'cluster.logging.clusterLogging[?enabled==true].types
+    ```
+  impact: >
+    Audit logs will be created on the master nodes, which will consume disk
+    space. Care should
+
+    be taken to avoid generating too large volumes of log information as this could impact the
+
+    available of the cluster nodes. S3 lifecycle features can be used to manage the accumulation
+
+    and management of logs over time.
+
+    See the following AWS resource for more information on these features:
+
+    http://docs.aws.amazon.com/AmazonS3/latest/dev/object-lifecycle-mgmt.html
+  default_value: >
+    By default, cluster control plane logs aren't sent to CloudWatch Logs. ...
+    
+    When you enable a log type, the logs are sent with a log verbosity level of 2 . 
+    
+    To enable or disable control plane
+
+    logs with the console. Open the Amazon EKS console at
+
+    https://console.aws.amazon.com/eks/home#/clusters .
+
+    Amazon EKS Information in CloudTrail CloudTrail is enabled on your AWS account when
+
+    you create the account. When activity occurs in Amazon EKS, that activity is recorded in a
+
+    CloudTrail event along with other AWS service events in Event history.
+  references: |
+    1. https://kubernetes.io/docs/tasks/debug-application-cluster/audit/
+    2. https://aws.github.io/aws-eks-best-practices/detective/
+    3. https://docs.aws.amazon.com/eks/latest/userguide/control-plane-logs.html
+    4. https://docs.aws.amazon.com/eks/latest/userguide/logging-using-cloudtrail.html
+  section: Logging
+  version: "1.0"
+  tags:
+  - CIS
+  - EKS
+  - CIS 2.1.1
+  - Logging
+  benchmark:
+    name: CIS Amazon Elastic Kubernetes Service (EKS) Benchmark
+    version: v1.0.1

--- a/compliance/cis_eks/rules/cis_2_1_1/data.yaml
+++ b/compliance/cis_eks/rules/cis_2_1_1/data.yaml
@@ -2,7 +2,7 @@ metadata:
   id: 2a7530ac-1a7b-5b64-91e2-6c1848d019bd
   name: Enable audit Logs (Manual)
   profile_applicability: |
-    • Level 1
+    * Level 1
   description: |
     The audit logs are part of the EKS managed Kubernetes control plane logs
     that are managed

--- a/compliance/cis_eks/rules/cis_2_1_1/data.yaml
+++ b/compliance/cis_eks/rules/cis_2_1_1/data.yaml
@@ -5,21 +5,15 @@ metadata:
     * Level 1
   description: |
     The audit logs are part of the EKS managed Kubernetes control plane logs
-    that are managed
-
-    by Amazon EKS. Amazon EKS is integrated with AWS CloudTrail, a service that provides a
-
+    that are managed by Amazon EKS. 
+    Amazon EKS is integrated with AWS CloudTrail, a service that provides a
     record of actions taken by a user, role, or an AWS service in Amazon EKS. CloudTrail
-
     captures all API calls for Amazon EKS as events. The calls captured include calls from the
-
     Amazon EKS console and code calls to the Amazon EKS API operations.
   rationale: |
     Exporting logs and metrics to a dedicated, persistent datastore such as
     CloudTrail ensures
-
     availability of audit data following a cluster security event, and provides a central location
-
     for analysis of log and metric data collated from multiple sources.
   audit: |
     Perform the following to determine if CloudTrail is enabled for all regions:
@@ -39,57 +33,36 @@ metadata:
     4. Ensure all 5 choices are set to Enabled
   remediation: |
     Perform the following to determine if CloudTrail is enabled for all regions:
-
     **Via The Management Console**
-
     1. Sign in to the AWS Management Console and open the EKS console at
-
     https://console.aws.amazon.com/eks
-
     2. Click on Cluster Name of the cluster you are auditing
-
     3. Click Logging
-
     4. Select Manage Logging from the button on the right hand side
-
     5. Toggle each selection to the Enabled position.
-
     6. Click Save Changes
 
     **Via CLI**
     ```
     aws --region "${REGION_CODE}" eks describe-cluster --name "${CLUSTER_NAME}" -
-
     -query 'cluster.logging.clusterLogging[?enabled==true].types
     ```
   impact: >
     Audit logs will be created on the master nodes, which will consume disk
-    space. Care should
-
-    be taken to avoid generating too large volumes of log information as this could impact the
-
+    space. 
+    Care should be taken to avoid generating too large volumes of log information as this could impact the
     available of the cluster nodes. S3 lifecycle features can be used to manage the accumulation
-
     and management of logs over time.
-
     See the following AWS resource for more information on these features:
-
     http://docs.aws.amazon.com/AmazonS3/latest/dev/object-lifecycle-mgmt.html
   default_value: >
     By default, cluster control plane logs aren't sent to CloudWatch Logs. ...
-    
     When you enable a log type, the logs are sent with a log verbosity level of 2 . 
-    
     To enable or disable control plane
-
     logs with the console. Open the Amazon EKS console at
-
     https://console.aws.amazon.com/eks/home#/clusters .
-
     Amazon EKS Information in CloudTrail CloudTrail is enabled on your AWS account when
-
     you create the account. When activity occurs in Amazon EKS, that activity is recorded in a
-
     CloudTrail event along with other AWS service events in Event history.
   references: |
     1. https://kubernetes.io/docs/tasks/debug-application-cluster/audit/

--- a/compliance/cis_eks/rules/cis_2_1_1/data.yaml
+++ b/compliance/cis_eks/rules/cis_2_1_1/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 2a7530ac-1a7b-5b64-91e2-6c1848d019bd
+  id: 433ae1b7-0411-54e2-8b06-f62be93b4089
   name: Enable audit Logs (Manual)
   profile_applicability: |
     * Level 1

--- a/compliance/cis_eks/rules/cis_2_1_1/rule.rego
+++ b/compliance/cis_eks/rules/cis_2_1_1/rule.rego
@@ -21,26 +21,3 @@ finding = result {
 		"evidence": {"disabled_logs": disabled_logs},
 	}
 }
-
-metadata = {
-	"name": "Enable audit Logs",
-	"description": `The audit logs are part of the EKS managed Kubernetes control plane logs that are managed by Amazon EKS.
-Amazon EKS is integrated with AWS CloudTrail, a service that provides a record of actions taken by a user, role, or an AWS service in Amazon EKS.
-CloudTrail captures all API calls for Amazon EKS as events.
-The calls captured include calls from the Amazon EKS console and code calls to the Amazon EKS API operations.`,
-	"rationale": `Exporting logs and metrics to a dedicated,
-persistent datastore such as CloudTrail ensures availability of audit data following a cluster security event,
-and provides a central location for analysis of log and metric data collated from multiple sources.`,
-	"impact": `Audit logs will be created on the master nodes, which will consume disk space.
-Care should be taken to avoid generating too large volumes of log information as this could impact the available of the cluster nodes.
-S3 lifecycle features can be used to manage the accumulation and management of logs over time.`,
-	"tags": array.concat(cis_eks.default_tags, ["CIS 2.1.1", "Logging"]),
-	"default_value": `By default, cluster control plane logs aren't sent to CloudWatch Logs.
-When you enable a log type, the logs are sent with a log verbosity level of 2.
-To enable or disable control plane logs with the console.
-Open the Amazon EKS console at https://console.aws.amazon.com/eks/home#/clusters.
-Amazon EKS Information in CloudTrail CloudTrail is enabled on your AWS account when you create the account.
-When activity occurs in Amazon EKS, that activity is recorded in a CloudTrail event along with other AWS service events in Event history.`,
-	"benchmark": cis_eks.benchmark_metadata,
-	"remediation": `aws --region "${REGION_CODE}" eks describe-cluster --name "${CLUSTER_NAME}" --query 'cluster.logging.clusterLogging[?enabled==true].types`,
-}

--- a/compliance/cis_eks/rules/cis_2_1_1/rule.rego
+++ b/compliance/cis_eks/rules/cis_2_1_1/rule.rego
@@ -1,6 +1,5 @@
 package compliance.cis_eks.rules.cis_2_1_1
 
-import data.compliance.cis_eks
 import data.compliance.cis_eks.data_adapter
 import data.compliance.lib.assert
 import data.compliance.lib.common

--- a/compliance/cis_eks/rules/cis_3_1_1/data.yaml
+++ b/compliance/cis_eks/rules/cis_3_1_1/data.yaml
@@ -37,7 +37,9 @@ metadata:
     Run the below command (based on the file location on your system) on the
     each worker node. 
     For example,
-    `chmod 644 <kubeconfig file>`
+    ```
+    chmod 644 <kubeconfig file>
+    ```
   impact: |
     None.
   default_value: |

--- a/compliance/cis_eks/rules/cis_3_1_1/data.yaml
+++ b/compliance/cis_eks/rules/cis_3_1_1/data.yaml
@@ -2,7 +2,7 @@ metadata:
   id: 4b8cc635-6f7f-50dc-96da-1bcb599f1c91
   name: Ensure that the kubeconfig file permissions are set to 644 or more restrictive (Manual)
   profile_applicability: |
-    • Level 1
+    * Level 1
   description: |
     If `kubelet` is running, and if it is using a file-based kubeconfig file,
     ensure that the proxy

--- a/compliance/cis_eks/rules/cis_3_1_1/data.yaml
+++ b/compliance/cis_eks/rules/cis_3_1_1/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 4b8cc635-6f7f-50dc-96da-1bcb599f1c91
+  id: fd3e93e3-c1c6-5dd7-a582-cf6ab65ea2f2
   name: Ensure that the kubeconfig file permissions are set to 644 or more restrictive (Manual)
   profile_applicability: |
     * Level 1

--- a/compliance/cis_eks/rules/cis_3_1_1/data.yaml
+++ b/compliance/cis_eks/rules/cis_3_1_1/data.yaml
@@ -6,48 +6,37 @@ metadata:
   description: |
     If `kubelet` is running, and if it is using a file-based kubeconfig file,
     ensure that the proxy
-
     kubeconfig file has permissions of `644` or more restrictive.
   rationale: |
     The `kubelet` kubeconfig file controls various parameters of the `kubelet`
     service in the worker node. 
     You should restrict its file permissions to maintain the integrity of the file.
-
     The file should be writable by only the administrators on the system.
-
     It is possible to run `kubelet` with the kubeconfig parameters configured as a Kubernetes
-
     ConfigMap instead of a file. In this case, there is no proxy kubeconfig file.
   audit: |
     SSH to the worker nodes
-
     To check to see if the Kubelet Service is running:
     ```
     sudo systemctl status kubelet
     ```
     The output should return `Active: active (running) since..`
-
     Run the following command on each node to find the appropriate kubeconfig file:
     ```
     ps -ef | grep kubelet
     ```
     The output of the above command should return something similar to `--kubeconfig
-
     /var/lib/kubelet/kubeconfig` which is the location of the kubeconfig file.
-
     Run this command to obtain the kubeconfig file permissions:
     ```
     stat -c %a /var/lib/kubelet/kubeconfig
     ```
     The output of the above command gives you the kubeconfig file's permissions.
-
     Verify that if a file is specified and it exists, the permissions are 644 or more restrictive.
   remediation: |
     Run the below command (based on the file location on your system) on the
-    each worker
-
-    node. For example,
-
+    each worker node. 
+    For example,
     `chmod 644 <kubeconfig file>`
   impact: |
     None.

--- a/compliance/cis_eks/rules/cis_3_1_1/data.yaml
+++ b/compliance/cis_eks/rules/cis_3_1_1/data.yaml
@@ -1,0 +1,67 @@
+metadata:
+  id: 4b8cc635-6f7f-50dc-96da-1bcb599f1c91
+  name: Ensure that the kubeconfig file permissions are set to 644 or more restrictive (Manual)
+  profile_applicability: |
+    • Level 1
+  description: |
+    If `kubelet` is running, and if it is using a file-based kubeconfig file,
+    ensure that the proxy
+
+    kubeconfig file has permissions of `644` or more restrictive.
+  rationale: |
+    The `kubelet` kubeconfig file controls various parameters of the `kubelet`
+    service in the worker node. 
+    You should restrict its file permissions to maintain the integrity of the file.
+
+    The file should be writable by only the administrators on the system.
+
+    It is possible to run `kubelet` with the kubeconfig parameters configured as a Kubernetes
+
+    ConfigMap instead of a file. In this case, there is no proxy kubeconfig file.
+  audit: |
+    SSH to the worker nodes
+
+    To check to see if the Kubelet Service is running:
+    ```
+    sudo systemctl status kubelet
+    ```
+    The output should return `Active: active (running) since..`
+
+    Run the following command on each node to find the appropriate kubeconfig file:
+    ```
+    ps -ef | grep kubelet
+    ```
+    The output of the above command should return something similar to `--kubeconfig
+
+    /var/lib/kubelet/kubeconfig` which is the location of the kubeconfig file.
+
+    Run this command to obtain the kubeconfig file permissions:
+    ```
+    stat -c %a /var/lib/kubelet/kubeconfig
+    ```
+    The output of the above command gives you the kubeconfig file's permissions.
+
+    Verify that if a file is specified and it exists, the permissions are 644 or more restrictive.
+  remediation: |
+    Run the below command (based on the file location on your system) on the
+    each worker
+
+    node. For example,
+
+    `chmod 644 <kubeconfig file>`
+  impact: |
+    None.
+  default_value: |
+    See the AWS EKS documentation for the default value.
+  references: |
+    1. https://kubernetes.io/docs/admin/kube-proxy/
+  section: Worker Node Configuration Files
+  version: "1.0"
+  tags:
+  - CIS
+  - EKS
+  - CIS 3.1.1
+  - Worker Node Configuration Files
+  benchmark:
+    name: CIS Amazon Elastic Kubernetes Service (EKS) Benchmark
+    version: v1.0.1

--- a/compliance/cis_eks/rules/cis_3_1_1/rule.rego
+++ b/compliance/cis_eks/rules/cis_3_1_1/rule.rego
@@ -1,6 +1,5 @@
 package compliance.cis_eks.rules.cis_3_1_1
 
-import data.compliance.cis_eks
 import data.compliance.lib.common
 import data.compliance.lib.data_adapter
 
@@ -18,18 +17,4 @@ finding = result {
 		"evaluation": common.calculate_result(rule_evaluation),
 		"evidence": {"filemode": filemode},
 	}
-}
-
-metadata = {
-	"name": "Ensure that the kubeconfig file permissions are set to 644 or more restrictive",
-	"description": "If kubelet is running, and if it is using a file-based kubeconfig file, ensure that the proxy kubeconfig file has permissions of 644 or more restrictive.",
-	"rationale": `The kubelet kubeconfig file controls various parameters of the kubelet service in the worker node.
-You should restrict its file permissions to maintain the integrity of the file.
-The file should be writable by only the administrators on the system.
-It is possible to run kubelet with the kubeconfig parameters configured as a Kubernetes ConfigMap instead of a file. In this case, there is no proxy kubeconfig file.`,
-	"impact": "None",
-	"tags": array.concat(cis_eks.default_tags, ["CIS 3.1.1", "Worker Node Configuration"]),
-	"default_value": "See the AWS EKS documentation for the default value.",
-	"benchmark": cis_eks.benchmark_metadata,
-	"remediation": "chmod 644 /var/lib/kubelet/kubeconfig",
 }

--- a/compliance/cis_eks/rules/cis_3_1_2/data.yaml
+++ b/compliance/cis_eks/rules/cis_3_1_2/data.yaml
@@ -1,0 +1,61 @@
+metadata:
+  id: 444acc9b-041e-5b16-9340-4fe44cf25b6a
+  name: Ensure that the kubelet kubeconfig file ownership is set to root:root (Manual)
+  profile_applicability: |
+    • Level 1
+  description: |
+    If `kubelet` is running, ensure that the file ownership of its kubeconfig file
+    is set to `root:root`.
+  rationale: |
+    The kubeconfig file for `kubelet` controls various parameters for the `kubelet`
+    service in the
+
+    worker node. You should set its file ownership to maintain the integrity of the file. 
+    The file should be owned by `root:root`.
+  audit: |
+    SSH to the worker nodes
+
+    To check to see if the Kubelet Service is running:
+    ```
+    sudo systemctl status kubelet
+    ```
+    The output should return `Active: active (running) since..`
+
+    Run the following command on each node to find the appropriate kubeconfig file:
+    ```
+    ps -ef | grep kubelet
+    ```
+    The output of the above command should return something similar to `--kubeconfig`
+
+    `/var/lib/kubelet/kubeconfig` which is the location of the kubeconfig file.
+
+    Run this command to obtain the kubeconfig file ownership:
+    ```
+    stat -c %U:%G /var/lib/kubelet/kubeconfig
+    ```
+    The output of the above command gives you the kubeconfig file's ownership. Verify that the
+
+    ownership is set to `root:root`.
+  remediation: |
+    Run the below command (based on the file location on your system) on the
+    each worker node. 
+    For example,
+    ```
+    chown root:root <proxy kubeconfig file>
+    ```
+  impact: |
+    None
+  default_value: |
+    See the AWS EKS documentation for the default value.
+  references: |
+    1. https://kubernetes.io/docs/admin/kube-proxy/
+  section: Worker Node Configuration Files
+  version: "1.0"
+  tags:
+  - CIS
+  - EKS
+  - CIS 3.1.2
+  - Worker Node Configuration Files
+  benchmark:
+    name: CIS Amazon Elastic Kubernetes Service (EKS) Benchmark
+    version: v1.0.1

--- a/compliance/cis_eks/rules/cis_3_1_2/data.yaml
+++ b/compliance/cis_eks/rules/cis_3_1_2/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 444acc9b-041e-5b16-9340-4fe44cf25b6a
+  id: 22c14de0-5c3b-5b14-b1ba-9cc831b48147
   name: Ensure that the kubelet kubeconfig file ownership is set to root:root (Manual)
   profile_applicability: |
     * Level 1

--- a/compliance/cis_eks/rules/cis_3_1_2/data.yaml
+++ b/compliance/cis_eks/rules/cis_3_1_2/data.yaml
@@ -9,32 +9,26 @@ metadata:
   rationale: |
     The kubeconfig file for `kubelet` controls various parameters for the `kubelet`
     service in the
-
     worker node. You should set its file ownership to maintain the integrity of the file. 
     The file should be owned by `root:root`.
   audit: |
     SSH to the worker nodes
-
     To check to see if the Kubelet Service is running:
     ```
     sudo systemctl status kubelet
     ```
     The output should return `Active: active (running) since..`
-
     Run the following command on each node to find the appropriate kubeconfig file:
     ```
     ps -ef | grep kubelet
     ```
     The output of the above command should return something similar to `--kubeconfig`
-
     `/var/lib/kubelet/kubeconfig` which is the location of the kubeconfig file.
-
     Run this command to obtain the kubeconfig file ownership:
     ```
     stat -c %U:%G /var/lib/kubelet/kubeconfig
     ```
     The output of the above command gives you the kubeconfig file's ownership. Verify that the
-
     ownership is set to `root:root`.
   remediation: |
     Run the below command (based on the file location on your system) on the

--- a/compliance/cis_eks/rules/cis_3_1_2/data.yaml
+++ b/compliance/cis_eks/rules/cis_3_1_2/data.yaml
@@ -2,7 +2,7 @@ metadata:
   id: 444acc9b-041e-5b16-9340-4fe44cf25b6a
   name: Ensure that the kubelet kubeconfig file ownership is set to root:root (Manual)
   profile_applicability: |
-    • Level 1
+    * Level 1
   description: |
     If `kubelet` is running, ensure that the file ownership of its kubeconfig file
     is set to `root:root`.

--- a/compliance/cis_eks/rules/cis_3_1_2/rule.rego
+++ b/compliance/cis_eks/rules/cis_3_1_2/rule.rego
@@ -1,6 +1,5 @@
 package compliance.cis_eks.rules.cis_3_1_2
 
-import data.compliance.cis_eks
 import data.compliance.lib.common
 import data.compliance.lib.data_adapter
 

--- a/compliance/cis_eks/rules/cis_3_1_2/rule.rego
+++ b/compliance/cis_eks/rules/cis_3_1_2/rule.rego
@@ -20,16 +20,3 @@ finding = result {
 		"evidence": {"uid": uid, "gid": gid},
 	}
 }
-
-metadata = {
-	"name": "Ensure that the kubelet kubeconfig file ownership is set to root:root",
-	"description": "If kubelet is running, ensure that the file ownership of its kubeconfig file is set to root:root.",
-	"rationale": `The kubeconfig file for kubelet controls various parameters for the kubelet service in the worker node.
-You should set its file ownership to maintain the integrity of the file.
-The fileshould be owned by root:root.`,
-	"impact": "None",
-	"tags": array.concat(cis_eks.default_tags, ["CIS 3.1.2", "Worker Node Configuration"]),
-	"benchmark": cis_eks.benchmark_metadata,
-	"remediation": "chown root:root /var/lib/kubelet/kubeconfig",
-	"default_value": "See the AWS EKS documentation for the default value.",
-}

--- a/compliance/cis_eks/rules/cis_3_1_3/data.yaml
+++ b/compliance/cis_eks/rules/cis_3_1_3/data.yaml
@@ -1,6 +1,6 @@
 ---
 metadata:
-  id: e4d3eae4-4868-58db-b316-0a07d17a321d
+  id: cd1f19c9-381b-5009-bc19-be33b52322d8
   name: Ensure that the kubelet configuration file has permissions set to 644 or more restrictive (Manual)
   profile_applicability: |
     * Level 1

--- a/compliance/cis_eks/rules/cis_3_1_3/data.yaml
+++ b/compliance/cis_eks/rules/cis_3_1_3/data.yaml
@@ -1,0 +1,26 @@
+{
+  "metadata": {
+    "id": "e4d3eae4-4868-58db-b316-0a07d17a321d",
+    "name": "Ensure that the kubelet configuration file has permissions set to 644 or more restrictive (Manual)",
+    "profile_applicability": "• Level 1\n",
+    "description": "Ensure that if the kubelet refers to a configuration file with the `--config`\nargument, that file has permissions of 644 or more restrictive.\n",
+    "rationale": "The kubelet reads various parameters, including security settings, from a config file\n\nspecified by the `--config` argument. If this file is specified you should restrict its file\n\npermissions to maintain the integrity of the file. The file should be writable by only the\n\nadministrators on the system.\n",
+    "audit": "First, SSH to the relevant worker node:\n\nTo check to see if the Kubelet Service is running:\n```\nsudo systemctl status kubelet\n```\nThe output should return `Active: active (running) since..`\n\nRun the following command on each node to find the appropriate Kubelet config file:\n```\nps -ef | grep kubelet\n```\nThe output of the above command should return something similar to `--config`\n\n`/etc/kubernetes/kubelet/kubelet-config.json` which is the location of the Kubelet\n\nconfig file.\n\nRun the following command:\n```\nstat -c %a /etc/kubernetes/kubelet/kubelet-config.json\n```\nThe output of the above command is the Kubelet config file's permissions. Verify that the\n\npermissions are `644` or more restrictive.\n",
+    "remediation": "Run the following command (using the config file location identied in the\nAudit step)\n```\nchmod 644 /etc/kubernetes/kubelet/kubelet-config.json\n```\n",
+    "impact": "None.\n",
+    "default_value": "See the AWS EKS documentation for the default value.\n",
+    "references": "1. https://kubernetes.io/docs/tasks/administer-cluster/kubelet-config-file/\n",
+    "section": "Worker Node Configuration Files",
+    "version": "1.0",
+    "tags": [
+      "CIS",
+      "EKS",
+      "CIS 3.1.3",
+      "Worker Node Configuration Files"
+    ],
+    "benchmark": {
+      "name": "CIS Amazon Elastic Kubernetes Service (EKS) Benchmark",
+      "version": "v1.0.1"
+    }
+  }
+}

--- a/compliance/cis_eks/rules/cis_3_1_3/data.yaml
+++ b/compliance/cis_eks/rules/cis_3_1_3/data.yaml
@@ -1,26 +1,65 @@
-{
-  "metadata": {
-    "id": "e4d3eae4-4868-58db-b316-0a07d17a321d",
-    "name": "Ensure that the kubelet configuration file has permissions set to 644 or more restrictive (Manual)",
-    "profile_applicability": "• Level 1\n",
-    "description": "Ensure that if the kubelet refers to a configuration file with the `--config`\nargument, that file has permissions of 644 or more restrictive.\n",
-    "rationale": "The kubelet reads various parameters, including security settings, from a config file\n\nspecified by the `--config` argument. If this file is specified you should restrict its file\n\npermissions to maintain the integrity of the file. The file should be writable by only the\n\nadministrators on the system.\n",
-    "audit": "First, SSH to the relevant worker node:\n\nTo check to see if the Kubelet Service is running:\n```\nsudo systemctl status kubelet\n```\nThe output should return `Active: active (running) since..`\n\nRun the following command on each node to find the appropriate Kubelet config file:\n```\nps -ef | grep kubelet\n```\nThe output of the above command should return something similar to `--config`\n\n`/etc/kubernetes/kubelet/kubelet-config.json` which is the location of the Kubelet\n\nconfig file.\n\nRun the following command:\n```\nstat -c %a /etc/kubernetes/kubelet/kubelet-config.json\n```\nThe output of the above command is the Kubelet config file's permissions. Verify that the\n\npermissions are `644` or more restrictive.\n",
-    "remediation": "Run the following command (using the config file location identied in the\nAudit step)\n```\nchmod 644 /etc/kubernetes/kubelet/kubelet-config.json\n```\n",
-    "impact": "None.\n",
-    "default_value": "See the AWS EKS documentation for the default value.\n",
-    "references": "1. https://kubernetes.io/docs/tasks/administer-cluster/kubelet-config-file/\n",
-    "section": "Worker Node Configuration Files",
-    "version": "1.0",
-    "tags": [
-      "CIS",
-      "EKS",
-      "CIS 3.1.3",
-      "Worker Node Configuration Files"
-    ],
-    "benchmark": {
-      "name": "CIS Amazon Elastic Kubernetes Service (EKS) Benchmark",
-      "version": "v1.0.1"
-    }
-  }
-}
+---
+metadata:
+  id: e4d3eae4-4868-58db-b316-0a07d17a321d
+  name: Ensure that the kubelet configuration file has permissions set to 644 or more restrictive (Manual)
+  profile_applicability: |
+    • Level 1
+  description: |
+    Ensure that if the kubelet refers to a configuration file with the `--config`
+    argument, that file has permissions of 644 or more restrictive.
+  rationale: |
+    The kubelet reads various parameters, including security settings, from a config file
+
+    specified by the `--config` argument. If this file is specified you should restrict its file
+
+    permissions to maintain the integrity of the file. The file should be writable by only the
+
+    administrators on the system.
+  audit: |
+    First, SSH to the relevant worker node:
+
+    To check to see if the Kubelet Service is running:
+    ```
+    sudo systemctl status kubelet
+    ```
+    The output should return `Active: active (running) since..`
+
+    Run the following command on each node to find the appropriate Kubelet config file:
+    ```
+    ps -ef | grep kubelet
+    ```
+    The output of the above command should return something similar to `--config`
+
+    `/etc/kubernetes/kubelet/kubelet-config.json` which is the location of the Kubelet
+
+    config file.
+
+    Run the following command:
+    ```
+    stat -c %a /etc/kubernetes/kubelet/kubelet-config.json
+    ```
+    The output of the above command is the Kubelet config file's permissions. Verify that the
+
+    permissions are `644` or more restrictive.
+  remediation: |
+    Run the following command (using the config file location identied in the
+    Audit step)
+    ```
+    chmod 644 /etc/kubernetes/kubelet/kubelet-config.json
+    ```
+  impact: |
+    None
+  default_value: |
+    See the AWS EKS documentation for the default value.
+  references: |
+    1. https://kubernetes.io/docs/tasks/administer-cluster/kubelet-config-file/
+  section: Worker Node Configuration Files
+  version: '1.0'
+  tags:
+  - CIS
+  - EKS
+  - CIS 3.1.3
+  - Worker Node Configuration Files
+  benchmark:
+    name: CIS Amazon Elastic Kubernetes Service (EKS) Benchmark
+    version: v1.0.1

--- a/compliance/cis_eks/rules/cis_3_1_3/data.yaml
+++ b/compliance/cis_eks/rules/cis_3_1_3/data.yaml
@@ -3,7 +3,7 @@ metadata:
   id: e4d3eae4-4868-58db-b316-0a07d17a321d
   name: Ensure that the kubelet configuration file has permissions set to 644 or more restrictive (Manual)
   profile_applicability: |
-    • Level 1
+    * Level 1
   description: |
     Ensure that if the kubelet refers to a configuration file with the `--config`
     argument, that file has permissions of 644 or more restrictive.

--- a/compliance/cis_eks/rules/cis_3_1_3/data.yaml
+++ b/compliance/cis_eks/rules/cis_3_1_3/data.yaml
@@ -1,4 +1,3 @@
----
 metadata:
   id: cd1f19c9-381b-5009-bc19-be33b52322d8
   name: Ensure that the kubelet configuration file has permissions set to 644 or more restrictive (Manual)
@@ -9,37 +8,28 @@ metadata:
     argument, that file has permissions of 644 or more restrictive.
   rationale: |
     The kubelet reads various parameters, including security settings, from a config file
-
     specified by the `--config` argument. If this file is specified you should restrict its file
-
     permissions to maintain the integrity of the file. The file should be writable by only the
-
     administrators on the system.
   audit: |
     First, SSH to the relevant worker node:
-
     To check to see if the Kubelet Service is running:
     ```
     sudo systemctl status kubelet
     ```
     The output should return `Active: active (running) since..`
-
     Run the following command on each node to find the appropriate Kubelet config file:
     ```
     ps -ef | grep kubelet
     ```
     The output of the above command should return something similar to `--config`
-
     `/etc/kubernetes/kubelet/kubelet-config.json` which is the location of the Kubelet
-
     config file.
-
     Run the following command:
     ```
     stat -c %a /etc/kubernetes/kubelet/kubelet-config.json
     ```
     The output of the above command is the Kubelet config file's permissions. Verify that the
-
     permissions are `644` or more restrictive.
   remediation: |
     Run the following command (using the config file location identied in the

--- a/compliance/cis_eks/rules/cis_3_1_3/rule.rego
+++ b/compliance/cis_eks/rules/cis_3_1_3/rule.rego
@@ -1,6 +1,5 @@
 package compliance.cis_eks.rules.cis_3_1_3
 
-import data.compliance.cis_eks
 import data.compliance.lib.common
 import data.compliance.lib.data_adapter
 
@@ -18,17 +17,4 @@ finding = result {
 		"evaluation": common.calculate_result(rule_evaluation),
 		"evidence": {"filemode": filemode},
 	}
-}
-
-metadata = {
-	"name": "Ensure that the kubelet configuration file has permissions set to 644 or more restrictive",
-	"description": "Ensure that if the kubelet refers to a configuration file with the --config argument, that file has permissions of 644 or more restrictive.",
-	"rationale": `The kubelet reads various parameters, including security settings, from a config file specifiedopa  by the --config argument.
-If this file is specified you should restrict its file permissions to maintain the integrity of the file.
-The file should be writable by only the administrators on the system.`,
-	"impact": "None",
-	"tags": array.concat(cis_eks.default_tags, ["CIS 3.1.3", "Worker Node Configuration"]),
-	"benchmark": cis_eks.benchmark_metadata,
-	"remediation": "chmod 644 /etc/kubernetes/kubelet/kubelet-config.json",
-	"default_value": "See the AWS EKS documentation for the default value.",
 }

--- a/compliance/cis_eks/rules/cis_3_1_4/data.yaml
+++ b/compliance/cis_eks/rules/cis_3_1_4/data.yaml
@@ -1,0 +1,66 @@
+metadata:
+  id: b9f3c6be-9e0d-55e5-8b6e-1971b3784e5b
+  name: Ensure that the kubelet configuration file ownership is set to root:root
+    (Manual)
+  profile_applicability: |
+    • Level 1
+  description: |
+    Ensure that if the kubelet refers to a configuration file with the `--config`
+    argument, that file is owned by `root:root`.
+  rationale: >
+    The kubelet reads various parameters, including security settings, from a
+    config file
+
+    specified by the `--config` argument. If this file is specified you should restrict its file
+
+    permissions to maintain the integrity of the file. The file should be writable by only the
+
+    administrators on the system.
+  audit: |
+    First, SSH to the relevant worker node:
+
+    To check to see if the Kubelet Service is running:
+    ```
+    sudo systemctl status kubelet
+    ```
+    The output should return `Active: active (running) since..`
+
+    Run the following command on each node to find the appropriate Kubelet config file:
+    ```
+    ps -ef | grep kubelet
+    ```
+    The output of the above command should return something similar to `--config`
+
+    `/etc/kubernetes/kubelet/kubelet-config.json` which is the location of the Kubelet
+
+    config file.
+
+    Run the following command:
+    ```
+    stat -c %U:%G /etc/kubernetes/kubelet/kubelet-config.json
+    ```
+    The output of the above command is the Kubelet config file's ownership. Verify that the
+
+    ownership is set to `root:root`
+  remediation: |
+    Run the following command (using the config file location identified in the
+    Audit step)
+    ```
+    chown root:root /etc/kubernetes/kubelet/kubelet-config.json
+    ```
+  impact: |
+    None
+  default_value: |
+    See the AWS EKS documentation for the default value.
+  references: |
+    1. https://kubernetes.io/docs/admin/kube-proxy/
+  section: Worker Node Configuration Files
+  version: "1.0"
+  tags:
+  - CIS
+  - EKS
+  - CIS 3.1.4
+  - Worker Node Configuration Files
+  benchmark:
+    name: CIS Amazon Elastic Kubernetes Service (EKS) Benchmark
+    version: v1.0.1

--- a/compliance/cis_eks/rules/cis_3_1_4/data.yaml
+++ b/compliance/cis_eks/rules/cis_3_1_4/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: b9f3c6be-9e0d-55e5-8b6e-1971b3784e5b
+  id: 09e032a7-9ac1-5964-a1da-cdb45e3f8a61
   name: Ensure that the kubelet configuration file ownership is set to root:root (Manual)
   profile_applicability: |
     * Level 1

--- a/compliance/cis_eks/rules/cis_3_1_4/data.yaml
+++ b/compliance/cis_eks/rules/cis_3_1_4/data.yaml
@@ -1,7 +1,6 @@
 metadata:
   id: b9f3c6be-9e0d-55e5-8b6e-1971b3784e5b
-  name: Ensure that the kubelet configuration file ownership is set to root:root
-    (Manual)
+  name: Ensure that the kubelet configuration file ownership is set to root:root (Manual)
   profile_applicability: |
     • Level 1
   description: |

--- a/compliance/cis_eks/rules/cis_3_1_4/data.yaml
+++ b/compliance/cis_eks/rules/cis_3_1_4/data.yaml
@@ -9,37 +9,28 @@ metadata:
   rationale: >
     The kubelet reads various parameters, including security settings, from a
     config file
-
     specified by the `--config` argument. If this file is specified you should restrict its file
-
     permissions to maintain the integrity of the file. The file should be writable by only the
-
     administrators on the system.
   audit: |
     First, SSH to the relevant worker node:
-
     To check to see if the Kubelet Service is running:
     ```
     sudo systemctl status kubelet
     ```
     The output should return `Active: active (running) since..`
-
     Run the following command on each node to find the appropriate Kubelet config file:
     ```
     ps -ef | grep kubelet
     ```
     The output of the above command should return something similar to `--config`
-
     `/etc/kubernetes/kubelet/kubelet-config.json` which is the location of the Kubelet
-
     config file.
-
     Run the following command:
     ```
     stat -c %U:%G /etc/kubernetes/kubelet/kubelet-config.json
     ```
     The output of the above command is the Kubelet config file's ownership. Verify that the
-
     ownership is set to `root:root`
   remediation: |
     Run the following command (using the config file location identified in the

--- a/compliance/cis_eks/rules/cis_3_1_4/data.yaml
+++ b/compliance/cis_eks/rules/cis_3_1_4/data.yaml
@@ -2,7 +2,7 @@ metadata:
   id: b9f3c6be-9e0d-55e5-8b6e-1971b3784e5b
   name: Ensure that the kubelet configuration file ownership is set to root:root (Manual)
   profile_applicability: |
-    • Level 1
+    * Level 1
   description: |
     Ensure that if the kubelet refers to a configuration file with the `--config`
     argument, that file is owned by `root:root`.

--- a/compliance/cis_eks/rules/cis_3_1_4/rule.rego
+++ b/compliance/cis_eks/rules/cis_3_1_4/rule.rego
@@ -20,16 +20,3 @@ finding = result {
 		"evidence": {"uid": uid, "gid": gid},
 	}
 }
-
-metadata = {
-	"name": "Ensure that the kubelet configuration file ownership is set to root:root",
-	"description": "Ensure that if the kubelet refers to a configuration file with the --config argument, that file is owned by root:root.",
-	"impact": "None",
-	"rationale": `The kubelet reads various parameters, including security settings, from a config file specified by the --config argument.
-If this file is specified you should restrict its file permissions to maintain the integrity of the file.
-The file should be writable by only the administrators on the system.`,
-	"tags": array.concat(cis_eks.default_tags, ["CIS 3.1.4", "Worker Node Configuration"]),
-	"benchmark": cis_eks.benchmark_metadata,
-	"remediation": "chown root:root /etc/kubernetes/kubelet/kubelet-config.json",
-	"default_value": "See the AWS EKS documentation for the default value.",
-}

--- a/compliance/cis_eks/rules/cis_3_1_4/rule.rego
+++ b/compliance/cis_eks/rules/cis_3_1_4/rule.rego
@@ -1,6 +1,5 @@
 package compliance.cis_eks.rules.cis_3_1_4
 
-import data.compliance.cis_eks
 import data.compliance.lib.common
 import data.compliance.lib.data_adapter
 

--- a/compliance/cis_eks/rules/cis_3_2_1/data.yaml
+++ b/compliance/cis_eks/rules/cis_3_2_1/data.yaml
@@ -1,0 +1,105 @@
+metadata:
+  id: d78c9ced-7c8e-5ba4-96fc-679f1bd345c5
+  name: Ensure that the --anonymous-auth argument is set to false(Automated)
+  profile_applicability: |
+    • Level 1
+  description: |
+    Disable anonymous requests to the Kubelet server.
+  rationale: |
+    When enabled, requests that are not rejected by other configured
+    authentication methods
+
+    are treated as anonymous requests. These requests are then served by the Kubelet server.
+
+    You should rely on authentication to authorize access and disallow anonymous requests.
+  audit: |
+    **Audit Method 1:**
+    If using a Kubelet configuration file, check that there is an entry for 
+    `authentication: anonymous: enabled` set to `false`.
+    First, SSH to the relevant node:
+    Run the following command on each node to find the appropriate Kubelet config file:
+    ```
+    ps -ef | grep kubelet
+    ```
+    The output of the above command should return something similar to 
+    `--config /etc/kubernetes/kubelet/kubelet-config.json` which is the location of the Kubelet
+    config file.
+    Open the Kubelet config file:
+    ```
+    sudo more /etc/kubernetes/kubelet/kubelet-config.json
+    ```
+    Verify that the `"authentication": { "anonymous": { "enabled": false }` argument is
+    set to `false`.
+    **Audit Method 2:**
+    If using the api configz endpoint consider searching for the status of `authentication...`
+    `"anonymous":{"enabled":false}` by extracting the live configuration from the nodes
+    running kubelet.
+    Set the local proxy port and the following variables and provide proxy port number and
+    node name;
+    `HOSTNAME_PORT="localhost-and-port-number"`
+    `NODE_NAME="The-Name-Of-Node-To-Extract-Configuration" from the output of`
+    `"kubectl get nodes"`
+    ```
+    kubectl proxy --port=8001 &
+    export HOSTNAME_PORT=localhost:8001 (example host and port number)
+    export NODE_NAME=ip-192.168.31.226.ec2.internal (example node name from
+    "kubectl get nodes")
+    curl -sSL "http://${HOSTNAME_PORT}/api/v1/nodes/${NODE_NAME}/proxy/configz"
+    ```
+  remediation: |
+    **Remediation Method 1:**
+    If modifying the Kubelet config file, edit the kubelet-config.json file
+    `/etc/kubernetes/kubelet/kubelet-config.json` and set the below parameter to `false`
+    ```
+    "authentication": { "anonymous": { "enabled": false
+    ```
+    **Remediation Method 2:**
+    If using executable arguments, edit the kubelet service file
+    `/etc/systemd/system/kubelet.service.d/10-kubelet-args.conf` on each worker node
+    and add the below parameter at the end of the `KUBELET_ARGS` variable string.
+    ```
+    --anonymous-auth=false
+    ```
+    **Remediation Method 3:**
+    If using the api configz endpoint consider searching for the status of
+    `"authentication.*anonymous":{"enabled":false}"` by extracting the live configuration
+    from the nodes running kubelet.
+    **See detailed step-by-step configmap procedures in Reconfigure a Node's Kubelet in a Live
+    Cluster, and then rerun the curl statement from audit process to check for kubelet
+    configuration changes
+    ```
+    kubectl proxy --port=8001 &
+    export HOSTNAME_PORT=localhost:8001 (example host and port number)
+    export NODE_NAME=ip-192.168.31.226.ec2.internal (example node name from
+    "kubectl get nodes")
+    curl -sSL "http://${HOSTNAME_PORT}/api/v1/nodes/${NODE_NAME}/proxy/configz"
+    ```
+    **For all three remediations:**
+    Based on your system, restart the kubelet service and check status
+    ```
+    systemctl daemon-reload
+    systemctl restart kubelet.service
+    systemctl status kubelet -l  
+    ```
+  impact: |
+    Anonymous requests will be rejected.
+  default_value: |
+    See the EKS documentation for the default value.
+  references: |
+    1. https://kubernetes.io/docs/admin/kubelet/
+
+    2. https://kubernetes.io/docs/admin/kubelet-authentication-authorization/#kubelet-
+
+    authentication
+
+    3. https://kubernetes.io/docs/tasks/administer-cluster/reconfigure-kubelet/
+  section: Kubelet
+  version: "1.0"
+  tags:
+  - CIS
+  - EKS
+  - CIS 3.2.1
+  - Kubelet
+  benchmark:
+    name: CIS Amazon Elastic Kubernetes Service (EKS) Benchmark
+    version: v1.0.1

--- a/compliance/cis_eks/rules/cis_3_2_1/data.yaml
+++ b/compliance/cis_eks/rules/cis_3_2_1/data.yaml
@@ -8,9 +8,7 @@ metadata:
   rationale: |
     When enabled, requests that are not rejected by other configured
     authentication methods
-
     are treated as anonymous requests. These requests are then served by the Kubelet server.
-
     You should rely on authentication to authorize access and disallow anonymous requests.
   audit: |
     **Audit Method 1:**
@@ -87,11 +85,7 @@ metadata:
     See the EKS documentation for the default value.
   references: |
     1. https://kubernetes.io/docs/admin/kubelet/
-
-    2. https://kubernetes.io/docs/admin/kubelet-authentication-authorization/#kubelet-
-
-    authentication
-
+    2. https://kubernetes.io/docs/admin/kubelet-authentication-authorization/#kubelet-authentication
     3. https://kubernetes.io/docs/tasks/administer-cluster/reconfigure-kubelet/
   section: Kubelet
   version: "1.0"

--- a/compliance/cis_eks/rules/cis_3_2_1/data.yaml
+++ b/compliance/cis_eks/rules/cis_3_2_1/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: d78c9ced-7c8e-5ba4-96fc-679f1bd345c5
+  id: d98fd08b-bafa-5314-8aa7-c5cf5e319739
   name: Ensure that the --anonymous-auth argument is set to false (Automated)
   profile_applicability: |
     * Level 1

--- a/compliance/cis_eks/rules/cis_3_2_1/data.yaml
+++ b/compliance/cis_eks/rules/cis_3_2_1/data.yaml
@@ -1,6 +1,6 @@
 metadata:
   id: d78c9ced-7c8e-5ba4-96fc-679f1bd345c5
-  name: Ensure that the --anonymous-auth argument is set to false(Automated)
+  name: Ensure that the --anonymous-auth argument is set to false (Automated)
   profile_applicability: |
     • Level 1
   description: |

--- a/compliance/cis_eks/rules/cis_3_2_1/data.yaml
+++ b/compliance/cis_eks/rules/cis_3_2_1/data.yaml
@@ -2,7 +2,7 @@ metadata:
   id: d78c9ced-7c8e-5ba4-96fc-679f1bd345c5
   name: Ensure that the --anonymous-auth argument is set to false (Automated)
   profile_applicability: |
-    • Level 1
+    * Level 1
   description: |
     Disable anonymous requests to the Kubelet server.
   rationale: |

--- a/compliance/cis_eks/rules/cis_3_2_1/rule.rego
+++ b/compliance/cis_eks/rules/cis_3_2_1/rule.rego
@@ -34,17 +34,3 @@ finding = result {
 		},
 	}
 }
-
-metadata = {
-	"name": "Ensure that the --anonymous-auth argument is set to false",
-	"description": "Disable anonymous requests to the Kubelet server.",
-	"impact": "Anonymous requests will be rejected.",
-	"tags": array.concat(cis_eks.default_tags, ["CIS 3.2.1", "Kubelet"]),
-	"benchmark": cis_eks.benchmark_metadata,
-	"default_value": "By default, anonymous access is enabled.",
-	"remediation": `If modifying the Kubelet config file, edit the kubelet-config.json file /etc/kubernetes/kubelet/kubelet-config.json and set the below parameter to false.
-"authentication": { "anonymous": { "enabled": false}}.
-If using executable arguments, edit the kubelet service file /etc/systemd/system/kubelet.service.d/10-kubelet-args.conf on each worker node and add the below parameter at the end of the KUBELET_ARGS variable string.
---anonymous-auth=false.
-If using the api configz endpoint consider searching for the status of "authentication.*anonymous":{"enabled":false}" by extracting the live configuration from the nodes running kubelet.`,
-}

--- a/compliance/cis_eks/rules/cis_3_2_2/data.yaml
+++ b/compliance/cis_eks/rules/cis_3_2_2/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 52d6142a-3cf1-5cd7-b939-170f281b4b8b
+  id: 737e58cc-60c3-5785-b2e6-7d1bb2ca1cca
   name: Ensure that the --authorization-mode argument is not set to Always Allow (Automated)
   profile_applicability: |
     * Level 1

--- a/compliance/cis_eks/rules/cis_3_2_2/data.yaml
+++ b/compliance/cis_eks/rules/cis_3_2_2/data.yaml
@@ -1,0 +1,104 @@
+metadata:
+  id: 52d6142a-3cf1-5cd7-b939-170f281b4b8b
+  name: Ensure that the --authorization-mode argument is not set to Always Allow(Automated)
+  profile_applicability: |
+    • Level 1
+  description: |
+    Do not allow all requests. Enable explicit authorization.
+  rationale: |
+    Kubelets, by default, allow all authenticated requests (even anonymous ones)
+    without
+
+    needing explicit authorization checks from the apiserver. You should restrict this behavior
+
+    and only allow explicitly authorized requests.
+  audit: |
+    **Audit Method 1:**
+    If using a Kubelet configuration file, check that there is an entry for `"authentication":`
+    `"webhook": "enabled"` set to `true`.
+    First, SSH to the relevant node:
+    Run the following command on each node to find the appropriate Kubelet config file:
+    ```
+    ps -ef | grep kubelet
+    ```
+    The output of the above command should return something similar to `--config`
+    `/etc/kubernetes/kubelet/kubelet-config.json` which is the location of the Kubelet
+    config file.
+    Open the Kubelet config file:
+    ```
+    sudo more /etc/kubernetes/kubelet/kubelet-config.json
+    ```
+    Verify that the `"authentication": {"webhook": { "enabled": is set to true.`
+    If the `"authentication": {"mode": { argument` is present check that it is not set to
+    `AlwaysAllow`. If it is not present check that there is a Kubelet config file specified by --
+    config, and that file sets `"authentication": {"mode": { ` to something other than
+    `AlwaysAllow`.
+    **Audit Method 2:**
+    If using the api configz endpoint consider searching for the status of `authentication...`
+    `"webhook":{"enabled":true}` by extracting the live configuration from the nodes running
+    kubelet.
+    Set the local proxy port and the following variables and provide proxy port number and
+    node name;
+    `HOSTNAME_PORT="localhost-and-port-number"`
+    `NODE_NAME="The-Name-Of-Node-To-Extract-Configuration" from the output of`
+    `"kubectl get nodes"`
+    ```
+    kubectl proxy --port=8001 &
+    export HOSTNAME_PORT=localhost:8001 (example host and port number)
+    export NODE_NAME=ip-192.168.31.226.ec2.internal (example node name from
+    "kubectl get nodes")
+    curl -sSL "http://${HOSTNAME_PORT}/api/v1/nodes/${NODE_NAME}/proxy/configz"
+    ```
+  remediation: |
+    **Remediation Method 1:**
+    If modifying the Kubelet config file, edit the kubelet-config.json file
+    `/etc/kubernetes/kubelet/kubelet-config.json` and set the below parameter to false
+    ```
+    "authentication"... "webhook":{"enabled":true
+    ```
+    **Remediation Method 2:**
+    If using executable arguments, edit the kubelet service file
+    `/etc/systemd/system/kubelet.service.d/10-kubelet-args.conf` on each worker node
+    and add the below parameter at the end of the `KUBELET_ARGS` variable string.
+    ```
+    --authorization-mode=Webhook
+    ```
+    **Remediation Method 3:**
+    If using the api configz endpoint consider searching for the status of
+    `"authentication.*webhook":{"enabled":true"` by extracting the live configuration from
+    the nodes running kubelet.
+    **See detailed step-by-step configmap procedures in Reconfigure a Node's Kubelet in a Live
+    Cluster, and then rerun the curl statement from audit process to check for kubelet
+    configuration changes
+    ```
+    kubectl proxy --port=8001 &
+    export HOSTNAME_PORT=localhost:8001 (example host and port number)
+    export NODE_NAME=ip-192.168.31.226.ec2.internal (example node name from
+    "kubectl get nodes")
+    curl -sSL "http://${HOSTNAME_PORT}/api/v1/nodes/${NODE_NAME}/proxy/configz"
+    ```
+    **For all three remediations:**
+    Based on your system, restart the kubelet service and check status
+    ```
+    systemctl daemon-reload
+    systemctl restart kubelet.service
+    systemctl status kubelet -l
+    ```
+  impact: |
+    Unauthorized requests will be denied.
+  default_value: |
+    See the EKS documentation for the default value.
+  references: |
+    1. https://kubernetes.io/docs/admin/kubelet/
+    2. https://kubernetes.io/docs/admin/kubelet-authentication-authorization/#kubelet-authentication
+    3. https://kubernetes.io/docs/tasks/administer-cluster/reconfigure-kubelet/
+  section: Kubelet
+  version: "1.0"
+  tags:
+  - CIS
+  - EKS
+  - CIS 3.2.2
+  - Kubelet
+  benchmark:
+    name: CIS Amazon Elastic Kubernetes Service (EKS) Benchmark
+    version: v1.0.1

--- a/compliance/cis_eks/rules/cis_3_2_2/data.yaml
+++ b/compliance/cis_eks/rules/cis_3_2_2/data.yaml
@@ -2,7 +2,7 @@ metadata:
   id: 52d6142a-3cf1-5cd7-b939-170f281b4b8b
   name: Ensure that the --authorization-mode argument is not set to Always Allow (Automated)
   profile_applicability: |
-    • Level 1
+    * Level 1
   description: |
     Do not allow all requests. Enable explicit authorization.
   rationale: |

--- a/compliance/cis_eks/rules/cis_3_2_2/data.yaml
+++ b/compliance/cis_eks/rules/cis_3_2_2/data.yaml
@@ -28,8 +28,8 @@ metadata:
     ```
     Verify that the `"authentication": {"webhook": { "enabled": is set to true.`
     If the `"authentication": {"mode": { argument` is present check that it is not set to
-    `AlwaysAllow`. If it is not present check that there is a Kubelet config file specified by --
-    config, and that file sets `"authentication": {"mode": { ` to something other than
+    `AlwaysAllow`. If it is not present check that there is a Kubelet config file specified by 
+    `--config`, and that file sets `"authentication": {"mode": { ` to something other than
     `AlwaysAllow`.
     **Audit Method 2:**
     If using the api configz endpoint consider searching for the status of `authentication...`

--- a/compliance/cis_eks/rules/cis_3_2_2/data.yaml
+++ b/compliance/cis_eks/rules/cis_3_2_2/data.yaml
@@ -8,9 +8,7 @@ metadata:
   rationale: |
     Kubelets, by default, allow all authenticated requests (even anonymous ones)
     without
-
     needing explicit authorization checks from the apiserver. You should restrict this behavior
-
     and only allow explicitly authorized requests.
   audit: |
     **Audit Method 1:**

--- a/compliance/cis_eks/rules/cis_3_2_2/data.yaml
+++ b/compliance/cis_eks/rules/cis_3_2_2/data.yaml
@@ -1,6 +1,6 @@
 metadata:
   id: 52d6142a-3cf1-5cd7-b939-170f281b4b8b
-  name: Ensure that the --authorization-mode argument is not set to Always Allow(Automated)
+  name: Ensure that the --authorization-mode argument is not set to Always Allow (Automated)
   profile_applicability: |
     • Level 1
   description: |

--- a/compliance/cis_eks/rules/cis_3_2_2/rule.rego
+++ b/compliance/cis_eks/rules/cis_3_2_2/rule.rego
@@ -41,19 +41,3 @@ finding = result {
 		},
 	}
 }
-
-metadata = {
-	"name": "Ensure that the --authorization-mode argument is not set to AlwaysAllow",
-	"description": "Do not allow all requests. Enable explicit authorization.",
-	"impact": "Unauthorized requests will be denied.",
-	"tags": array.concat(cis_eks.default_tags, ["CIS 3.2.2", "Kubelet"]),
-	"benchmark": cis_eks.benchmark_metadata,
-	"remediation": `If modifying the Kubelet config file, edit the kubelet-config.json file /etc/kubernetes/kubelet/kubelet-config.json and set the below parameter to false.
-"authentication"... "webhook":{"enabled":true...
-If using executable arguments, edit the kubelet service file /etc/systemd/system/kubelet.service.d/10-kubelet-args.conf on each worker node and add the below parameter at the end of the KUBELET_ARGS variable string.
---authorization-mode=Webhook.
-If using the api configz endpoint consider searching for the status of "authentication.*webhook":{"enabled":true" by extracting the live configuration from the nodes running kubelet.`,
-	"rationale": `Kubelets, by default, allow all authenticated requests (even anonymous ones) without needing explicit authorization checks from the apiserver.
-You should restrict this behavior and only allow explicitly authorized requests.`,
-	"default_value": "See the EKS documentation for the default value.",
-}

--- a/compliance/cis_eks/rules/cis_3_2_3/data.yaml
+++ b/compliance/cis_eks/rules/cis_3_2_3/data.yaml
@@ -1,0 +1,114 @@
+metadata:
+  id: 067c33b0-f259-5c8c-940c-549ecd1f2466
+  name: Ensure that the --client-ca-file argument is set as appropriate (Manual)
+  profile_applicability: |
+    • Level 1
+  description: |
+    Enable Kubelet authentication using certificates.
+  rationale: >
+    The connections from the apiserver to the kubelet are used for fetching logs
+    for pods,
+
+    attaching (through kubectl) to running pods, and using the kubelet’s port-forwarding
+
+    functionality. These connections terminate at the kubelet’s HTTPS endpoint. By default, the
+
+    apiserver does not verify the kubelet’s serving certificate, which makes the connection
+
+    subject to man-in-the-middle attacks, and unsafe to run over untrusted and/or public
+
+    networks. Enabling Kubelet certificate authentication ensures that the apiserver could
+
+    authenticate the Kubelet before submitting any requests.
+  audit: |
+    **Audit Method 1:**
+    If using a Kubelet configuration file, check that there is an entry for `"x509":`
+    `{"clientCAFile:"` set to the location of the client certificate authority file.
+    First, SSH to the relevant node:
+    Run the following command on each node to find the appropriate Kubelet config file:
+    ```
+    ps -ef | grep kubelet
+    ```
+    The output of the above command should return something similar to `--config`
+    `/etc/kubernetes/kubelet/kubelet-config.json` which is the location of the Kubelet
+    config file.
+    Open the Kubelet config file:
+    ```
+    sudo more /etc/kubernetes/kubelet/kubelet-config.json
+    ```
+    Verify that the `"x509": {"clientCAFile:"` argument exists and is set to the location of the
+    client certificate authority file.
+    If the `"x509": {"clientCAFile:"` argument is not present, check that there is a Kubelet
+    config file specified by --config, and that the file sets `"authentication": { "x509":`
+    `{"clientCAFile:"` to the location of the client certificate authority file.
+
+    **Audit Method 2:**
+    If using the api configz endpoint consider searching for the status of `authentication..`
+    `x509":("clientCAFile":"/etc/kubernetes/pki/ca.crt` by extracting the live
+    configuration from the nodes running kubelet.
+    Set the local proxy port and the following variables and provide proxy port number and
+    node name;
+    `HOSTNAME_PORT="localhost-and-port-number"`
+    `NODE_NAME="The-Name-Of-Node-To-Extract-Configuration" from the output of`
+    `"kubectl get nodes"`
+    ```
+    kubectl proxy --port=8001 &
+    export HOSTNAME_PORT=localhost:8001 (example host and port number)
+    export NODE_NAME=ip-192.168.31.226.ec2.internal (example node name from
+    "kubectl get nodes")
+    curl -sSL "http://${HOSTNAME_PORT}/api/v1/nodes/${NODE_NAME}/proxy/configz"
+    ```
+  remediation: |
+    **Remediation Method 1:**
+    If modifying the Kubelet config file, edit the kubelet-config.json file
+    `/etc/kubernetes/kubelet/kubelet-config.json` and set the below parameter to false
+    ```
+    "authentication": { "x509": {"clientCAFile:" to the location of the client CA
+    file.
+    ```
+    **Remediation Method 2:**
+    If using executable arguments, edit the kubelet service file
+    `/etc/systemd/system/kubelet.service.d/10-kubelet-args.conf` on each worker node
+    and add the below parameter at the end of the `KUBELET_ARGS` variable string.
+    ```
+    --client-ca-file=<path/to/client-ca-file>
+    ```
+    **Remediation Method 3:**
+    If using the api configz endpoint consider searching for the status of
+    `"authentication.*x509":("clientCAFile":"/etc/kubernetes/pki/ca.crt"` by
+    extracting the live configuration from the nodes running kubelet.
+    **See detailed step-by-step configmap procedures in Reconfigure a Node's Kubelet in a Live
+    Cluster, and then rerun the curl statement from audit process to check for kubelet
+    configuration changes
+    ```
+    kubectl proxy --port=8001 &
+    export HOSTNAME_PORT=localhost:8001 (example host and port number)
+    export NODE_NAME=ip-192.168.31.226.ec2.internal (example node name from
+    "kubectl get nodes")
+    curl -sSL "http://${HOSTNAME_PORT}/api/v1/nodes/${NODE_NAME}/proxy/configz"
+    ```
+    **For all three remediations:**
+    Based on your system, restart the kubelet service and check status
+    ```
+    systemctl daemon-reload
+    systemctl restart kubelet.service
+    systemctl status kubelet -l
+    ```
+  impact: |
+    You require TLS to be configured on apiserver as well as kubelets.
+  default_value: |
+    See the EKS documentation for the default value.
+  references: |
+    1. https://kubernetes.io/docs/admin/kubelet/
+    2. https://kubernetes.io/docs/reference/command-line-tools-reference/kubelet-authentication-authorization/
+    3. https://kubernetes.io/docs/tasks/administer-cluster/reconfigure-kubelet/
+  section: Kubelet
+  version: "1.0"
+  tags:
+  - CIS
+  - EKS
+  - CIS 3.2.3
+  - Kubelet
+  benchmark:
+    name: CIS Amazon Elastic Kubernetes Service (EKS) Benchmark
+    version: v1.0.1

--- a/compliance/cis_eks/rules/cis_3_2_3/data.yaml
+++ b/compliance/cis_eks/rules/cis_3_2_3/data.yaml
@@ -8,17 +8,11 @@ metadata:
   rationale: >
     The connections from the apiserver to the kubelet are used for fetching logs
     for pods,
-
     attaching (through kubectl) to running pods, and using the kubelet’s port-forwarding
-
     functionality. These connections terminate at the kubelet’s HTTPS endpoint. By default, the
-
     apiserver does not verify the kubelet’s serving certificate, which makes the connection
-
     subject to man-in-the-middle attacks, and unsafe to run over untrusted and/or public
-
     networks. Enabling Kubelet certificate authentication ensures that the apiserver could
-
     authenticate the Kubelet before submitting any requests.
   audit: |
     **Audit Method 1:**

--- a/compliance/cis_eks/rules/cis_3_2_3/data.yaml
+++ b/compliance/cis_eks/rules/cis_3_2_3/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 067c33b0-f259-5c8c-940c-549ecd1f2466
+  id: 46014c5a-c573-5357-b567-964e0139dcd3
   name: Ensure that the --client-ca-file argument is set as appropriate (Manual)
   profile_applicability: |
     * Level 1

--- a/compliance/cis_eks/rules/cis_3_2_3/data.yaml
+++ b/compliance/cis_eks/rules/cis_3_2_3/data.yaml
@@ -2,7 +2,7 @@ metadata:
   id: 067c33b0-f259-5c8c-940c-549ecd1f2466
   name: Ensure that the --client-ca-file argument is set as appropriate (Manual)
   profile_applicability: |
-    • Level 1
+    * Level 1
   description: |
     Enable Kubelet authentication using certificates.
   rationale: >

--- a/compliance/cis_eks/rules/cis_3_2_3/data.yaml
+++ b/compliance/cis_eks/rules/cis_3_2_3/data.yaml
@@ -33,7 +33,7 @@ metadata:
     Verify that the `"x509": {"clientCAFile:"` argument exists and is set to the location of the
     client certificate authority file.
     If the `"x509": {"clientCAFile:"` argument is not present, check that there is a Kubelet
-    config file specified by --config, and that the file sets `"authentication": { "x509":`
+    config file specified by `--config`, and that the file sets `"authentication": { "x509":`
     `{"clientCAFile:"` to the location of the client certificate authority file.
 
     **Audit Method 2:**

--- a/compliance/cis_eks/rules/cis_3_2_3/rule.rego
+++ b/compliance/cis_eks/rules/cis_3_2_3/rule.rego
@@ -32,20 +32,3 @@ finding = result {
 		},
 	}
 }
-
-metadata = {
-	"name": "Ensure that the --client-ca-file argument is set as appropriate",
-	"description": "Enable Kubelet authentication using certificates.",
-	"impact": "You require TLS to be configured on apiserver as well as kubelets.",
-	"tags": array.concat(cis_eks.default_tags, ["CIS 3.2.3", "Kubelet"]),
-	"benchmark": cis_eks.benchmark_metadata,
-	"remediation": `If modifying the Kubelet config file, edit the kubelet-config.json file /etc/kubernetes/kubelet/kubelet-config.json and set the below parameter to false
-"authentication": { "x509": {"clientCAFile:" to the location of the client CA file}}.
-If using executable arguments, edit the kubelet service file /etc/systemd/system/kubelet.service.d/10-kubelet-args.conf on each worker node and add the below parameter at the end of the KUBELET_ARGS variable string. 
---client-ca-file=<path/to/client-ca-file>
-If using the api configz endpoint consider searching for the status of "authentication.*x509":("clientCAFile":"/etc/kubernetes/pki/ca.crt" by extracting the live configuration from the nodes running kubelet.`,
-	"rationale": `The connections from the apiserver to the kubelet are used for fetching logs for pods, attaching (through kubectl) to running pods, and using the kubelet’s port-forwarding functionality.
-These connections terminate at the kubelet’s HTTPS endpoint.
-By default, the apiserver does not verify the kubelet’s serving certificate, which makes the connection subject to man-in-the-middle attacks, and unsafe to run over untrusted and/or public networks. Enabling Kubelet certificate authentication ensures that the apiserver could authenticate the Kubelet before submitting any requests.`,
-	"default_value": "See the EKS documentation for the default value.",
-}

--- a/compliance/cis_eks/rules/cis_3_2_6/data.yaml
+++ b/compliance/cis_eks/rules/cis_3_2_6/data.yaml
@@ -9,13 +9,9 @@ metadata:
   rationale: >
     Kernel parameters are usually tuned and hardened by the system
     administrators before
-
     putting the systems into production. These parameters protect the kernel and the system.
-
     Your kubelet kernel defaults that rely on such parameters should be appropriately set to
-
     match the desired secured system state. Ignoring this could potentially lead to running
-
     pods with undesired kernel behavior.
   audit: |
     **Audit Method 1:**

--- a/compliance/cis_eks/rules/cis_3_2_6/data.yaml
+++ b/compliance/cis_eks/rules/cis_3_2_6/data.yaml
@@ -1,0 +1,106 @@
+metadata:
+  id: 11d4b01d-3c65-5944-aab4-3a1733917299
+  name: Ensure that the --protect-kernel-defaults argument is set to true(Automated)
+  profile_applicability: |
+    • Level 1
+  description: |
+    Protect tuned kernel parameters from overriding kubelet default kernel
+    parameter values.
+  rationale: >
+    Kernel parameters are usually tuned and hardened by the system
+    administrators before
+
+    putting the systems into production. These parameters protect the kernel and the system.
+
+    Your kubelet kernel defaults that rely on such parameters should be appropriately set to
+
+    match the desired secured system state. Ignoring this could potentially lead to running
+
+    pods with undesired kernel behavior.
+  audit: |
+    **Audit Method 1:**
+    If using a Kubelet configuration file, check that there is an entry for
+    `protectKernelDefaults` is set to `true`.
+    First, SSH to the relevant node:
+    Run the following command on each node to find the appropriate Kubelet config file:
+    ```
+    ps -ef | grep kubelet
+    ```
+    The output of the above command should return something similar to `--config`
+    `/etc/kubernetes/kubelet/kubelet-config.json` which is the location of the Kubelet
+    config file.
+    Open the Kubelet config file:
+    ```
+    cat /etc/kubernetes/kubelet/kubelet-config.json
+    ```
+    Verify that the `--protect-kernel-defaults=true`.
+    If the `--protect-kernel-defaults` argument is not present, check that there is a Kubelet
+    config file specified by `--config`, and that the file sets `protectKernelDefaults` to `true`.
+    **Audit Method 2:**
+    If using the api configz endpoint consider searching for the status of
+    `"protectKernelDefaults"` by extracting the live configuration from the nodes running
+    kubelet.
+    Set the local proxy port and the following variables and provide proxy port number and
+    node name;
+    `HOSTNAME_PORT="localhost-and-port-number"`
+    `NODE_NAME="The-Name-Of-Node-To-Extract-Configuration" from the output of`
+    `"kubectl get nodes"`
+    ```
+    kubectl proxy --port=8001 &
+    export HOSTNAME_PORT=localhost:8001 (example host and port number)
+    export NODE_NAME=ip-192.168.31.226.ec2.internal (example node name from
+    "kubectl get nodes")
+    curl -sSL "http://${HOSTNAME_PORT}/api/v1/nodes/${NODE_NAME}/proxy/configz"
+    ```
+  remediation: |
+    Remediation Method 1:
+    If modifying the Kubelet config file, edit the kubelet-config.json file
+    `/etc/kubernetes/kubelet/kubelet-config.json` and set the below parameter to `true`
+    ```
+    "protectKernelDefaults":
+    ```
+    **Remediation Method 2:**
+    If using a Kubelet config file, edit the file to set `protectKernelDefaults` to `true`.
+    If using executable arguments, edit the kubelet service file
+    `/etc/systemd/system/kubelet.service.d/10-kubelet-args.conf` on each worker node
+    and add the below parameter at the end of the `KUBELET_ARGS` variable string.
+    ```
+    ----protect-kernel-defaults=true
+    ```
+    **Remediation Method 3:**
+    If using the api configz endpoint consider searching for the status of
+    `"protectKernelDefaults":` by extracting the live configuration from the nodes running
+    kubelet.
+    **See detailed step-by-step configmap procedures in Reconfigure a Node's Kubelet in a Live
+    Cluster, and then rerun the curl statement from audit process to check for kubelet
+    configuration changes
+    ```
+    kubectl proxy --port=8001 &
+    export HOSTNAME_PORT=localhost:8001 (example host and port number)
+    export NODE_NAME=ip-192.168.31.226.ec2.internal (example node name from
+    "kubectl get nodes")
+    curl -sSL "http://${HOSTNAME_PORT}/api/v1/nodes/${NODE_NAME}/proxy/configz"
+    ```
+    **For all three remediations:**
+    Based on your system, restart the kubelet service and check status
+    ```
+    systemctl daemon-reload
+    systemctl restart kubelet.service
+    systemctl status kubelet -l
+    ```
+  impact: |
+    You would have to re-tune kernel parameters to match kubelet parameters.
+  default_value: |
+    See the EKS documentation for the default value.
+  references: |
+    1. https://kubernetes.io/docs/admin/kubelet/
+  section: Kubelet
+  version: "1.0"
+  tags:
+  - CIS
+  - EKS
+  - CIS 3.2.6
+  - Kubelet
+  benchmark:
+    name: CIS Amazon Elastic Kubernetes Service (EKS) Benchmark
+    version: v1.0.1

--- a/compliance/cis_eks/rules/cis_3_2_6/data.yaml
+++ b/compliance/cis_eks/rules/cis_3_2_6/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 11d4b01d-3c65-5944-aab4-3a1733917299
+  id: 136ee092-7486-59d2-8f77-760b743c8a72
   name: Ensure that the --protect-kernel-defaults argument is set to true (Automated)
   profile_applicability: |
     * Level 1

--- a/compliance/cis_eks/rules/cis_3_2_6/data.yaml
+++ b/compliance/cis_eks/rules/cis_3_2_6/data.yaml
@@ -1,6 +1,6 @@
 metadata:
   id: 11d4b01d-3c65-5944-aab4-3a1733917299
-  name: Ensure that the --protect-kernel-defaults argument is set to true(Automated)
+  name: Ensure that the --protect-kernel-defaults argument is set to true (Automated)
   profile_applicability: |
     * Level 1
   description: |

--- a/compliance/cis_eks/rules/cis_3_2_6/data.yaml
+++ b/compliance/cis_eks/rules/cis_3_2_6/data.yaml
@@ -2,7 +2,7 @@ metadata:
   id: 11d4b01d-3c65-5944-aab4-3a1733917299
   name: Ensure that the --protect-kernel-defaults argument is set to true(Automated)
   profile_applicability: |
-    • Level 1
+    * Level 1
   description: |
     Protect tuned kernel parameters from overriding kubelet default kernel
     parameter values.

--- a/compliance/cis_eks/rules/cis_3_2_6/rule.rego
+++ b/compliance/cis_eks/rules/cis_3_2_6/rule.rego
@@ -37,21 +37,3 @@ finding = result {
 		},
 	}
 }
-
-metadata = {
-	"name": "Ensure that the --protect-kernel-defaults argument is set to true",
-	"description": "Protect tuned kernel parameters from overriding kubelet default kernel parameter values.",
-	"impact": "You would have to re-tune kernel parameters to match kubelet parameters.",
-	"tags": array.concat(cis_eks.default_tags, ["CIS 3.2.6", "Kubelet"]),
-	"benchmark": cis_eks.benchmark_metadata,
-	"remediation": `If modifying the Kubelet config file, edit the kubelet-config.json file /etc/kubernetes/kubelet/kubelet-config.json and set the below parameter to true
-"protectKernelDefaults":
-If using a Kubelet config file, edit the file to set protectKernelDefaults to true.
-If using executable arguments, edit the kubelet service file /etc/systemd/system/kubelet.service.d/10-kubelet-args.conf on each worker node and add the below parameter at the end of the KUBELET_ARGS variable string.
-----protect-kernel-defaults=true
-If using the api configz endpoint consider searching for the status of "protectKernelDefaults": by extracting the live configuration from the nodes running kubelet.`,
-	"rationale": `Kernel parameters are usually tuned and hardened by the system administrators before putting the systems into production.
-These parameters protect the kernel and the system. Your kubelet kernel defaults that rely on such parameters should be appropriately set to match the desired secured system state.
-Ignoring this could potentially lead to running pods with undesired kernel behavior.`,
-	"default_value": "See the EKS documentation for the default value.",
-}

--- a/compliance/cis_eks/rules/cis_3_2_7/data.yaml
+++ b/compliance/cis_eks/rules/cis_3_2_7/data.yaml
@@ -7,16 +7,11 @@ metadata:
     Allow Kubelet to manage iptables.
   rationale: >
     Kubelets can automatically manage the required changes to iptables based on
-    how you
-
-    choose your networking options for the pods. It is recommended to let kubelets manage
-
+    how you choose your networking options for the pods. 
+    It is recommended to let kubelets manage
     the changes to iptables. This ensures that the iptables configuration remains in sync with
-
     pods networking configuration. Manually configuring iptables with dynamic pod network
-
     configuration changes might hamper the communication between pods/containers and to
-
     the outside world. You might have iptables rules too restrictive or too open.
   audit: |
     **Audit Method 1:**

--- a/compliance/cis_eks/rules/cis_3_2_7/data.yaml
+++ b/compliance/cis_eks/rules/cis_3_2_7/data.yaml
@@ -2,7 +2,7 @@ metadata:
   id: 5f789a14-88cb-56cb-bbea-01b9adc91470
   name: Ensure that the --make-iptables-util-chains argument is set to true (Automated)
   profile_applicability: |
-    • Level 1
+    * Level 1
   description: |
     Allow Kubelet to manage iptables.
   rationale: >

--- a/compliance/cis_eks/rules/cis_3_2_7/data.yaml
+++ b/compliance/cis_eks/rules/cis_3_2_7/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 5f789a14-88cb-56cb-bbea-01b9adc91470
+  id: 7d7d7235-406a-5d9b-9401-7034758b2e8b
   name: Ensure that the --make-iptables-util-chains argument is set to true (Automated)
   profile_applicability: |
     * Level 1

--- a/compliance/cis_eks/rules/cis_3_2_7/data.yaml
+++ b/compliance/cis_eks/rules/cis_3_2_7/data.yaml
@@ -56,7 +56,7 @@ metadata:
     ```
     "makeIPTablesUtilChains": true
     ```
-    `Remediation Method 2:`
+    **Remediation Method 2:**
     If using executable arguments, edit the kubelet service file
     `/etc/systemd/system/kubelet.service.d/10-kubelet-args.conf` on each worker node
     and add the below parameter at the end of the `KUBELET_ARGS` variable string.

--- a/compliance/cis_eks/rules/cis_3_2_7/data.yaml
+++ b/compliance/cis_eks/rules/cis_3_2_7/data.yaml
@@ -1,0 +1,111 @@
+metadata:
+  id: 5f789a14-88cb-56cb-bbea-01b9adc91470
+  name: Ensure that the --make-iptables-util-chains argument is set to true (Automated)
+  profile_applicability: |
+    • Level 1
+  description: |
+    Allow Kubelet to manage iptables.
+  rationale: >
+    Kubelets can automatically manage the required changes to iptables based on
+    how you
+
+    choose your networking options for the pods. It is recommended to let kubelets manage
+
+    the changes to iptables. This ensures that the iptables configuration remains in sync with
+
+    pods networking configuration. Manually configuring iptables with dynamic pod network
+
+    configuration changes might hamper the communication between pods/containers and to
+
+    the outside world. You might have iptables rules too restrictive or too open.
+  audit: |
+    **Audit Method 1:**
+    If using a Kubelet configuration file, check that there is an entry for
+    `makeIPTablesUtilChains` set to `true`.
+    First, SSH to the relevant node:
+    Run the following command on each node to find the appropriate Kubelet config file:
+    ```
+    ps -ef | grep kubelet
+    ```
+    The output of the above command should return something similar to `--config`
+    `/etc/kubernetes/kubelet/kubelet-config.json` which is the location of the Kubelet
+    config file.
+    Open the Kubelet config file:
+    ```
+    cat /etc/kubernetes/kubelet/kubelet-config.json
+    ```
+    Verify that if the `makeIPTablesUtilChains` argument exists then it is set to `true`.
+    If the `--make-iptables-util-chains` argument does not exist, and there is a Kubelet config
+    file specified by `--config`, verify that the file does not set `makeIPTablesUtilChains` to
+    `false`.
+    **Audit Method 2:**
+    If using the api configz endpoint consider searching for the status of `authentication...`
+    `"makeIPTablesUtilChains":true` by extracting the live configuration from the nodes
+    running kubelet.
+    Set the local proxy port and the following variables and provide proxy port number and
+    node name;
+    `HOSTNAME_PORT="localhost-and-port-number"`
+    `NODE_NAME="The-Name-Of-Node-To-Extract-Configuration" from the output of`
+    `"kubectl get nodes"`
+    ```
+    kubectl proxy --port=8001 &
+    export HOSTNAME_PORT=localhost:8001 (example host and port number)
+    export NODE_NAME=ip-192.168.31.226.ec2.internal (example node name from
+    "kubectl get nodes")
+    curl -sSL "http://${HOSTNAME_PORT}/api/v1/nodes/${NODE_NAME}/proxy/configz"
+    ```
+  remediation: |
+    **Remediation Method 1:**
+    If modifying the Kubelet config file, edit the kubelet-config.json file
+    `/etc/kubernetes/kubelet/kubelet-config.json` and set the below parameter to `false`
+    ```
+    "makeIPTablesUtilChains": true
+    ```
+    `Remediation Method 2:`
+    If using executable arguments, edit the kubelet service file
+    `/etc/systemd/system/kubelet.service.d/10-kubelet-args.conf` on each worker node
+    and add the below parameter at the end of the `KUBELET_ARGS` variable string.
+    ```
+    --make-iptables-util-chains:true
+    ```
+    **Remediation Method 3:**
+    If using the api configz endpoint consider searching for the status of
+    `"makeIPTablesUtilChains": true` by extracting the live configuration from the nodes
+    running kubelet.
+    **See detailed step-by-step configmap procedures in Reconfigure a Node's Kubelet in a Live
+    Cluster, and then rerun the curl statement from audit process to check for kubelet
+    configuration changes
+    ```
+    kubectl proxy --port=8001 &
+    export HOSTNAME_PORT=localhost:8001 (example host and port number)
+    export NODE_NAME=ip-192.168.31.226.ec2.internal (example node name from
+    "kubectl get nodes")
+    curl -sSL "http://${HOSTNAME_PORT}/api/v1/nodes/${NODE_NAME}/proxy/configz"
+    ```
+    For all three remediations:
+    Based on your system, restart the `kubelet` service and check status
+    ```
+    systemctl daemon-reload
+    systemctl restart kubelet.service
+    systemctl status kubelet -l      
+    ```
+  impact: |
+    Kubelet would manage the iptables on the system and keep it in sync. If you
+    are using any
+
+    other iptables management solution, then there might be some conflicts.
+  default_value: |
+    See the Amazon EKS documentation for the default value.
+  references: |
+    1. https://kubernetes.io/docs/admin/kubelet/
+    2. https://kubernetes.io/docs/tasks/administer-cluster/reconfigure-kubelet/
+  section: Kubelet
+  version: "1.0"
+  tags:
+  - CIS
+  - EKS
+  - CIS 3.2.7
+  - Kubelet
+  benchmark:
+    name: CIS Amazon Elastic Kubernetes Service (EKS) Benchmark
+    version: v1.0.1

--- a/compliance/cis_eks/rules/cis_3_2_7/rule.rego
+++ b/compliance/cis_eks/rules/cis_3_2_7/rule.rego
@@ -33,23 +33,3 @@ finding = result {
 		},
 	}
 }
-
-metadata = {
-	"name": "Ensure that the --make-iptables-util-chains argument is set to true",
-	"description": "Allow Kubelet to manage iptables.",
-	"impact": `Kubelet would manage the iptables on the system and keep it in sync.
-If you are using any other iptables management solution, then there might be some conflicts.`,
-	"tags": array.concat(cis_eks.default_tags, ["CIS 3.2.7", "Kubelet"]),
-	"benchmark": cis_eks.benchmark_metadata,
-	"remediation": `If modifying the Kubelet config file, edit the kubelet-config.json file /etc/kubernetes/kubelet/kubelet-config.json and set the below parameter to false
-"makeIPTablesUtilChains": true
-If using executable arguments, edit the kubelet service file /etc/systemd/system/kubelet.service.d/10-kubelet-args.conf on each worker node and add the below parameter at the end of the KUBELET_ARGS variable string.
---make-iptables-util-chains:true
-If using the api configz endpoint consider searching for the status of "makeIPTablesUtilChains": true by extracting the live configuration from the nodes running kubelet.`,
-	"default_value": "See the Amazon EKS documentation for the default value.",
-	"rationale": `Kubelets can automatically manage the required changes to iptables based on how you choose your networking options for the pods.
-It is recommended to let kubelets manage the changes to iptables.
-This ensures that the iptables configuration remains in sync with pods networking configuration.
-Manually configuring iptables with dynamic pod network configuration changes might hamper the communication between pods/containers and to the outside world.
-You might have iptables rules too restrictive or too open.`,
-}

--- a/compliance/cis_eks/rules/cis_4_2_1/data.yaml
+++ b/compliance/cis_eks/rules/cis_4_2_1/data.yaml
@@ -2,7 +2,7 @@ metadata:
   id: ca97c06c-6484-58e6-bedc-9d7f37e6d8b8
   name: Minimize the admission of privileged containers (Automated)
   profile_applicability: |
-    • Level 1
+    * Level 1
   description: |
     Do not generally permit containers to be run with the
     `securityContext.privileged` flag set to true.

--- a/compliance/cis_eks/rules/cis_4_2_1/data.yaml
+++ b/compliance/cis_eks/rules/cis_4_2_1/data.yaml
@@ -9,19 +9,12 @@ metadata:
   rationale: >
     Privileged containers have access to all Linux Kernel capabilities and
     devices. A container
-
     running with full privileges can do almost everything that the host can do. This flag exists
-
     to allow special use-cases, like manipulating the network stack and accessing devices.
-
     There should be at least one PodSecurityPolicy (PSP) defined which does not permit
-
     privileged containers.
-
     If you need to run privileged containers, this should be defined in a separate PSP and you
-
     should carefully check RBAC controls to ensure that only limited service accounts and
-
     users are given permission to access that PSP.
   audit: |
     Get the set of PSPs with the following command:
@@ -43,79 +36,42 @@ metadata:
   default_value: >
     By default, when you provision an EKS cluster, a pod security policy called
     eks.privileged
-
     is automatically created. The manifest for that policy appears below:
-    
     ```
-    
     apiVersion: extensions/v1beta1
-
     kind: PodSecurityPolicy
-
     metadata:
-
     annotations:
-
     kubernetes.io/description: privileged allows full unrestricted access to
-
     pod features,
-
     as if the PodSecurityPolicy controller was not enabled.
-
     seccomp.security.alpha.kubernetes.io/allowedProfileNames: '*'
-
     labels:
-
     eks.amazonaws.com/component: pod-security-policy
-
     kubernetes.io/cluster-service: "true"
-
     name: eks.privileged
-    
     spec:
-
     allowPrivilegeEscalation: true
-
     allowedCapabilities:
-
     - '*'
-
     fsGroup:
-
     rule: RunAsAny
-
     hostIPC: true
-
     hostNetwork: true
-
     hostPID: true
-
     hostPorts:
-
     - max: 65535
-
     min: 0
-
     privileged: true
-
     runAsUser:
-
     rule: RunAsAny
-
     seLinux:
-
     rule: RunAsAny	
-
     supplementalGroups:
-
     rule: RunAsAny
-
     volumes:
-
     - '*'
-    
     ```
-
   references: |
     1.https://kubernetes.io/docs/concepts/policy/pod-security-policy/#enabling-pod-security-policies
     2. https://aws.github.io/aws-eks-best-practices/pods/#restrict-the-containers-that-can-run-as-privileged

--- a/compliance/cis_eks/rules/cis_4_2_1/data.yaml
+++ b/compliance/cis_eks/rules/cis_4_2_1/data.yaml
@@ -1,0 +1,131 @@
+metadata:
+  id: ca97c06c-6484-58e6-bedc-9d7f37e6d8b8
+  name: Minimize the admission of privileged containers (Automated)
+  profile_applicability: |
+    • Level 1
+  description: |
+    Do not generally permit containers to be run with the
+    `securityContext.privileged` flag set to true.
+  rationale: >
+    Privileged containers have access to all Linux Kernel capabilities and
+    devices. A container
+
+    running with full privileges can do almost everything that the host can do. This flag exists
+
+    to allow special use-cases, like manipulating the network stack and accessing devices.
+
+    There should be at least one PodSecurityPolicy (PSP) defined which does not permit
+
+    privileged containers.
+
+    If you need to run privileged containers, this should be defined in a separate PSP and you
+
+    should carefully check RBAC controls to ensure that only limited service accounts and
+
+    users are given permission to access that PSP.
+  audit: |
+    Get the set of PSPs with the following command:
+    ```
+    kubectl get psp
+    ```
+    For each PSP, check whether privileged is enabled:
+    ```
+    kubectl get psp -o json
+    ```
+    Verify that there is at least one PSP which does not return true.
+    `kubectl get psp <name> -o=jsonpath='{.spec.privileged}'`
+  remediation: |
+    Create a PSP as described in the Kubernetes documentation, ensuring that the
+    `.spec.privileged field is omitted or set to false.`
+  impact: >
+    Pods defined with `spec.containers[].securityContext.privileged: true` will
+    not be permitted.
+  default_value: >
+    By default, when you provision an EKS cluster, a pod security policy called
+    eks.privileged
+
+    is automatically created. The manifest for that policy appears below:
+    
+    ```
+    
+    apiVersion: extensions/v1beta1
+
+    kind: PodSecurityPolicy
+
+    metadata:
+
+    annotations:
+
+    kubernetes.io/description: privileged allows full unrestricted access to
+
+    pod features,
+
+    as if the PodSecurityPolicy controller was not enabled.
+
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: '*'
+
+    labels:
+
+    eks.amazonaws.com/component: pod-security-policy
+
+    kubernetes.io/cluster-service: "true"
+
+    name: eks.privileged
+    
+    spec:
+
+    allowPrivilegeEscalation: true
+
+    allowedCapabilities:
+
+    - '*'
+
+    fsGroup:
+
+    rule: RunAsAny
+
+    hostIPC: true
+
+    hostNetwork: true
+
+    hostPID: true
+
+    hostPorts:
+
+    - max: 65535
+
+    min: 0
+
+    privileged: true
+
+    runAsUser:
+
+    rule: RunAsAny
+
+    seLinux:
+
+    rule: RunAsAny	
+
+    supplementalGroups:
+
+    rule: RunAsAny
+
+    volumes:
+
+    - '*'
+    
+    ```
+
+  references: |
+    1.https://kubernetes.io/docs/concepts/policy/pod-security-policy/#enabling-pod-security-policies
+    2. https://aws.github.io/aws-eks-best-practices/pods/#restrict-the-containers-that-can-run-as-privileged
+  section: Pod Security Policies
+  version: "1.0"
+  tags:
+  - CIS
+  - EKS
+  - CIS 4.2.1
+  - Pod Security Policies
+  benchmark:
+    name: CIS Amazon Elastic Kubernetes Service (EKS) Benchmark
+    version: v1.0.1

--- a/compliance/cis_eks/rules/cis_4_2_1/data.yaml
+++ b/compliance/cis_eks/rules/cis_4_2_1/data.yaml
@@ -72,7 +72,7 @@ metadata:
     - '*'
     ```
   references: |
-    1.https://kubernetes.io/docs/concepts/policy/pod-security-policy/#enabling-pod-security-policies
+    1. https://kubernetes.io/docs/concepts/policy/pod-security-policy/#enabling-pod-security-policies
     2. https://aws.github.io/aws-eks-best-practices/pods/#restrict-the-containers-that-can-run-as-privileged
   section: Pod Security Policies
   version: "1.0"

--- a/compliance/cis_eks/rules/cis_4_2_1/data.yaml
+++ b/compliance/cis_eks/rules/cis_4_2_1/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: ca97c06c-6484-58e6-bedc-9d7f37e6d8b8
+  id: 1319beca-0436-5d6e-8d4a-1ee1bea35311
   name: Minimize the admission of privileged containers (Automated)
   profile_applicability: |
     * Level 1

--- a/compliance/cis_eks/rules/cis_4_2_1/data.yaml
+++ b/compliance/cis_eks/rules/cis_4_2_1/data.yaml
@@ -25,18 +25,17 @@ metadata:
     ```
     kubectl get psp -o json
     ```
-    Verify that there is at least one PSP which does not return true.
+    Verify that there is at least one PSP which does not return `true`.
     `kubectl get psp <name> -o=jsonpath='{.spec.privileged}'`
   remediation: |
     Create a PSP as described in the Kubernetes documentation, ensuring that the
-    `.spec.privileged field is omitted or set to false.`
+    `.spec.privileged` field is omitted or set to `false`.
   impact: >
     Pods defined with `spec.containers[].securityContext.privileged: true` will
     not be permitted.
-  default_value: >
+  default_value: |
     By default, when you provision an EKS cluster, a pod security policy called
-    eks.privileged
-    is automatically created. The manifest for that policy appears below:
+    eks.privileged is automatically created. The manifest for that policy appears below:
     ```
     apiVersion: extensions/v1beta1
     kind: PodSecurityPolicy

--- a/compliance/cis_eks/rules/cis_4_2_1/rule.rego
+++ b/compliance/cis_eks/rules/cis_4_2_1/rule.rego
@@ -1,6 +1,5 @@
 package compliance.cis_eks.rules.cis_4_2_1
 
-import data.compliance.cis_eks
 import data.compliance.lib.common
 import data.compliance.lib.data_adapter
 

--- a/compliance/cis_eks/rules/cis_4_2_1/rule.rego
+++ b/compliance/cis_eks/rules/cis_4_2_1/rule.rego
@@ -28,18 +28,3 @@ finding = result {
 		},
 	}
 }
-
-metadata = {
-	"name": "Minimize the admission of privileged containers",
-	"description": "Do not generally permit containers to be run with the securityContext.privileged flag set to true.",
-	"rationale": `Privileged containers have access to all Linux Kernel capabilities and devices.
-A container running with full privileges can do almost everything that the host can do.
-This flag exists to allow special use-cases, like manipulating the network stack and accessing devices.
-There should be at least one PodSecurityPolicy (PSP) defined which does not permit privileged containers.
-If you need to run privileged containers, this should be defined in a separate PSP and you should carefully check RBAC controls to ensure that only limited service accounts and users are given permission to access that PSP.`,
-	"impact": "Pods defined with spec.containers[].securityContext.privileged: true will not be permitted.",
-	"remediation": "Create a PSP as described in the Kubernetes documentation, ensuring that the .spec.privileged field is omitted or set to false.",
-	"default_value": "By default, when you provision an EKS cluster, a pod security policy called eks.privileged is automatically created.",
-	"benchmark": cis_eks.benchmark_metadata,
-	"tags": array.concat(cis_eks.default_tags, ["CIS 4.2.1", "Pod Security Policies"]),
-}

--- a/compliance/cis_eks/rules/cis_4_2_2/data.yaml
+++ b/compliance/cis_eks/rules/cis_4_2_2/data.yaml
@@ -2,7 +2,7 @@ metadata:
   id: 383b439d-aa57-5f22-ac46-d06ae0ad655c
   name: Minimize the admission of containers wishing to share the hostprocess ID namespace (Automated)
   profile_applicability: |
-    • Level 1
+    * Level 1
   description: |
     Do not generally permit containers to be run with the `hostPID` flag set to
     `true`.

--- a/compliance/cis_eks/rules/cis_4_2_2/data.yaml
+++ b/compliance/cis_eks/rules/cis_4_2_2/data.yaml
@@ -9,19 +9,12 @@ metadata:
   rationale: >
     A container running in the host's PID namespace can inspect processes
     running outside the
-
     container. If the container also has access to ptrace capabilities this can be used to escalate
-
     privileges outside of the container.
-
     There should be at least one PodSecurityPolicy (PSP) defined which does not permit
-
     containers to share the host PID namespace.
-
     If you need to run containers which require hostPID, this should be defined in a separate
-
     PSP and you should carefully check RBAC controls to ensure that only limited service
-
     accounts and users are given permission to access that PSP.
   audit: |
     Get the set of PSPs with the following command:

--- a/compliance/cis_eks/rules/cis_4_2_2/data.yaml
+++ b/compliance/cis_eks/rules/cis_4_2_2/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 383b439d-aa57-5f22-ac46-d06ae0ad655c
+  id: 29f995c1-1553-5200-9c08-530032d4ed1d
   name: Minimize the admission of containers wishing to share the hostprocess ID namespace (Automated)
   profile_applicability: |
     * Level 1

--- a/compliance/cis_eks/rules/cis_4_2_2/data.yaml
+++ b/compliance/cis_eks/rules/cis_4_2_2/data.yaml
@@ -1,0 +1,55 @@
+metadata:
+  id: 383b439d-aa57-5f22-ac46-d06ae0ad655c
+  name: Minimize the admission of containers wishing to share the hostprocess ID namespace (Automated)
+  profile_applicability: |
+    • Level 1
+  description: |
+    Do not generally permit containers to be run with the `hostPID` flag set to
+    `true`.
+  rationale: >
+    A container running in the host's PID namespace can inspect processes
+    running outside the
+
+    container. If the container also has access to ptrace capabilities this can be used to escalate
+
+    privileges outside of the container.
+
+    There should be at least one PodSecurityPolicy (PSP) defined which does not permit
+
+    containers to share the host PID namespace.
+
+    If you need to run containers which require hostPID, this should be defined in a separate
+
+    PSP and you should carefully check RBAC controls to ensure that only limited service
+
+    accounts and users are given permission to access that PSP.
+  audit: |
+    Get the set of PSPs with the following command:
+    ```
+    kubectl get psp
+    ```
+    For each PSP, check whether privileged is enabled:
+    ```
+    kubectl get psp <name> -o=jsonpath='{.spec.hostPID}'
+    ```
+    Verify that there is at least one PSP which does not return true.
+  remediation: |
+    Create a PSP as described in the Kubernetes documentation, ensuring that the
+    `.spec.hostPID` field is omitted or set to false.
+  impact: |
+    Pods defined with `spec.hostPID: true` will not be permitted unless they are
+    run under a specific PSP.
+  default_value: |
+    By default, PodSecurityPolicies are not defined.
+  references: |
+    1. https://kubernetes.io/docs/concepts/policy/pod-security-policy
+  section: Pod Security Policies
+  version: "1.0"
+  tags:
+  - CIS
+  - EKS
+  - CIS 4.2.2
+  - Pod Security Policies
+  benchmark:
+    name: CIS Amazon Elastic Kubernetes Service (EKS) Benchmark
+    version: v1.0.1

--- a/compliance/cis_eks/rules/cis_4_2_2/rule.rego
+++ b/compliance/cis_eks/rules/cis_4_2_2/rule.rego
@@ -1,6 +1,5 @@
 package compliance.cis_eks.rules.cis_4_2_2
 
-import data.compliance.cis_eks
 import data.compliance.lib.assert
 import data.compliance.lib.common
 import data.compliance.lib.data_adapter

--- a/compliance/cis_eks/rules/cis_4_2_2/rule.rego
+++ b/compliance/cis_eks/rules/cis_4_2_2/rule.rego
@@ -19,17 +19,3 @@ finding = result {
 		"evidence": json.filter(data_adapter.pod, ["uid", "spec/hostPID"]),
 	}
 }
-
-metadata = {
-	"name": "Minimize the admission of containers wishing to share the host process ID namespace",
-	"description": "Do not generally permit containers to be run with the hostPID flag set to true.",
-	"rationale": `A container running in the host's PID namespace can inspect processes running outside the container.
-If the container also has access to ptrace capabilities this can be used to escalate privileges outside of the container.
-There should be at least one PodSecurityPolicy (PSP) defined which does not permit containers to share the host PID namespace.
-If you need to run containers which require hostPID, this should be defined in a separate PSP and you should carefully check RBAC controls to ensure that only limited service accounts and users are given permission to access that PSP.`,
-	"impact": "Pods defined with spec.hostPID: true will not be permitted unless they are run under a specific PSP.",
-	"remediation": "Create a PSP as described in the Kubernetes documentation, ensuring that the .spec.hostPID field is omitted or set to false.",
-	"default_value": "By default, PodSecurityPolicies are not defined.",
-	"benchmark": cis_eks.benchmark_metadata,
-	"tags": array.concat(cis_eks.default_tags, ["CIS 4.2.2", "Pod Security Policies"]),
-}

--- a/compliance/cis_eks/rules/cis_4_2_3/data.yaml
+++ b/compliance/cis_eks/rules/cis_4_2_3/data.yaml
@@ -1,0 +1,53 @@
+metadata:
+  id: e206118b-ec27-5280-b237-a1ef23c40b7a
+  name: Minimize the admission of containers wishing to share the hostIPC namespace (Automated)
+  profile_applicability: |
+    • Level 1
+  description: |
+    Do not generally permit containers to be run with the hostIPC flag set to
+    true.
+  rationale: >
+    A container running in the host's IPC namespace can use IPC to interact with
+    processes
+
+    outside the container.
+
+    There should be at least one PodSecurityPolicy (PSP) defined which does not permit
+
+    containers to share the host IPC namespace.
+
+    If you have a requirement to containers which require hostIPC, this should be defined in a
+
+    separate PSP and you should carefully check RBAC controls to ensure that only limited
+
+    service accounts and users are given permission to access that PSP.
+  audit: |
+    Get the set of PSPs with the following command:
+    ```
+    kubectl get psp
+    ```
+    For each PSP, check whether privileged is enabled:
+    ```
+    kubectl get psp <name> -o=jsonpath='{.spec.hostIPC}'
+    ```
+    Verify that there is at least one PSP which does not return true.
+  remediation: |
+    Create a PSP as described in the Kubernetes documentation, ensuring that the
+    `.spec.hostIPC` field is omitted or set to false.
+  impact: |
+    Pods defined with `spec.hostIPC: true` will not be permitted unless they are
+    run under a specific PSP.
+  default_value: |
+    By default, PodSecurityPolicies are not defined.
+  references: |
+    1. https://kubernetes.io/docs/concepts/policy/pod-security-policy
+  section: Pod Security Policies
+  version: "1.0"
+  tags:
+  - CIS
+  - EKS
+  - CIS 4.2.3
+  - Pod Security Policies
+  benchmark:
+    name: CIS Amazon Elastic Kubernetes Service (EKS) Benchmark
+    version: v1.0.1

--- a/compliance/cis_eks/rules/cis_4_2_3/data.yaml
+++ b/compliance/cis_eks/rules/cis_4_2_3/data.yaml
@@ -2,7 +2,7 @@ metadata:
   id: e206118b-ec27-5280-b237-a1ef23c40b7a
   name: Minimize the admission of containers wishing to share the hostIPC namespace (Automated)
   profile_applicability: |
-    • Level 1
+    * Level 1
   description: |
     Do not generally permit containers to be run with the hostIPC flag set to
     true.

--- a/compliance/cis_eks/rules/cis_4_2_3/data.yaml
+++ b/compliance/cis_eks/rules/cis_4_2_3/data.yaml
@@ -9,17 +9,11 @@ metadata:
   rationale: >
     A container running in the host's IPC namespace can use IPC to interact with
     processes
-
     outside the container.
-
     There should be at least one PodSecurityPolicy (PSP) defined which does not permit
-
     containers to share the host IPC namespace.
-
     If you have a requirement to containers which require hostIPC, this should be defined in a
-
     separate PSP and you should carefully check RBAC controls to ensure that only limited
-
     service accounts and users are given permission to access that PSP.
   audit: |
     Get the set of PSPs with the following command:

--- a/compliance/cis_eks/rules/cis_4_2_3/data.yaml
+++ b/compliance/cis_eks/rules/cis_4_2_3/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: e206118b-ec27-5280-b237-a1ef23c40b7a
+  id: 1b727ec0-12aa-5598-ae7b-3123f5d76610
   name: Minimize the admission of containers wishing to share the hostIPC namespace (Automated)
   profile_applicability: |
     * Level 1

--- a/compliance/cis_eks/rules/cis_4_2_3/rule.rego
+++ b/compliance/cis_eks/rules/cis_4_2_3/rule.rego
@@ -1,6 +1,5 @@
 package compliance.cis_eks.rules.cis_4_2_3
 
-import data.compliance.cis_eks
 import data.compliance.lib.assert
 import data.compliance.lib.common
 import data.compliance.lib.data_adapter
@@ -18,17 +17,4 @@ finding = result {
 		"evaluation": common.calculate_result(rule_evaluation),
 		"evidence": json.filter(data_adapter.pod, ["uid", "spec/hostIPC"]),
 	}
-}
-
-metadata = {
-	"name": "Minimize the admission of containers wishing to share the host process IPC namespace",
-	"description": "Do not generally permit containers to be run with the hostIPC flag set to true.",
-	"rationale": `A container running in the host's IPC namespace can use IPC to interact with processes outside the container.
-There should be at least one PodSecurityPolicy (PSP) defined which does not permit containers to share the host IPC namespace.
-If you have a requirement to containers which require hostIPC, this should be defined in a separate PSP and you should carefully check RBAC controls to ensure that only limited service accounts and users are given permission to access that PSP.`,
-	"impact": "Pods defined with spec.hostIPC: true will not be permitted unless they are run under a specific PSP.",
-	"remediation": "Create a PSP as described in the Kubernetes documentation, ensuring that the .spec.hostIPC field is omitted or set to false.",
-	"default_value": "By default, PodSecurityPolicies are not defined.",
-	"benchmark": cis_eks.benchmark_metadata,
-	"tags": array.concat(cis_eks.default_tags, ["CIS 4.2.3", "Pod Security Policies"]),
 }

--- a/compliance/cis_eks/rules/cis_4_2_4/data.yaml
+++ b/compliance/cis_eks/rules/cis_4_2_4/data.yaml
@@ -1,0 +1,55 @@
+metadata:
+  id: 57f22327-1ce8-57d7-ae7f-47344e970031
+  name: Minimize the admission of containers wishing to share the hostnetwork namespace (Automated)
+  profile_applicability: |
+    • Level 1
+  description: |
+    Do not generally permit containers to be run with the `hostNetwork` flag set
+    to true.
+  rationale: |
+    A container running in the host's network namespace could access the local
+    loopback
+
+    device, and could access network traffic to and from other pods.
+
+    There should be at least one PodSecurityPolicy (PSP) defined which does not permit
+
+    containers to share the host network namespace.
+
+    If you have need to run containers which require hostNetwork, this should be defined in a
+
+    separate PSP and you should carefully check RBAC controls to ensure that only limited
+
+    service accounts and users are given permission to access that PSP.
+  audit: |
+    Get the set of PSPs with the following command:
+    ```
+    kubectl get psp
+    ```
+    For each PSP, check whether privileged is enabled:
+    ```
+    kubectl get psp <name> -o=jsonpath='{.spec.hostNetwork}'
+    ```
+    Verify that there is at least one PSP which does not return true.
+  remediation: |
+    Create a PSP as described in the Kubernetes documentation, ensuring that the
+    `.spec.hostNetwork` field is omitted or set to false.
+  impact: >
+    Pods defined with `spec.hostNetwork: true` will not be permitted unless they
+    are run
+
+    under a specific PSP.
+  default_value: |
+    By default, PodSecurityPolicies are not defined.
+  references: |
+    1. https://kubernetes.io/docs/concepts/policy/pod-security-policy
+  section: Pod Security Policies
+  version: "1.0"
+  tags:
+  - CIS
+  - EKS
+  - CIS 4.2.4
+  - Pod Security Policies
+  benchmark:
+    name: CIS Amazon Elastic Kubernetes Service (EKS) Benchmark
+    version: v1.0.1

--- a/compliance/cis_eks/rules/cis_4_2_4/data.yaml
+++ b/compliance/cis_eks/rules/cis_4_2_4/data.yaml
@@ -1,6 +1,6 @@
 metadata:
-  id: 8f13ab3c-ee3e-5c0a-857d-95214a2c3f71
-  name: Minimize the admission of containers wishing to share the hostnetwork namespace (Automated)
+  id: 4b4dc57c-c46d-5db2-822d-ad702b0dd1d1
+  name: Minimize the admission of containers wishing to share the host network namespace (Automated)
   profile_applicability: |
     * Level 1
   description: |

--- a/compliance/cis_eks/rules/cis_4_2_4/data.yaml
+++ b/compliance/cis_eks/rules/cis_4_2_4/data.yaml
@@ -2,7 +2,7 @@ metadata:
   id: 57f22327-1ce8-57d7-ae7f-47344e970031
   name: Minimize the admission of containers wishing to share the hostnetwork namespace (Automated)
   profile_applicability: |
-    • Level 1
+    * Level 1
   description: |
     Do not generally permit containers to be run with the `hostNetwork` flag set
     to true.

--- a/compliance/cis_eks/rules/cis_4_2_4/data.yaml
+++ b/compliance/cis_eks/rules/cis_4_2_4/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 57f22327-1ce8-57d7-ae7f-47344e970031
+  id: 8f13ab3c-ee3e-5c0a-857d-95214a2c3f71
   name: Minimize the admission of containers wishing to share the hostnetwork namespace (Automated)
   profile_applicability: |
     * Level 1

--- a/compliance/cis_eks/rules/cis_4_2_4/data.yaml
+++ b/compliance/cis_eks/rules/cis_4_2_4/data.yaml
@@ -9,17 +9,11 @@ metadata:
   rationale: |
     A container running in the host's network namespace could access the local
     loopback
-
     device, and could access network traffic to and from other pods.
-
     There should be at least one PodSecurityPolicy (PSP) defined which does not permit
-
     containers to share the host network namespace.
-
     If you have need to run containers which require hostNetwork, this should be defined in a
-
     separate PSP and you should carefully check RBAC controls to ensure that only limited
-
     service accounts and users are given permission to access that PSP.
   audit: |
     Get the set of PSPs with the following command:
@@ -36,9 +30,7 @@ metadata:
     `.spec.hostNetwork` field is omitted or set to false.
   impact: >
     Pods defined with `spec.hostNetwork: true` will not be permitted unless they
-    are run
-
-    under a specific PSP.
+    are run under a specific PSP.
   default_value: |
     By default, PodSecurityPolicies are not defined.
   references: |

--- a/compliance/cis_eks/rules/cis_4_2_4/rule.rego
+++ b/compliance/cis_eks/rules/cis_4_2_4/rule.rego
@@ -18,16 +18,3 @@ finding = result {
 		"evidence": json.filter(data_adapter.pod, ["uid", "spec/hostNetwork"]),
 	}
 }
-
-metadata = {
-	"name": "Minimize the admission of containers wishing to share the host network namespace",
-	"description": "Do not generally permit containers to be run with the hostNetwork flag set to true.",
-	"rationale": `A container running in the host's network namespace could access the local loopback device, and could access network traffic to and from other pods.
-There should be at least one PodSecurityPolicy (PSP) defined which does not permit containers to share the host network namespace.
-If you have need to run containers which require hostNetwork, this should be defined in a separate PSP and you should carefully check RBAC controls to ensure that only limited service accounts and users are given permission to access that PSP.`,
-	"impact": "Pods defined with spec.hostNetwork: true will not be permitted unless they are run under a specific PSP.",
-	"remediation": "Create a PSP as described in the Kubernetes documentation, ensuring that the .spec.hostNetwork field is omitted or set to false.",
-	"default_value": "By default, PodSecurityPolicies are not defined.",
-	"benchmark": cis_eks.benchmark_metadata,
-	"tags": array.concat(cis_eks.default_tags, ["CIS 4.2.4", "Pod Security Policies"]),
-}

--- a/compliance/cis_eks/rules/cis_4_2_4/rule.rego
+++ b/compliance/cis_eks/rules/cis_4_2_4/rule.rego
@@ -1,6 +1,5 @@
 package compliance.cis_eks.rules.cis_4_2_4
 
-import data.compliance.cis_eks
 import data.compliance.lib.assert
 import data.compliance.lib.common
 import data.compliance.lib.data_adapter

--- a/compliance/cis_eks/rules/cis_4_2_5/data.yaml
+++ b/compliance/cis_eks/rules/cis_4_2_5/data.yaml
@@ -1,0 +1,59 @@
+metadata:
+  id: 1d7ade15-2ec7-5436-b517-bf8fa815baf5
+  name: Minimize the admission of containers with allowPrivilegeEscalation (Automated)
+  profile_applicability: |
+    • Level 1
+  description: |
+    Do not generally permit containers to be run with the
+    `allowPrivilegeEscalation` flag set to true.
+  rationale: >
+    A container running with the `allowPrivilegeEscalation` flag set to `true` may
+    have
+
+    processes that can gain more privileges than their parent.
+
+    There should be at least one PodSecurityPolicy (PSP) defined which does not permit
+
+    containers to allow privilege escalation. The option exists (and is defaulted to true) to
+
+    permit setuid binaries to run.
+
+    If you have need to run containers which use setuid binaries or require privilege escalation,
+
+    this should be defined in a separate PSP and you should carefully check RBAC controls to
+
+    ensure that only limited service accounts and users are given permission to access that
+
+    PSP.
+  audit: |
+    Get the set of PSPs with the following command:
+    ```
+    kubectl get psp
+    ```
+    For each PSP, check whether privileged is enabled:
+    ```
+    kubectl get psp <name> -o=jsonpath='{.spec.allowPrivilegeEscalation}'
+    ```
+    Verify that there is at least one PSP which does not return true.
+  remediation: |
+    Create a PSP as described in the Kubernetes documentation, ensuring that the
+    `.spec.allowPrivilegeEscalation` field is omitted or set to false.
+  impact: >
+    Pods defined with `spec.allowPrivilegeEscalation: true` will not be permitted
+    unless
+
+    they are run under a specific PSP.
+  default_value: |
+    By default, PodSecurityPolicies are not defined.
+  references: |
+    1. https://kubernetes.io/docs/concepts/policy/pod-security-policy
+  section: Pod Security Policies
+  version: "1.0"
+  tags:
+  - CIS
+  - EKS
+  - CIS 4.2.5
+  - Pod Security Policies
+  benchmark:
+    name: CIS Amazon Elastic Kubernetes Service (EKS) Benchmark
+    version: v1.0.1

--- a/compliance/cis_eks/rules/cis_4_2_5/data.yaml
+++ b/compliance/cis_eks/rules/cis_4_2_5/data.yaml
@@ -2,7 +2,7 @@ metadata:
   id: 1d7ade15-2ec7-5436-b517-bf8fa815baf5
   name: Minimize the admission of containers with allowPrivilegeEscalation (Automated)
   profile_applicability: |
-    • Level 1
+    * Level 1
   description: |
     Do not generally permit containers to be run with the
     `allowPrivilegeEscalation` flag set to true.

--- a/compliance/cis_eks/rules/cis_4_2_5/data.yaml
+++ b/compliance/cis_eks/rules/cis_4_2_5/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 1d7ade15-2ec7-5436-b517-bf8fa815baf5
+  id: 2eaebbf1-4cd6-5e02-9f8d-fc2be36f3c86
   name: Minimize the admission of containers with allowPrivilegeEscalation (Automated)
   profile_applicability: |
     * Level 1

--- a/compliance/cis_eks/rules/cis_4_2_5/data.yaml
+++ b/compliance/cis_eks/rules/cis_4_2_5/data.yaml
@@ -9,21 +9,13 @@ metadata:
   rationale: >
     A container running with the `allowPrivilegeEscalation` flag set to `true` may
     have
-
     processes that can gain more privileges than their parent.
-
     There should be at least one PodSecurityPolicy (PSP) defined which does not permit
-
     containers to allow privilege escalation. The option exists (and is defaulted to true) to
-
     permit setuid binaries to run.
-
     If you have need to run containers which use setuid binaries or require privilege escalation,
-
     this should be defined in a separate PSP and you should carefully check RBAC controls to
-
     ensure that only limited service accounts and users are given permission to access that
-
     PSP.
   audit: |
     Get the set of PSPs with the following command:
@@ -40,9 +32,7 @@ metadata:
     `.spec.allowPrivilegeEscalation` field is omitted or set to false.
   impact: >
     Pods defined with `spec.allowPrivilegeEscalation: true` will not be permitted
-    unless
-
-    they are run under a specific PSP.
+    unless they are run under a specific PSP.
   default_value: |
     By default, PodSecurityPolicies are not defined.
   references: |

--- a/compliance/cis_eks/rules/cis_4_2_5/rule.rego
+++ b/compliance/cis_eks/rules/cis_4_2_5/rule.rego
@@ -1,6 +1,5 @@
 package compliance.cis_eks.rules.cis_4_2_5
 
-import data.compliance.cis_eks
 import data.compliance.lib.common
 import data.compliance.lib.data_adapter
 
@@ -27,18 +26,4 @@ finding = result {
 			"containers": {json.filter(c, ["name", "securityContext/allowPrivilegeEscalation"]) | c := data_adapter.containers[_]},
 		},
 	}
-}
-
-metadata = {
-	"name": "Minimize the admission of containers with allowPrivilegeEscalation",
-	"description": "Do not generally permit containers to be run with the allowPrivilegeEscalation flag set to true",
-	"rationale": `A container running with the allowPrivilegeEscalation flag set to true may have processes that can gain more privileges than their parent.
-There should be at least one PodSecurityPolicy (PSP) defined which does not permit containers to allow privilege escalation. The option exists (and is defaulted to true) to permit setuid binaries to run.
-If you have need to run containers which use setuid binaries or require privilege escalation,
-this should be defined in a separate PSP and you should carefully check RBAC controls to ensure that only limited service accounts and users are given permission to access that PSP.`,
-	"impact": "Pods defined with spec.allowPrivilegeEscalation: true will not be permitted unless they are run under a specific PSP.",
-	"remediation": "Create a PSP as described in the Kubernetes documentation, ensuring that the .spec.allowPrivilegeEscalation field is omitted or set to false.",
-	"default_value": "By default, PodSecurityPolicies are not defined.",
-	"benchmark": cis_eks.benchmark_metadata,
-	"tags": array.concat(cis_eks.default_tags, ["CIS 4.2.5", "Pod Security Policies"]),
 }

--- a/compliance/cis_eks/rules/cis_4_2_6/data.yaml
+++ b/compliance/cis_eks/rules/cis_4_2_6/data.yaml
@@ -2,7 +2,7 @@ metadata:
   id: 70387cdd-bce8-52f8-acc6-eac01c5b405e
   name: Minimize the admission of root containers (Automated)
   profile_applicability: |
-    • Level 2
+    * Level 2
   description: |
     Do not generally permit containers to be run as the root user.
   rationale: >

--- a/compliance/cis_eks/rules/cis_4_2_6/data.yaml
+++ b/compliance/cis_eks/rules/cis_4_2_6/data.yaml
@@ -1,0 +1,60 @@
+metadata:
+  id: 70387cdd-bce8-52f8-acc6-eac01c5b405e
+  name: Minimize the admission of root containers (Automated)
+  profile_applicability: |
+    • Level 2
+  description: |
+    Do not generally permit containers to be run as the root user.
+  rationale: >
+    Containers may run as any Linux user. Containers which run as the root user,
+    whilst
+
+    constrained by Container Runtime security features still have a escalated likelihood of
+
+    container breakout.
+
+    Ideally, all containers should run as a defined non-UID 0 user.
+
+    There should be at least one PodSecurityPolicy (PSP) defined which does not permit root
+
+    users in a container.
+
+    If you need to run root containers, this should be defined in a separate PSP and you should
+
+    carefully check RBAC controls to ensure that only limited service accounts and users are
+
+    given permission to access that PSP.
+  audit: |
+    Get the set of PSPs with the following command:
+    ```
+    kubectl get psp
+    ```
+    For each PSP, check whether running containers as root is enabled:
+    ```
+    kubectl get psp <name> -o=jsonpath='{.spec.runAsUser.rule}'
+    ```
+    Verify that there is at least one PSP which returns MustRunAsNonRoot or MustRunAs with the
+
+    range of UIDs not including 0.
+  remediation: |
+    Create a PSP as described in the Kubernetes documentation, ensuring that the
+
+    `.spec.runAsUser.rule` is set to either `MustRunAsNonRoot` or `MustRunAs` with the range of
+
+    UIDs not including 0.
+  impact: |
+    Pods with containers which run as the root user will not be permitted.
+  default_value: |
+    By default, PodSecurityPolicies are not defined.
+  references: |
+    1.https://kubernetes.io/docs/concepts/policy/pod-security-policy/#enabling-pod-security-policies
+  section: Pod Security Policies
+  version: "1.0"
+  tags:
+  - CIS
+  - EKS
+  - CIS 4.2.6
+  - Pod Security Policies
+  benchmark:
+    name: CIS Amazon Elastic Kubernetes Service (EKS) Benchmark
+    version: v1.0.1

--- a/compliance/cis_eks/rules/cis_4_2_6/data.yaml
+++ b/compliance/cis_eks/rules/cis_4_2_6/data.yaml
@@ -36,7 +36,7 @@ metadata:
   default_value: |
     By default, PodSecurityPolicies are not defined.
   references: |
-    1.https://kubernetes.io/docs/concepts/policy/pod-security-policy/#enabling-pod-security-policies
+    1. https://kubernetes.io/docs/concepts/policy/pod-security-policy/#enabling-pod-security-policies
   section: Pod Security Policies
   version: "1.0"
   tags:

--- a/compliance/cis_eks/rules/cis_4_2_6/data.yaml
+++ b/compliance/cis_eks/rules/cis_4_2_6/data.yaml
@@ -8,21 +8,13 @@ metadata:
   rationale: >
     Containers may run as any Linux user. Containers which run as the root user,
     whilst
-
     constrained by Container Runtime security features still have a escalated likelihood of
-
     container breakout.
-
     Ideally, all containers should run as a defined non-UID 0 user.
-
     There should be at least one PodSecurityPolicy (PSP) defined which does not permit root
-
     users in a container.
-
     If you need to run root containers, this should be defined in a separate PSP and you should
-
     carefully check RBAC controls to ensure that only limited service accounts and users are
-
     given permission to access that PSP.
   audit: |
     Get the set of PSPs with the following command:
@@ -34,13 +26,10 @@ metadata:
     kubectl get psp <name> -o=jsonpath='{.spec.runAsUser.rule}'
     ```
     Verify that there is at least one PSP which returns MustRunAsNonRoot or MustRunAs with the
-
     range of UIDs not including 0.
   remediation: |
     Create a PSP as described in the Kubernetes documentation, ensuring that the
-
     `.spec.runAsUser.rule` is set to either `MustRunAsNonRoot` or `MustRunAs` with the range of
-
     UIDs not including 0.
   impact: |
     Pods with containers which run as the root user will not be permitted.

--- a/compliance/cis_eks/rules/cis_4_2_6/data.yaml
+++ b/compliance/cis_eks/rules/cis_4_2_6/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 70387cdd-bce8-52f8-acc6-eac01c5b405e
+  id: dcccab00-07f8-55e8-bfa8-0f82d362e4ce
   name: Minimize the admission of root containers (Automated)
   profile_applicability: |
     * Level 2

--- a/compliance/cis_eks/rules/cis_4_2_6/data.yaml
+++ b/compliance/cis_eks/rules/cis_4_2_6/data.yaml
@@ -25,7 +25,7 @@ metadata:
     ```
     kubectl get psp <name> -o=jsonpath='{.spec.runAsUser.rule}'
     ```
-    Verify that there is at least one PSP which returns MustRunAsNonRoot or MustRunAs with the
+    Verify that there is at least one PSP which returns `MustRunAsNonRoot` or `MustRunAs` with the
     range of UIDs not including 0.
   remediation: |
     Create a PSP as described in the Kubernetes documentation, ensuring that the

--- a/compliance/cis_eks/rules/cis_4_2_6/rule.rego
+++ b/compliance/cis_eks/rules/cis_4_2_6/rule.rego
@@ -1,6 +1,5 @@
 package compliance.cis_eks.rules.cis_4_2_6
 
-import data.compliance.cis_eks
 import data.compliance.lib.common
 import data.compliance.lib.data_adapter
 
@@ -33,18 +32,4 @@ finding = result {
 		"evaluation": common.calculate_result(rule_evaluation),
 		"evidence": object.union(pod, containers),
 	}
-}
-
-metadata = {
-	"name": "Minimize the admission of root containers",
-	"description": "Do not generally permit containers to be run as the root user.",
-	"rationale": `Containers may run as any Linux user. Containers which run as the root user, whilst constrained by Container Runtime security features still have a escalated likelihood of container breakout.
-Ideally, all containers should run as a defined non-UID 0 user.
-There should be at least one PodSecurityPolicy (PSP) defined which does not permit root users in a container.
-If you need to run root containers, this should be defined in a separate PSP and you should carefully check RBAC controls to ensure that only limited service accounts and users are given permission to access that PSP.`,
-	"impact": "Pods with containers which run as the root user will not be permitted.",
-	"remediation": "Create a PSP as described in the Kubernetes documentation, ensuring that the .spec.runAsUser.rule is set to either MustRunAsNonRoot or MustRunAs with the range of UIDs not including 0.",
-	"default_value": "By default, PodSecurityPolicies are not defined.",
-	"benchmark": cis_eks.benchmark_metadata,
-	"tags": array.concat(cis_eks.default_tags, ["CIS 4.2.6", "Pod Security Policies"]),
 }

--- a/compliance/cis_eks/rules/cis_4_2_7/data.yaml
+++ b/compliance/cis_eks/rules/cis_4_2_7/data.yaml
@@ -9,23 +9,14 @@ metadata:
   rationale: >
     Containers run with a default set of capabilities as assigned by the
     Container Runtime. By
-
     default this can include potentially dangerous capabilities. With Docker as the container
-
     runtime the NET_RAW capability is enabled which may be misused by malicious
-
     containers.
-
     Ideally, all containers should drop this capability.
-
     There should be at least one PodSecurityPolicy (PSP) defined which prevents containers
-
     with the NET_RAW capability from launching.
-
     If you need to run containers with this capability, this should be defined in a separate PSP
-
     and you should carefully check RBAC controls to ensure that only limited service accounts
-
     and users are given permission to access that PSP.
   audit: |
     Get the set of PSPs with the following command:
@@ -47,7 +38,6 @@ metadata:
     By default, PodSecurityPolicies are not defined.
   references: |
     1.https://kubernetes.io/docs/concepts/policy/pod-security-policy/#enabling-pod-security-policies
-
     2. https://www.nccgroup.trust/uk/our-research/abusing-privileged-and-unprivileged-linux-containers/
   section: Pod Security Policies
   version: "1.0"

--- a/compliance/cis_eks/rules/cis_4_2_7/data.yaml
+++ b/compliance/cis_eks/rules/cis_4_2_7/data.yaml
@@ -1,6 +1,6 @@
 metadata:
-  id: 4c94ad80-79b7-58e3-99a0-1d761163b7d2
-  name: Minimize the admission of containers with the NET_RAWcapability (Automated)
+  id: a3cd45ae-ba6b-564a-bd85-810efbbe5cea
+  name: Minimize the admission of containers with the NET_RAW capability (Automated)
   profile_applicability: |
     * Level 1
   description: |
@@ -37,7 +37,7 @@ metadata:
   default_value: |
     By default, PodSecurityPolicies are not defined.
   references: |
-    1.https://kubernetes.io/docs/concepts/policy/pod-security-policy/#enabling-pod-security-policies
+    1. https://kubernetes.io/docs/concepts/policy/pod-security-policy/#enabling-pod-security-policies
     2. https://www.nccgroup.trust/uk/our-research/abusing-privileged-and-unprivileged-linux-containers/
   section: Pod Security Policies
   version: "1.0"

--- a/compliance/cis_eks/rules/cis_4_2_7/data.yaml
+++ b/compliance/cis_eks/rules/cis_4_2_7/data.yaml
@@ -2,7 +2,7 @@ metadata:
   id: 5b5f285a-772e-50f7-bda8-1965f7ef216c
   name: Minimize the admission of containers with the NET_RAWcapability (Automated)
   profile_applicability: |
-    • Level 1
+    * Level 1
   description: |
     Do not generally permit containers with the potentially dangerous NET_RAW
     capability.

--- a/compliance/cis_eks/rules/cis_4_2_7/data.yaml
+++ b/compliance/cis_eks/rules/cis_4_2_7/data.yaml
@@ -1,0 +1,61 @@
+metadata:
+  id: 5b5f285a-772e-50f7-bda8-1965f7ef216c
+  name: Minimize the admission of containers with the NET_RAWcapability (Automated)
+  profile_applicability: |
+    • Level 1
+  description: |
+    Do not generally permit containers with the potentially dangerous NET_RAW
+    capability.
+  rationale: >
+    Containers run with a default set of capabilities as assigned by the
+    Container Runtime. By
+
+    default this can include potentially dangerous capabilities. With Docker as the container
+
+    runtime the NET_RAW capability is enabled which may be misused by malicious
+
+    containers.
+
+    Ideally, all containers should drop this capability.
+
+    There should be at least one PodSecurityPolicy (PSP) defined which prevents containers
+
+    with the NET_RAW capability from launching.
+
+    If you need to run containers with this capability, this should be defined in a separate PSP
+
+    and you should carefully check RBAC controls to ensure that only limited service accounts
+
+    and users are given permission to access that PSP.
+  audit: |
+    Get the set of PSPs with the following command:
+    ```
+    kubectl get psp
+    ```
+    For each PSP, check whether NET_RAW is disabled:
+    ```
+    kubectl get psp <name> -o=jsonpath='{.spec.requiredDropCapabilities}'
+    ```
+    Verify that there is at least one PSP which returns NET_RAW or ALL.
+  remediation: |
+    Create a PSP as described in the Kubernetes documentation, ensuring that the
+    `.spec.requiredDropCapabilities` is set to include either `NET_RAW` or `ALL`.
+  impact: |
+    Pods with containers which run with the NET_RAW capability will not be
+    permitted.
+  default_value: |
+    By default, PodSecurityPolicies are not defined.
+  references: |
+    1.https://kubernetes.io/docs/concepts/policy/pod-security-policy/#enabling-pod-security-policies
+
+    2. https://www.nccgroup.trust/uk/our-research/abusing-privileged-and-unprivileged-linux-containers/
+  section: Pod Security Policies
+  version: "1.0"
+  tags:
+  - CIS
+  - EKS
+  - CIS 4.2.7
+  - Pod Security Policies
+  benchmark:
+    name: CIS Amazon Elastic Kubernetes Service (EKS) Benchmark
+    version: v1.0.1

--- a/compliance/cis_eks/rules/cis_4_2_7/data.yaml
+++ b/compliance/cis_eks/rules/cis_4_2_7/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 5b5f285a-772e-50f7-bda8-1965f7ef216c
+  id: 4c94ad80-79b7-58e3-99a0-1d761163b7d2
   name: Minimize the admission of containers with the NET_RAWcapability (Automated)
   profile_applicability: |
     * Level 1

--- a/compliance/cis_eks/rules/cis_4_2_7/rule.rego
+++ b/compliance/cis_eks/rules/cis_4_2_7/rule.rego
@@ -1,6 +1,5 @@
 package compliance.cis_eks.rules.cis_4_2_7
 
-import data.compliance.cis_eks
 import data.compliance.lib.common
 import data.compliance.lib.data_adapter
 
@@ -30,21 +29,4 @@ finding = result {
 		"evaluation": common.calculate_result(rule_evaluation),
 		"evidence": json.filter(data_adapter.pod, ["uid", "spec/requiredDropCapabilities"]),
 	}
-}
-
-metadata = {
-	"name": "Minimize the admission of containers with the NET_RAW capability",
-	"description": "Do not generally permit containers with the potentially dangerous NET_RAW capability.",
-	"rationale": `Containers run with a default set of capabilities as assigned by the Container Runtime.
-By default this can include potentially dangerous capabilities.
-With Docker as the container runtime the NET_RAW capability is enabled which may be misused by malicious containers.
-Ideally, all containers should drop this capability.
-There should be at least one PodSecurityPolicy (PSP) defined which prevents containers with the NET_RAW capability from launching.
-If you need to run containers with this capability,
-this should be defined in a separate PSP and you should carefully check RBAC controls to ensure that only limited service accounts and users are given permission to access that PSP.`,
-	"impact": "Pods with containers which run with the NET_RAW capability will not be permitted.",
-	"remediation": "Create a PSP as described in the Kubernetes documentation, ensuring that the .spec.requiredDropCapabilities is set to include either NET_RAW or ALL.",
-	"default_value": "By default, PodSecurityPolicies are not defined.",
-	"benchmark": cis_eks.benchmark_metadata,
-	"tags": array.concat(cis_eks.default_tags, ["CIS 4.2.7", "Pod Security Policies"]),
 }

--- a/compliance/cis_eks/rules/cis_4_2_8/data.yaml
+++ b/compliance/cis_eks/rules/cis_4_2_8/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 6962c99c-c5dd-5d8f-a118-f45108875e78
+  id: a7e49914-1cab-599f-8d8a-bce7d808dc66
   name: Minimize the admission of containers with added capabilities (Automated)
   profile_applicability: |
     * Level 1

--- a/compliance/cis_eks/rules/cis_4_2_8/data.yaml
+++ b/compliance/cis_eks/rules/cis_4_2_8/data.yaml
@@ -1,0 +1,58 @@
+metadata:
+  id: 6962c99c-c5dd-5d8f-a118-f45108875e78
+  name: Minimize the admission of containers with added capabilities (Automated)
+  profile_applicability: |
+    • Level 1
+  description: |
+    Do not generally permit containers with capabilities assigned beyond the
+    default set.
+  rationale: >
+    Containers run with a default set of capabilities as assigned by the
+    Container Runtime.
+
+    Capabilities outside this set can be added to containers which could expose them to risks of
+
+    container breakout attacks.
+
+    There should be at least one PodSecurityPolicy (PSP) defined which prevents containers
+
+    with capabilities beyond the default set from launching.
+
+    If you need to run containers with additional capabilities, this should be defined in a
+
+    separate PSP and you should carefully check RBAC controls to ensure that only limited
+
+    service accounts and users are given permission to access that PSP.
+  audit: |
+    Get the set of PSPs with the following command:
+    ```
+    kubectl get psp
+    ```
+    Verify that there are no PSPs present which have `allowedCapabilities` set to anything
+
+    other than an empty array.
+  remediation: |
+    Ensure that `allowedCapabilities` is not present in PSPs for the cluster
+    unless it is set to an
+
+    empty array.
+  impact: >
+    Pods with containers which require capabilities outwith the default set will
+    not be
+
+    permitted.
+  default_value: |
+    By default, PodSecurityPolicies are not defined.
+  references: |
+    1.https://kubernetes.io/docs/concepts/policy/pod-security-policy/#enabling-pod-security-policies
+    2. https://www.nccgroup.trust/uk/our-research/abusing-privileged-and-unprivileged-linux-containers/
+  section: Pod Security Policies
+  version: "1.0"
+  tags:
+  - CIS
+  - EKS
+  - CIS 4.2.8
+  - Pod Security Policies
+  benchmark:
+    name: CIS Amazon Elastic Kubernetes Service (EKS) Benchmark
+    version: v1.0.1

--- a/compliance/cis_eks/rules/cis_4_2_8/data.yaml
+++ b/compliance/cis_eks/rules/cis_4_2_8/data.yaml
@@ -9,19 +9,12 @@ metadata:
   rationale: >
     Containers run with a default set of capabilities as assigned by the
     Container Runtime.
-
     Capabilities outside this set can be added to containers which could expose them to risks of
-
     container breakout attacks.
-
     There should be at least one PodSecurityPolicy (PSP) defined which prevents containers
-
     with capabilities beyond the default set from launching.
-
     If you need to run containers with additional capabilities, this should be defined in a
-
     separate PSP and you should carefully check RBAC controls to ensure that only limited
-
     service accounts and users are given permission to access that PSP.
   audit: |
     Get the set of PSPs with the following command:
@@ -29,18 +22,14 @@ metadata:
     kubectl get psp
     ```
     Verify that there are no PSPs present which have `allowedCapabilities` set to anything
-
     other than an empty array.
   remediation: |
     Ensure that `allowedCapabilities` is not present in PSPs for the cluster
     unless it is set to an
-
     empty array.
   impact: >
     Pods with containers which require capabilities outwith the default set will
-    not be
-
-    permitted.
+    not be permitted.
   default_value: |
     By default, PodSecurityPolicies are not defined.
   references: |

--- a/compliance/cis_eks/rules/cis_4_2_8/data.yaml
+++ b/compliance/cis_eks/rules/cis_4_2_8/data.yaml
@@ -2,7 +2,7 @@ metadata:
   id: 6962c99c-c5dd-5d8f-a118-f45108875e78
   name: Minimize the admission of containers with added capabilities (Automated)
   profile_applicability: |
-    • Level 1
+    * Level 1
   description: |
     Do not generally permit containers with capabilities assigned beyond the
     default set.

--- a/compliance/cis_eks/rules/cis_4_2_8/data.yaml
+++ b/compliance/cis_eks/rules/cis_4_2_8/data.yaml
@@ -33,7 +33,7 @@ metadata:
   default_value: |
     By default, PodSecurityPolicies are not defined.
   references: |
-    1.https://kubernetes.io/docs/concepts/policy/pod-security-policy/#enabling-pod-security-policies
+    1. https://kubernetes.io/docs/concepts/policy/pod-security-policy/#enabling-pod-security-policies
     2. https://www.nccgroup.trust/uk/our-research/abusing-privileged-and-unprivileged-linux-containers/
   section: Pod Security Policies
   version: "1.0"

--- a/compliance/cis_eks/rules/cis_4_2_8/rule.rego
+++ b/compliance/cis_eks/rules/cis_4_2_8/rule.rego
@@ -1,6 +1,5 @@
 package compliance.cis_eks.rules.cis_4_2_8
 
-import data.compliance.cis_eks
 import data.compliance.lib.assert
 import data.compliance.lib.common
 import data.compliance.lib.data_adapter
@@ -20,18 +19,4 @@ finding = result {
 		"evaluation": common.calculate_result(rule_evaluation),
 		"evidence": json.filter(data_adapter.pod, ["uid", "spec/allowedCapabilities"]),
 	}
-}
-
-metadata = {
-	"name": "Minimize the admission of containers with added capabilities",
-	"description": "Do not generally permit containers with capabilities assigned beyond the default set.",
-	"rationale": `Containers run with a default set of capabilities as assigned by the Container Runtime.
-Capabilities outside this set can be added to containers which could expose them to risks of container breakout attacks.
-There should be at least one PodSecurityPolicy (PSP) defined which prevents containers with capabilities beyond the default set from launching.
-If you need to run containers with additional capabilities, this should be defined in a separate PSP and you should carefully check RBAC controls to ensure that only limited service accounts and users are given permission to access that PSP.`,
-	"impact": "Pods with containers which require capabilities outwith the default set will not be permitted.",
-	"remediation": "Ensure that allowedCapabilities is not present in PSPs for the cluster unless it is set to an empty array.",
-	"default_value": "By default, PodSecurityPolicies are not defined.",
-	"benchmark": cis_eks.benchmark_metadata,
-	"tags": array.concat(cis_eks.default_tags, ["CIS 4.2.8", "Pod Security Policies"]),
 }

--- a/compliance/cis_eks/rules/cis_4_2_9/data.yaml
+++ b/compliance/cis_eks/rules/cis_4_2_9/data.yaml
@@ -22,16 +22,16 @@ metadata:
     kubectl get psp <name> -o=jsonpath='{.spec.requiredDropCapabilities}'
     ```
   remediation: >
-    Review the use of capabilites in applications runnning on your cluster.
+    Review the use of capabilities in applications running on your cluster.
     Where a namespace
-    contains applicaions which do not require any Linux capabities to operate consider adding
+    contains applications which do not require any Linux capabilities to operate consider adding
     a PSP which forbids the admission of containers which do not drop all capabilities.
   impact: |
     Pods with containers require capabilities to operate will not be permitted.
   default_value: |
     By default, PodSecurityPolicies are not defined.
   references: |
-    1.https://kubernetes.io/docs/concepts/policy/pod-security-policy/#enabling-pod-security-policies
+    1. https://kubernetes.io/docs/concepts/policy/pod-security-policy/#enabling-pod-security-policies
     2. https://www.nccgroup.trust/uk/our-research/abusing-privileged-and-unprivileged-linux-containers/
   section: Pod Security Policies
   version: "1.0"

--- a/compliance/cis_eks/rules/cis_4_2_9/data.yaml
+++ b/compliance/cis_eks/rules/cis_4_2_9/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: e6d9726b-acca-54da-9d2f-9eb2648ed7ea
+  id: 26dba6c5-6823-56ac-8ea2-40a977bc6a5e
   name: Minimize the admission of containers with capabilities assigned (Manual)
   profile_applicability: |
     * Level 2

--- a/compliance/cis_eks/rules/cis_4_2_9/data.yaml
+++ b/compliance/cis_eks/rules/cis_4_2_9/data.yaml
@@ -8,13 +8,9 @@ metadata:
   rationale: >
     Containers run with a default set of capabilities as assigned by the
     Container Runtime.
-
     Capabilities are parts of the rights generally granted on a Linux system to the root user.
-
     In many cases applications running in containers do not require any capabilities to operate,
-
     so from the perspective of the principal of least privilege use of capabilities should be
-
     minimized.
   audit: |
     Get the set of PSPs with the following command:
@@ -28,9 +24,7 @@ metadata:
   remediation: >
     Review the use of capabilites in applications runnning on your cluster.
     Where a namespace
-
     contains applicaions which do not require any Linux capabities to operate consider adding
-
     a PSP which forbids the admission of containers which do not drop all capabilities.
   impact: |
     Pods with containers require capabilities to operate will not be permitted.
@@ -38,7 +32,6 @@ metadata:
     By default, PodSecurityPolicies are not defined.
   references: |
     1.https://kubernetes.io/docs/concepts/policy/pod-security-policy/#enabling-pod-security-policies
-
     2. https://www.nccgroup.trust/uk/our-research/abusing-privileged-and-unprivileged-linux-containers/
   section: Pod Security Policies
   version: "1.0"

--- a/compliance/cis_eks/rules/cis_4_2_9/data.yaml
+++ b/compliance/cis_eks/rules/cis_4_2_9/data.yaml
@@ -1,0 +1,52 @@
+metadata:
+  id: e6d9726b-acca-54da-9d2f-9eb2648ed7ea
+  name: Minimize the admission of containers with capabilities assigned (Manual)
+  profile_applicability: |
+    • Level 2
+  description: |
+    Do not generally permit containers with capabilities
+  rationale: >
+    Containers run with a default set of capabilities as assigned by the
+    Container Runtime.
+
+    Capabilities are parts of the rights generally granted on a Linux system to the root user.
+
+    In many cases applications running in containers do not require any capabilities to operate,
+
+    so from the perspective of the principal of least privilege use of capabilities should be
+
+    minimized.
+  audit: |
+    Get the set of PSPs with the following command:
+    ```
+    kubectl get psp
+    ```
+    For each PSP, check whether capabilities have been forbidden:
+    ```
+    kubectl get psp <name> -o=jsonpath='{.spec.requiredDropCapabilities}'
+    ```
+  remediation: >
+    Review the use of capabilites in applications runnning on your cluster.
+    Where a namespace
+
+    contains applicaions which do not require any Linux capabities to operate consider adding
+
+    a PSP which forbids the admission of containers which do not drop all capabilities.
+  impact: |
+    Pods with containers require capabilities to operate will not be permitted.
+  default_value: |
+    By default, PodSecurityPolicies are not defined.
+  references: |
+    1.https://kubernetes.io/docs/concepts/policy/pod-security-policy/#enabling-pod-security-policies
+
+    2. https://www.nccgroup.trust/uk/our-research/abusing-privileged-and-unprivileged-linux-containers/
+  section: Pod Security Policies
+  version: "1.0"
+  tags:
+  - CIS
+  - EKS
+  - CIS 4.2.9
+  - Pod Security Policies
+  benchmark:
+    name: CIS Amazon Elastic Kubernetes Service (EKS) Benchmark
+    version: v1.0.1

--- a/compliance/cis_eks/rules/cis_4_2_9/data.yaml
+++ b/compliance/cis_eks/rules/cis_4_2_9/data.yaml
@@ -2,7 +2,7 @@ metadata:
   id: e6d9726b-acca-54da-9d2f-9eb2648ed7ea
   name: Minimize the admission of containers with capabilities assigned (Manual)
   profile_applicability: |
-    • Level 2
+    * Level 2
   description: |
     Do not generally permit containers with capabilities
   rationale: >

--- a/compliance/cis_eks/rules/cis_4_2_9/rule.rego
+++ b/compliance/cis_eks/rules/cis_4_2_9/rule.rego
@@ -1,6 +1,5 @@
 package compliance.cis_eks.rules.cis_4_2_9
 
-import data.compliance.cis_eks
 import data.compliance.lib.assert
 import data.compliance.lib.common
 import data.compliance.lib.data_adapter
@@ -25,19 +24,4 @@ finding = result {
 		"evaluation": common.calculate_result(rule_evaluation),
 		"containers": {json.filter(c, ["name", "securityContext/capabilities"]) | c := data_adapter.containers[_]},
 	}
-}
-
-metadata = {
-	"name": "Minimize the admission of containers with capabilities assigned",
-	"description": "Do not generally permit containers with capabilities",
-	"rationale": `Containers run with a default set of capabilities as assigned by the Container Runtime.
-Capabilities are parts of the rights generally granted on a Linux system to the root user.
-In many cases applications running in containers do not require any capabilities to operate,
-so from the perspective of the principal of least privilege use of capabilities should be minimized.`,
-	"impact": "Pods with containers require capabilities to operate will not be permitted.",
-	"remediation": `Review the use of capabilities in applications running on your cluster.
-Where a namespace contains applications which do not require any Linux capabilities to operate consider adding a PSP which forbids the admission of containers which do not drop all capabilities.`,
-	"default_value": "By default, PodSecurityPolicies are not defined.",
-	"benchmark": cis_eks.benchmark_metadata,
-	"tags": array.concat(cis_eks.default_tags, ["CIS 4.2.9", "Pod Security Policies"]),
 }

--- a/compliance/cis_eks/rules/cis_5_1_1/data.yaml
+++ b/compliance/cis_eks/rules/cis_5_1_1/data.yaml
@@ -1,0 +1,93 @@
+metadata:
+  id: 38666df7-2440-595d-8e5b-0b51ab1c6178
+  name: Ensure Image Vulnerability Scanning using Amazon ECR imagescanning or a third party provider (Manual)
+  profile_applicability: |
+    • Level 1
+  description: |
+    Scan images being deployed to Amazon EKS for vulnerabilities.
+  rationale: >
+    Vulnerabilities in software packages can be exploited by hackers or
+    malicious users to
+
+    obtain unauthorized access to local cloud resources. Amazon ECR and other third party
+
+    products allow images to be scanned for known vulnerabilities.
+  audit: >
+    Please follow AWS ECS or your 3rd party image scanning provider's guidelines
+    for enabling
+
+    Image Scanning.
+  remediation: |
+    To utilize AWS ECR for Image scanning please follow the steps below:
+
+    To create a repository configured for scan on push (AWS CLI)
+    ```
+    aws ecr create-repository --repository-name $REPO_NAME --image-scanning-
+    
+    configuration scanOnPush=true --region $REGION_CODE
+    ```
+    To edit the settings of an existing repository (AWS CLI)
+    ```
+    aws ecr put-image-scanning-configuration --repository-name $REPO_NAME --
+
+    image-scanning-configuration scanOnPush=true --region $REGION_CODE
+    ```
+    Use the following steps to start a manual image scan using the AWS Management Console.
+
+    1. Open the Amazon ECR console at
+
+    https://console.aws.amazon.com/ecr/repositories.
+
+    2. From the navigation bar, choose the Region to create your repository in.
+
+    3. In the navigation pane, choose Repositories.
+
+    4. On the Repositories page, choose the repository that contains the image to scan.
+
+    5. On the Images page, select the image to scan and then choose Scan.
+  impact: |
+    If you are utilizing AWS ECR
+
+    The following are common image scan failures. You can view errors like this in the Amazon
+
+    ECR console by displaying the image details or through the API or AWS CLI by using the
+
+    DescribeImageScanFindings API.
+
+    UnsupportedImageError You may get an UnsupportedImageError error when attempting
+
+    to scan an image that was built using an operating system that Amazon ECR doesn't
+
+    support image scanning for. Amazon ECR supports package vulnerability scanning for
+
+    major versions of Amazon Linux, Amazon Linux 2, Debian, Ubuntu, CentOS, Oracle Linux,
+
+    Alpine, and RHEL Linux distributions. Amazon ECR does not support scanning images built
+
+    from the Docker scratch image.
+
+    An UNDEFINED severity level is returned You may receive a scan finding that has a severity
+
+    level of UNDEFINED. The following are the common causes for this:
+
+    The vulnerability was not assigned a priority by the CVE source.
+
+    The vulnerability was assigned a priority that Amazon ECR did not recognize.
+
+    To determine the severity and description of a vulnerability, you can view the CVE directly
+
+    from the source.
+  default_value: |
+    Images are not scanned by Default.
+  references: |
+    1. https://docs.aws.amazon.com/AmazonECR/latest/userguide/image-scanning.html
+  section: Image Registry and Image Scanning
+  version: "1.0"
+  tags:
+  - CIS
+  - EKS
+  - CIS 5.1.1
+  - Image Registry and Image Scanning
+  benchmark:
+    name: CIS Amazon Elastic Kubernetes Service (EKS) Benchmark
+    version: v1.0.1

--- a/compliance/cis_eks/rules/cis_5_1_1/data.yaml
+++ b/compliance/cis_eks/rules/cis_5_1_1/data.yaml
@@ -8,74 +8,46 @@ metadata:
   rationale: >
     Vulnerabilities in software packages can be exploited by hackers or
     malicious users to
-
     obtain unauthorized access to local cloud resources. Amazon ECR and other third party
-
     products allow images to be scanned for known vulnerabilities.
   audit: >
     Please follow AWS ECS or your 3rd party image scanning provider's guidelines
-    for enabling
-
-    Image Scanning.
+    for enabling Image Scanning.
   remediation: |
     To utilize AWS ECR for Image scanning please follow the steps below:
-
     To create a repository configured for scan on push (AWS CLI)
     ```
     aws ecr create-repository --repository-name $REPO_NAME --image-scanning-
-    
     configuration scanOnPush=true --region $REGION_CODE
     ```
     To edit the settings of an existing repository (AWS CLI)
     ```
     aws ecr put-image-scanning-configuration --repository-name $REPO_NAME --
-
     image-scanning-configuration scanOnPush=true --region $REGION_CODE
     ```
     Use the following steps to start a manual image scan using the AWS Management Console.
-
     1. Open the Amazon ECR console at
-
     https://console.aws.amazon.com/ecr/repositories.
-
     2. From the navigation bar, choose the Region to create your repository in.
-
     3. In the navigation pane, choose Repositories.
-
     4. On the Repositories page, choose the repository that contains the image to scan.
-
     5. On the Images page, select the image to scan and then choose Scan.
   impact: |
     If you are utilizing AWS ECR
-
     The following are common image scan failures. You can view errors like this in the Amazon
-
     ECR console by displaying the image details or through the API or AWS CLI by using the
-
     DescribeImageScanFindings API.
-
     UnsupportedImageError You may get an UnsupportedImageError error when attempting
-
     to scan an image that was built using an operating system that Amazon ECR doesn't
-
     support image scanning for. Amazon ECR supports package vulnerability scanning for
-
     major versions of Amazon Linux, Amazon Linux 2, Debian, Ubuntu, CentOS, Oracle Linux,
-
     Alpine, and RHEL Linux distributions. Amazon ECR does not support scanning images built
-
     from the Docker scratch image.
-
     An UNDEFINED severity level is returned You may receive a scan finding that has a severity
-
     level of UNDEFINED. The following are the common causes for this:
-
     The vulnerability was not assigned a priority by the CVE source.
-
     The vulnerability was assigned a priority that Amazon ECR did not recognize.
-
     To determine the severity and description of a vulnerability, you can view the CVE directly
-
     from the source.
   default_value: |
     Images are not scanned by Default.

--- a/compliance/cis_eks/rules/cis_5_1_1/data.yaml
+++ b/compliance/cis_eks/rules/cis_5_1_1/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 38666df7-2440-595d-8e5b-0b51ab1c6178
+  id: af4cc6d6-dd53-5b13-9a13-8987e5453a16
   name: Ensure Image Vulnerability Scanning using Amazon ECR imagescanning or a third party provider (Manual)
   profile_applicability: |
     * Level 1

--- a/compliance/cis_eks/rules/cis_5_1_1/data.yaml
+++ b/compliance/cis_eks/rules/cis_5_1_1/data.yaml
@@ -1,6 +1,6 @@
 metadata:
-  id: af4cc6d6-dd53-5b13-9a13-8987e5453a16
-  name: Ensure Image Vulnerability Scanning using Amazon ECR imagescanning or a third party provider (Manual)
+  id: a8592cf4-d913-5906-8499-dc1d5a410e2f
+  name: Ensure Image Vulnerability Scanning using Amazon ECR image scanning or a third party provider (Manual)
   profile_applicability: |
     * Level 1
   description: |

--- a/compliance/cis_eks/rules/cis_5_1_1/data.yaml
+++ b/compliance/cis_eks/rules/cis_5_1_1/data.yaml
@@ -2,7 +2,7 @@ metadata:
   id: 38666df7-2440-595d-8e5b-0b51ab1c6178
   name: Ensure Image Vulnerability Scanning using Amazon ECR imagescanning or a third party provider (Manual)
   profile_applicability: |
-    • Level 1
+    * Level 1
   description: |
     Scan images being deployed to Amazon EKS for vulnerabilities.
   rationale: >

--- a/compliance/cis_eks/rules/cis_5_1_1/rule.rego
+++ b/compliance/cis_eks/rules/cis_5_1_1/rule.rego
@@ -1,6 +1,5 @@
 package compliance.cis_eks.rules.cis_5_1_1
 
-import data.compliance.cis_eks
 import data.compliance.cis_eks.data_adapter
 import data.compliance.lib.assert
 import data.compliance.lib.common
@@ -33,38 +32,4 @@ finding = result {
 		"evaluation": common.calculate_result(rule_evaluation),
 		"evidence": evidence,
 	}
-}
-
-metadata = {
-	"name": "Ensure Image Vulnerability Scanning using Amazon ECR image scanning or a third party providers",
-	"description": "Scan images being deployed to Amazon EKS for vulnerabilities.",
-	"rationale": `Vulnerabilities in software packages can be exploited by hackers or malicious users to obtain unauthorized access to local cloud resources.
-Amazon ECR and other third party products allow images to be scanned for known vulnerabilities.`,
-	"remediation": `To utilize AWS ECR for Image scanning please follow the steps below:
-To create a repository configured for scan on push (AWS CLI)
-
-aws ecr create-repository --repository-name $REPO_NAME --image-scanning-configuration scanOnPush=true --region $REGION_CODE
-
-To edit the settings of an existing repository (AWS CLI)
-
-aws ecr put-image-scanning-configuration --repository-name $REPO_NAME --image-scanning-configuration scanOnPush=true --region $REGION_CODE
-Use the following steps to start a manual image scan using the AWS Management Console.
-1. Open the Amazon ECR console at https://console.aws.amazon.com/ecr/repositories.
-2. From the navigation bar, choose the Region to create your repository in.
-3. In the navigation pane, choose Repositories.
-4. On the Repositories page, choose the repository that contains the image to scan.
-5. On the Images page, select the image to scan and then choose Scan.`,
-	"tags": array.concat(cis_eks.default_tags, ["CIS 5.1.1", "Image Registry and Image Scanning"]),
-	"default_value": "Images are not scanned by Default.",
-	"benchmark": cis_eks.benchmark_metadata,
-	"impact": `If you are utilizing AWS ECR The following are common image scan failures.
-You can view errors like this in the Amazon ECR console by displaying the image details or through the API or AWS CLI by using the DescribeImageScanFindings API.
-UnsupportedImageError You may get an UnsupportedImageError error when attempting to scan an image that was built using an operating system that Amazon ECR doesn't support image scanning for.
-Amazon ECR supports package vulnerability scanning for major versions of Amazon Linux, Amazon Linux 2, Debian, Ubuntu, CentOS, Oracle Linux, Alpine, and RHEL Linux distributions.
-Amazon ECR does not support scanning images built from the Docker scratch image.
-An UNDEFINED severity level is returned You may receive a scan finding that has a severity level of UNDEFINED.
-The following are the common causes for this:
-The vulnerability was not assigned a priority by the CVE source.
-The vulnerability was assigned a priority that Amazon ECR did not recognize.
-To determine the severity and description of a vulnerability, you can view the CVE directly from the source.`,
 }

--- a/compliance/cis_eks/rules/cis_5_3_1/data.yaml
+++ b/compliance/cis_eks/rules/cis_5_3_1/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: d7a57d4f-6bc8-5cbf-a1d7-97120fcbec94
+  id: 7169a9b3-0f98-5b5e-a95b-bfd1d3322817
   name: Ensure Kubernetes Secrets are encrypted using Customer MasterKeys (CMKs) managed in AWS KMS (Automated)
   profile_applicability: |
     * Level 1

--- a/compliance/cis_eks/rules/cis_5_3_1/data.yaml
+++ b/compliance/cis_eks/rules/cis_5_3_1/data.yaml
@@ -2,7 +2,7 @@ metadata:
   id: d7a57d4f-6bc8-5cbf-a1d7-97120fcbec94
   name: Ensure Kubernetes Secrets are encrypted using Customer MasterKeys (CMKs) managed in AWS KMS (Automated)
   profile_applicability: |
-    • Level 1
+    * Level 1
   description: >
     Encrypt Kubernetes secrets, stored in etcd, using secrets encryption feature
     during

--- a/compliance/cis_eks/rules/cis_5_3_1/data.yaml
+++ b/compliance/cis_eks/rules/cis_5_3_1/data.yaml
@@ -54,6 +54,7 @@ metadata:
     in the links
 
     within the 'References' section.
+  impact : ""
   default_value: |
     By default, Application-layer Secrets Encryption is not enabled.
   references: |

--- a/compliance/cis_eks/rules/cis_5_3_1/data.yaml
+++ b/compliance/cis_eks/rules/cis_5_3_1/data.yaml
@@ -6,45 +6,28 @@ metadata:
   description: >
     Encrypt Kubernetes secrets, stored in etcd, using secrets encryption feature
     during
-
     Amazon EKS cluster creation.
   rationale: |
     Kubernetes can store secrets that pods can access via a mounted volume.
     Today,
-
     Kubernetes secrets are stored with Base64 encoding, but encrypting is the recommended
-
     approach. Amazon EKS clusters version 1.13 and higher support the capability of
-
     encrypting your Kubernetes secrets using AWS Key Management Service (KMS) Customer
-
     Managed Keys (CMK). The only requirement is to enable the encryption provider support
-
     during EKS cluster creation.
-
     Use AWS Key Management Service (KMS) keys to provide envelope encryption of
-
     Kubernetes secrets stored in Amazon EKS. Implementing envelope encryption is
-
     considered a security best practice for applications that store sensitive data and is part of a
-
     defense in depth security strategy.
-
     Application-layer Secrets Encryption provides an additional layer of security for sensitive
-
     data, such as user defined Secrets and Secrets required for the operation of the cluster,
-
     such as service account keys, which are all stored in etcd.
-
     Using this functionality, you can use a key, that you manage in AWS KMS, to encrypt data at
-
     the application layer. This protects against attackers in the event that they manage to gain
-
     access to etcd.
   audit: |
     For Amazon EKS clusters with Secrets Encryption enabled, look for
     'encryptionConfig'
-
     configuration when you run:
     ```
     aws eks describe-cluster --name="<cluster-name>"
@@ -52,7 +35,6 @@ metadata:
   remediation: >
     Enable 'Secrets Encryption' during Amazon EKS cluster creation as described
     in the links
-
     within the 'References' section.
   impact : ""
   default_value: |

--- a/compliance/cis_eks/rules/cis_5_3_1/data.yaml
+++ b/compliance/cis_eks/rules/cis_5_3_1/data.yaml
@@ -1,0 +1,71 @@
+metadata:
+  id: d7a57d4f-6bc8-5cbf-a1d7-97120fcbec94
+  name: Ensure Kubernetes Secrets are encrypted using Customer MasterKeys (CMKs) managed in AWS KMS (Automated)
+  profile_applicability: |
+    • Level 1
+  description: >
+    Encrypt Kubernetes secrets, stored in etcd, using secrets encryption feature
+    during
+
+    Amazon EKS cluster creation.
+  rationale: |
+    Kubernetes can store secrets that pods can access via a mounted volume.
+    Today,
+
+    Kubernetes secrets are stored with Base64 encoding, but encrypting is the recommended
+
+    approach. Amazon EKS clusters version 1.13 and higher support the capability of
+
+    encrypting your Kubernetes secrets using AWS Key Management Service (KMS) Customer
+
+    Managed Keys (CMK). The only requirement is to enable the encryption provider support
+
+    during EKS cluster creation.
+
+    Use AWS Key Management Service (KMS) keys to provide envelope encryption of
+
+    Kubernetes secrets stored in Amazon EKS. Implementing envelope encryption is
+
+    considered a security best practice for applications that store sensitive data and is part of a
+
+    defense in depth security strategy.
+
+    Application-layer Secrets Encryption provides an additional layer of security for sensitive
+
+    data, such as user defined Secrets and Secrets required for the operation of the cluster,
+
+    such as service account keys, which are all stored in etcd.
+
+    Using this functionality, you can use a key, that you manage in AWS KMS, to encrypt data at
+
+    the application layer. This protects against attackers in the event that they manage to gain
+
+    access to etcd.
+  audit: |
+    For Amazon EKS clusters with Secrets Encryption enabled, look for
+    'encryptionConfig'
+
+    configuration when you run:
+    ```
+    aws eks describe-cluster --name="<cluster-name>"
+    ```
+  remediation: >
+    Enable 'Secrets Encryption' during Amazon EKS cluster creation as described
+    in the links
+
+    within the 'References' section.
+  default_value: |
+    By default, Application-layer Secrets Encryption is not enabled.
+  references: |
+    1. https://docs.aws.amazon.com/eks/latest/userguide/create-cluster.html
+    2. https://eksworkshop.com/beginner/191_secrets/
+  section: AWS Key Management Service (KMS)
+  version: "1.0"
+  tags:
+  - CIS
+  - EKS
+  - CIS 5.3.1
+  - AWS Key Management Service (KMS)
+  benchmark:
+    name: CIS Amazon Elastic Kubernetes Service (EKS) Benchmark
+    version: v1.0.1

--- a/compliance/cis_eks/rules/cis_5_3_1/data.yaml
+++ b/compliance/cis_eks/rules/cis_5_3_1/data.yaml
@@ -1,6 +1,6 @@
 metadata:
-  id: 7169a9b3-0f98-5b5e-a95b-bfd1d3322817
-  name: Ensure Kubernetes Secrets are encrypted using Customer MasterKeys (CMKs) managed in AWS KMS (Automated)
+  id: fa91cef9-6c40-5644-b39d-d17e0f66d507
+  name: Ensure Kubernetes Secrets are encrypted using Customer Master Keys (CMKs) managed in AWS KMS (Automated)
   profile_applicability: |
     * Level 1
   description: >

--- a/compliance/cis_eks/rules/cis_5_3_1/rule.rego
+++ b/compliance/cis_eks/rules/cis_5_3_1/rule.rego
@@ -1,6 +1,5 @@
 package compliance.cis_eks.rules.cis_5_3_1
 
-import data.compliance.cis_eks
 import data.compliance.cis_eks.data_adapter
 import data.compliance.lib.common
 
@@ -22,22 +21,4 @@ finding = result {
 		"evaluation": common.calculate_result(rule_evaluation),
 		"evidence": {"encryption_config": input.resource.Cluster},
 	}
-}
-
-metadata = {
-	"name": "Ensure Kubernetes Secrets are encrypted using Customer Master Keys (CMKs) managed in AWS KMS",
-	"description": "Encrypt Kubernetes secrets, stored in etcd, using secrets encryption feature during Amazon EKS cluster creation.",
-	"rationale": `Kubernetes can store secrets that pods can access via a mounted volume.
-Today, Kubernetes secrets are stored with Base64 encoding, but encrypting is the recommended approach.
-Amazon EKS clusters version 1.13 and higher support the capability of encrypting your Kubernetes secrets using AWS Key Management Service (KMS) Customer Managed Keys (CMK).
-The only requirement is to enable the encryption provider support during EKS cluster creation.
-Use AWS Key Management Service (KMS) keys to provide envelope encryption of Kubernetes secrets stored in Amazon EKS. Implementing envelope encryption is considered a security best practice for applications that store sensitive data and is part of a defense in depth security strategy.
-Application-layer Secrets Encryption provides an additional layer of security for sensitive data, such as user defined Secrets and Secrets required for the operation of the cluster, such as service account keys, which are all stored in etcd.
-Using this functionality, you can use a key, that you manage in AWS KMS, to encrypt data at the application layer.
-This protects against attackers in the event that they manage to gain access to etcd.`,
-	"impact": `None`,
-	"tags": array.concat(cis_eks.default_tags, ["CIS 5.3.1", "AWS Key Management Service (KMS)"]),
-	"default_value": "By default, Application-layer Secrets Encryption is not enabled.",
-	"benchmark": cis_eks.benchmark_metadata,
-	"remediation": "Enable 'Secrets Encryption' during Amazon EKS cluster creation as described in the links within the 'References' section.",
 }

--- a/compliance/cis_eks/rules/cis_5_4_1/data.yaml
+++ b/compliance/cis_eks/rules/cis_5_4_1/data.yaml
@@ -1,0 +1,194 @@
+metadata:
+  id: 09971768-827f-595d-861b-408ba32cc827
+  name: Restrict Access to the Control Plane Endpoint (Manual)
+  profile_applicability: |
+    • Level 1
+  description: >
+    Enable Endpoint Private Access to restrict access to the cluster's control
+    plane to only an
+
+    allowlist of authorized IPs.
+  rationale: >
+    Authorized networks are a way of specifying a restricted range of IP
+    addresses that are
+
+    permitted to access your cluster's control plane. Kubernetes Engine uses both Transport
+
+    Layer Security (TLS) and authentication to provide secure access to your cluster's control
+
+    plane from the public internet. This provides you the flexibility to administer your cluster
+
+    from anywhere; however, you might want to further restrict access to a set of IP addresses
+
+    that you control. You can set this restriction by specifying an authorized network.
+
+    Restricting access to an authorized network can provide additional security benefits for
+
+    your container cluster, including:
+
+    • Better protection from outsider attacks: Authorized networks provide an additional
+
+    layer of security by limiting external access to a specific set of addresses you
+
+    designate, such as those that originate from your premises. This helps protect access
+
+    to your cluster in the case of a vulnerability in the cluster's authentication or
+
+    authorization mechanism.
+
+    • Better protection from insider attacks: Authorized networks help protect your
+
+    cluster from accidental leaks of master certificates from your company's premises.
+
+    Leaked certificates used from outside Amazon EC2 and outside the authorized IP
+
+    ranges (for example, from addresses outside your company) are still denied access.
+  audit: |
+    ```
+    Input:
+    aws eks describe-cluster \
+    --region <region> \
+    --name <clustername>
+    ```
+    Output:
+    ```
+    ...
+    "endpointPublicAccess": false,
+    "endpointPrivateAccess": true,
+    "publicAccessCidrs": [
+    "203.0.113.5/32"
+    ]
+    ...
+    ```
+  remediation: |
+    Complete the following steps using the AWS CLI version 1.18.10 or later. You
+    can check
+
+    your current version with aws --version. To install or upgrade the AWS CLI, see Installing
+
+    the AWS CLI.
+
+    Update your cluster API server endpoint access with the following AWS CLI command.
+
+    Substitute your cluster name and desired endpoint access values. If you set
+
+    endpointPublicAccess=true, then you can (optionally) enter single CIDR block, or a comma-
+
+    separated list of CIDR blocks for publicAccessCidrs. The blocks cannot include reserved
+
+    addresses. If you specify CIDR blocks, then the public API server endpoint will only receive
+
+    requests from the listed blocks. There is a maximum number of CIDR blocks that you can
+
+    specify. For more information, see Amazon EKS Service Quotas. If you restrict access to
+
+    your public endpoint using CIDR blocks, it is recommended that you also enable private
+
+    endpoint access so that worker nodes and Fargate pods (if you use them) can communicate
+
+    with the cluster. Without the private endpoint enabled, your public access endpoint CIDR
+
+    sources must include the egress sources from your VPC. For example, if you have a worker
+
+    node in a private subnet that communicates to the internet through a NAT Gateway, you
+
+    will need to add the outbound IP address of the NAT gateway as part of a whitelisted CIDR
+
+    block on your public endpoint. If you specify no CIDR blocks, then the public API server
+
+    endpoint receives requests from all (0.0.0.0/0) IP addresses.
+
+    Note
+
+    The following command enables private access and public access from a single IP address
+
+    for the API server endpoint. Replace 203.0.113.5/32 with a single CIDR block, or a comma-
+
+    separated list of CIDR blocks that you want to restrict network access to.
+
+    Example command:
+    ```
+
+    aws eks update-cluster-config \
+
+    --region region-code \
+
+    --name dev \
+
+    --resources-vpc-config \
+
+    endpointPublicAccess=true, \
+
+    publicAccessCidrs="203.0.113.5/32",\
+
+    endpointPrivateAccess=true
+    ```
+
+    Output:
+    ```
+
+    {
+
+    "update": {
+
+    "id": "e6f0905f-a5d4-4a2a-8c49-EXAMPLE00000",
+
+    "status": "InProgress",
+
+    "type": "EndpointAccessUpdate",
+
+    "params": [
+
+    {
+
+    "type": "EndpointPublicAccess",
+
+    "value": "true"
+
+    },
+
+    {
+
+    "type": "EndpointPrivateAccess",
+
+    "value": "true"
+
+    },
+
+    {
+
+    "type": "publicAccessCidrs",
+
+    "value": "[\203.0.113.5/32\"]"
+
+    }
+
+    ],
+
+    "createdAt": 1576874258.137,
+
+    "errors": []
+
+    }
+    ```
+  impact: >
+    When implementing Endpoint Private Access, be careful to ensure all desired
+    networks are
+
+    on the allowlist (whitelist) to prevent inadvertently blocking external access to your
+
+    cluster's control plane.
+  default_value: |
+    By default, Endpoint Private Access is disabled.
+  references: |
+    1. https://docs.aws.amazon.com/eks/latest/userguide/cluster-endpoint.html
+  section: Cluster Networking
+  version: "1.0"
+  tags:
+  - CIS
+  - EKS
+  - CIS 5.4.1
+  - Cluster Networking
+  benchmark:
+    name: CIS Amazon Elastic Kubernetes Service (EKS) Benchmark
+    version: v1.0.1

--- a/compliance/cis_eks/rules/cis_5_4_1/data.yaml
+++ b/compliance/cis_eks/rules/cis_5_4_1/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 09971768-827f-595d-861b-408ba32cc827
+  id: f0d65fdb-035c-5e08-b4f8-0a1356c4005c
   name: Restrict Access to the Control Plane Endpoint (Manual)
   profile_applicability: |
     * Level 1

--- a/compliance/cis_eks/rules/cis_5_4_1/data.yaml
+++ b/compliance/cis_eks/rules/cis_5_4_1/data.yaml
@@ -26,8 +26,8 @@ metadata:
     Leaked certificates used from outside Amazon EC2 and outside the authorized IP
     ranges (for example, from addresses outside your company) are still denied access.
   audit: |
-    ```
     Input:
+    ```
     aws eks describe-cluster \
     --region <region> \
     --name <clustername>

--- a/compliance/cis_eks/rules/cis_5_4_1/data.yaml
+++ b/compliance/cis_eks/rules/cis_5_4_1/data.yaml
@@ -26,8 +26,8 @@ metadata:
     Leaked certificates used from outside Amazon EC2 and outside the authorized IP
     ranges (for example, from addresses outside your company) are still denied access.
   audit: |
-    Input:
     ```
+    Input:
     aws eks describe-cluster \
     --region <region> \
     --name <clustername>

--- a/compliance/cis_eks/rules/cis_5_4_1/data.yaml
+++ b/compliance/cis_eks/rules/cis_5_4_1/data.yaml
@@ -6,7 +6,7 @@ metadata:
   description: >
     Enable Endpoint Private Access to restrict access to the cluster's control
     plane to only an allowlist of authorized IPs.
-  rationale: >
+  rationale: |
     Authorized networks are a way of specifying a restricted range of IP
     addresses that are
     permitted to access your cluster's control plane. Kubernetes Engine uses both Transport

--- a/compliance/cis_eks/rules/cis_5_4_1/data.yaml
+++ b/compliance/cis_eks/rules/cis_5_4_1/data.yaml
@@ -5,43 +5,25 @@ metadata:
     * Level 1
   description: >
     Enable Endpoint Private Access to restrict access to the cluster's control
-    plane to only an
-
-    allowlist of authorized IPs.
+    plane to only an allowlist of authorized IPs.
   rationale: >
     Authorized networks are a way of specifying a restricted range of IP
     addresses that are
-
     permitted to access your cluster's control plane. Kubernetes Engine uses both Transport
-
     Layer Security (TLS) and authentication to provide secure access to your cluster's control
-
     plane from the public internet. This provides you the flexibility to administer your cluster
-
     from anywhere; however, you might want to further restrict access to a set of IP addresses
-
     that you control. You can set this restriction by specifying an authorized network.
-
     Restricting access to an authorized network can provide additional security benefits for
-
     your container cluster, including:
-
     * Better protection from outsider attacks: Authorized networks provide an additional
-
     layer of security by limiting external access to a specific set of addresses you
-
     designate, such as those that originate from your premises. This helps protect access
-
     to your cluster in the case of a vulnerability in the cluster's authentication or
-
     authorization mechanism.
-
     * Better protection from insider attacks: Authorized networks help protect your
-
     cluster from accidental leaks of master certificates from your company's premises.
-
     Leaked certificates used from outside Amazon EC2 and outside the authorized IP
-
     ranges (for example, from addresses outside your company) are still denied access.
   audit: |
     ```
@@ -63,120 +45,66 @@ metadata:
   remediation: |
     Complete the following steps using the AWS CLI version 1.18.10 or later. You
     can check
-
     your current version with aws --version. To install or upgrade the AWS CLI, see Installing
-
     the AWS CLI.
-
     Update your cluster API server endpoint access with the following AWS CLI command.
-
     Substitute your cluster name and desired endpoint access values. If you set
-
     endpointPublicAccess=true, then you can (optionally) enter single CIDR block, or a comma-
-
     separated list of CIDR blocks for publicAccessCidrs. The blocks cannot include reserved
-
     addresses. If you specify CIDR blocks, then the public API server endpoint will only receive
-
     requests from the listed blocks. There is a maximum number of CIDR blocks that you can
-
     specify. For more information, see Amazon EKS Service Quotas. If you restrict access to
-
     your public endpoint using CIDR blocks, it is recommended that you also enable private
-
     endpoint access so that worker nodes and Fargate pods (if you use them) can communicate
-
     with the cluster. Without the private endpoint enabled, your public access endpoint CIDR
-
     sources must include the egress sources from your VPC. For example, if you have a worker
-
     node in a private subnet that communicates to the internet through a NAT Gateway, you
-
     will need to add the outbound IP address of the NAT gateway as part of a whitelisted CIDR
-
     block on your public endpoint. If you specify no CIDR blocks, then the public API server
-
     endpoint receives requests from all (0.0.0.0/0) IP addresses.
-
     Note
-
     The following command enables private access and public access from a single IP address
-
     for the API server endpoint. Replace 203.0.113.5/32 with a single CIDR block, or a comma-
-
     separated list of CIDR blocks that you want to restrict network access to.
-
     Example command:
     ```
-
     aws eks update-cluster-config \
-
     --region region-code \
-
     --name dev \
-
     --resources-vpc-config \
-
     endpointPublicAccess=true, \
-
     publicAccessCidrs="203.0.113.5/32",\
-
     endpointPrivateAccess=true
     ```
-
     Output:
     ```
-
     {
-
     "update": {
-
     "id": "e6f0905f-a5d4-4a2a-8c49-EXAMPLE00000",
-
     "status": "InProgress",
-
     "type": "EndpointAccessUpdate",
-
     "params": [
-
     {
-
     "type": "EndpointPublicAccess",
-
     "value": "true"
-
     },
-
     {
-
     "type": "EndpointPrivateAccess",
-
     "value": "true"
-
     },
-
     {
-
     "type": "publicAccessCidrs",
-
     "value": "[\203.0.113.5/32\"]"
-
     }
-
     ],
-
     "createdAt": 1576874258.137,
-
     "errors": []
-
     }
     ```
   impact: >
     When implementing Endpoint Private Access, be careful to ensure all desired
     networks are
-
     on the allowlist (whitelist) to prevent inadvertently blocking external access to your
-
     cluster's control plane.
   default_value: |
     By default, Endpoint Private Access is disabled.

--- a/compliance/cis_eks/rules/cis_5_4_1/data.yaml
+++ b/compliance/cis_eks/rules/cis_5_4_1/data.yaml
@@ -2,7 +2,7 @@ metadata:
   id: 09971768-827f-595d-861b-408ba32cc827
   name: Restrict Access to the Control Plane Endpoint (Manual)
   profile_applicability: |
-    • Level 1
+    * Level 1
   description: >
     Enable Endpoint Private Access to restrict access to the cluster's control
     plane to only an
@@ -26,7 +26,7 @@ metadata:
 
     your container cluster, including:
 
-    • Better protection from outsider attacks: Authorized networks provide an additional
+    * Better protection from outsider attacks: Authorized networks provide an additional
 
     layer of security by limiting external access to a specific set of addresses you
 
@@ -36,7 +36,7 @@ metadata:
 
     authorization mechanism.
 
-    • Better protection from insider attacks: Authorized networks help protect your
+    * Better protection from insider attacks: Authorized networks help protect your
 
     cluster from accidental leaks of master certificates from your company's premises.
 

--- a/compliance/cis_eks/rules/cis_5_4_1/rule.rego
+++ b/compliance/cis_eks/rules/cis_5_4_1/rule.rego
@@ -1,6 +1,5 @@
 package compliance.cis_eks.rules.cis_5_4_1
 
-import data.compliance.cis_eks
 import data.compliance.cis_eks.data_adapter
 import data.compliance.lib.common
 
@@ -42,39 +41,4 @@ finding = result {
 			"public_access_cidrs": input.resource.Cluster.ResourcesVpcConfig.PublicAccessCidrs,
 		},
 	}
-}
-
-metadata = {
-	"name": "Restrict Access to the Control Plane Endpoint",
-	"description": "Enable Endpoint Private Access to restrict access to the cluster's control plane to only an allowlist of authorized IPs.",
-	"rationale": `Authorized networks are a way of specifying a restricted range of IP addresses that are permitted to access your cluster's control plane.
-Kubernetes Engine uses both Transport Layer Security (TLS) and authentication to provide secure access to your cluster's control plane from the public internet.
-This provides you the flexibility to administer your cluster from anywhere; however, you might want to further restrict access to a set of IP addresses that you control.
-You can set this restriction by specifying an authorized network.
-Restricting access to an authorized network can provide additional security benefits for your container cluster, including:
-• Better protection from outsider attacks: Authorized networks provide an additiofnal layer of security by limiting external access to a specific set of addresses you designate, such as those that originate from your premises.
-  This helps protect access to your cluster in the case of a vulnerability in the cluster's authentication or authorization mechanism.
-• Better protection from insider attacks: Authorized networks help protect your fcluster from accidental leaks of master certificates from your company's premises.
-Leaked certificates used from outside Amazon EC2 and outside the authorized IP  ranges (for example, from addresses outside your company) are still denied access.`,
-	"impact": `When implementing Endpoint Private Access, be careful to ensure all desired networks are on the allowlist (whitelist) to prevent inadvertently blocking external access to your cluster's control plane.`,
-	"tags": array.concat(cis_eks.default_tags, ["CIS 5.4.1", "Cluster Networking"]),
-	"default_value": "By default, Endpoint Private Access is disabled.",
-	"benchmark": cis_eks.benchmark_metadata,
-	"remediation": `Complete the following steps using the AWS CLI version 1.18.10 or later.
-You can check your current version with aws --version. To install or upgrade the AWS CLI, see Installing the AWS CLI.
-Update your cluster API server endpoint access with the following AWS CLI command.
-Substitute your cluster name and desired endpoint access values.
-If you set endpointPublicAccess=true, then you can (optionally) enter single CIDR block, or a comma-separated list of CIDR blocks for publicAccessCidrs.
-The blocks cannot include reserved addresses.
-If you specify CIDR blocks, then the public API server endpoint will only receive requests from the listed blocks.
-There is a maximum number of CIDR blocks that you can specify.
-For more information, see Amazon EKS Service Quotas.
-If you restrict access to your public endpoint using CIDR blocks, it is recommended that you also enable private endpoint access so that worker nodes and Fargate pods (if you use them) can communicate with the cluster.
-Without the private endpoint enabled, your public access endpoint CIDR sources must include the egress sources from your VPC.
-For example, if you have a worker node in a private subnet that communicates to the internet through a NAT Gateway, you will need to add the outbound IP address of the NAT gateway as part of a whitelisted CIDR block on your public endpoint.
-If you specify no CIDR blocks, then the public API server endpoint receives requests from all (0.0.0.0/0) IP addresses.
-Note The following command enables private access and public access from a single IP address for the API server endpoint.
-Replace 203.0.113.5/32 with a single CIDR block, or a comma- separated list of CIDR blocks that you want to restrict network access to.
-Example command:
-aws eks update-cluster-config --region region-code --name dev --resources-vpc-config endpointPublicAccess=true publicAccessCidrs="203.0.113.5/32" gitendpointPrivateAccess=true`,
 }

--- a/compliance/cis_eks/rules/cis_5_4_2/data.yaml
+++ b/compliance/cis_eks/rules/cis_5_4_2/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 9d5d8422-dbee-5832-a5cf-a79764de13dd
+  id: c4faa477-6da2-5220-a678-0200ae5be03f
   name: Ensure clusters are created with Private Endpoint Enabled andPublic Access Disabled (Manual)
   profile_applicability: |
     * Level 2

--- a/compliance/cis_eks/rules/cis_5_4_2/data.yaml
+++ b/compliance/cis_eks/rules/cis_5_4_2/data.yaml
@@ -1,6 +1,6 @@
 metadata:
-  id: c4faa477-6da2-5220-a678-0200ae5be03f
-  name: Ensure clusters are created with Private Endpoint Enabled andPublic Access Disabled (Manual)
+  id: 677697a6-309b-5a91-ba2b-1acd571817a6
+  name: Ensure clusters are created with Private Endpoint Enabled and Public Access Disabled (Manual)
   profile_applicability: |
     * Level 2
   description: >

--- a/compliance/cis_eks/rules/cis_5_4_2/data.yaml
+++ b/compliance/cis_eks/rules/cis_5_4_2/data.yaml
@@ -21,7 +21,7 @@ metadata:
     master's VPC network to perform any attack on the Kubernetes API.
   audit: ""
   remediation: ""
-  impact: >
+  impact: |
     Configure the EKS cluster endpoint to be private. See Modifying Cluster
     Endpoint Access for
     further information on this topic.

--- a/compliance/cis_eks/rules/cis_5_4_2/data.yaml
+++ b/compliance/cis_eks/rules/cis_5_4_2/data.yaml
@@ -3,7 +3,7 @@ metadata:
   name: Ensure clusters are created with Private Endpoint Enabled andPublic Access
     Disabled (Manual)
   profile_applicability: |
-    • Level 2
+    * Level 2
   description: >
     Disable access to the Kubernetes API from outside the node network if it is
     not required.

--- a/compliance/cis_eks/rules/cis_5_4_2/data.yaml
+++ b/compliance/cis_eks/rules/cis_5_4_2/data.yaml
@@ -1,7 +1,6 @@
 metadata:
   id: 9d5d8422-dbee-5832-a5cf-a79764de13dd
-  name: Ensure clusters are created with Private Endpoint Enabled andPublic Access
-    Disabled (Manual)
+  name: Ensure clusters are created with Private Endpoint Enabled andPublic Access Disabled (Manual)
   profile_applicability: |
     * Level 2
   description: >

--- a/compliance/cis_eks/rules/cis_5_4_2/data.yaml
+++ b/compliance/cis_eks/rules/cis_5_4_2/data.yaml
@@ -9,48 +9,29 @@ metadata:
   rationale: >
     In a private cluster, the master node has two endpoints, a private and
     public endpoint. The
-
     private endpoint is the internal IP address of the master, behind an internal load balancer
-
     in the master's VPC network. Nodes communicate with the master using the private
-
     endpoint. The public endpoint enables the Kubernetes API to be accessed from outside the
-
     master's VPC network.
-
     Although Kubernetes API requires an authorized token to perform sensitive actions, a
-
     vulnerability could potentially expose the Kubernetes publically with unrestricted access.
-
     Additionally, an attacker may be able to identify the current cluster and Kubernetes API
-
     version and determine whether it is vulnerable to an attack. Unless required, disabling
-
     public endpoint will help prevent such threats, and require the attacker to be on the
-
     master's VPC network to perform any attack on the Kubernetes API.
   audit: ""
   remediation: ""
   impact: >
     Configure the EKS cluster endpoint to be private. See Modifying Cluster
     Endpoint Access for
-
     further information on this topic.
-
     1. Leave the cluster endpoint public and specify which CIDR blocks can communicate
-
     with the cluster endpoint. The blocks are effectively a whitelisted set of public IP
-
     addresses that are allowed to access the cluster endpoint.
-
     2. Configure public access with a set of whitelisted CIDR blocks and set private
-
     endpoint access to enabled. This will allow public access from a specific range of
-
     public IPs while forcing all network traffic between the kubelets (workers) and the
-
     Kubernetes API through the cross-account ENIs that get provisioned into the cluster
-
     VPC when the control plane is provisioned.
   default_value: |
     By default, the Private Endpoint is disabled.

--- a/compliance/cis_eks/rules/cis_5_4_2/data.yaml
+++ b/compliance/cis_eks/rules/cis_5_4_2/data.yaml
@@ -1,0 +1,69 @@
+metadata:
+  id: 9d5d8422-dbee-5832-a5cf-a79764de13dd
+  name: Ensure clusters are created with Private Endpoint Enabled andPublic Access
+    Disabled (Manual)
+  profile_applicability: |
+    • Level 2
+  description: >
+    Disable access to the Kubernetes API from outside the node network if it is
+    not required.
+  rationale: >
+    In a private cluster, the master node has two endpoints, a private and
+    public endpoint. The
+
+    private endpoint is the internal IP address of the master, behind an internal load balancer
+
+    in the master's VPC network. Nodes communicate with the master using the private
+
+    endpoint. The public endpoint enables the Kubernetes API to be accessed from outside the
+
+    master's VPC network.
+
+    Although Kubernetes API requires an authorized token to perform sensitive actions, a
+
+    vulnerability could potentially expose the Kubernetes publically with unrestricted access.
+
+    Additionally, an attacker may be able to identify the current cluster and Kubernetes API
+
+    version and determine whether it is vulnerable to an attack. Unless required, disabling
+
+    public endpoint will help prevent such threats, and require the attacker to be on the
+
+    master's VPC network to perform any attack on the Kubernetes API.
+  audit: ""
+  remediation: ""
+  impact: >
+    Configure the EKS cluster endpoint to be private. See Modifying Cluster
+    Endpoint Access for
+
+    further information on this topic.
+
+    1. Leave the cluster endpoint public and specify which CIDR blocks can communicate
+
+    with the cluster endpoint. The blocks are effectively a whitelisted set of public IP
+
+    addresses that are allowed to access the cluster endpoint.
+
+    2. Configure public access with a set of whitelisted CIDR blocks and set private
+
+    endpoint access to enabled. This will allow public access from a specific range of
+
+    public IPs while forcing all network traffic between the kubelets (workers) and the
+
+    Kubernetes API through the cross-account ENIs that get provisioned into the cluster
+
+    VPC when the control plane is provisioned.
+  default_value: |
+    By default, the Private Endpoint is disabled.
+  references: |
+    1. https://docs.aws.amazon.com/eks/latest/userguide/cluster-endpoint.html
+  section: Cluster Networking
+  version: "1.0"
+  tags:
+  - CIS
+  - EKS
+  - CIS 5.4.2
+  - Cluster Networking
+  benchmark:
+    name: CIS Amazon Elastic Kubernetes Service (EKS) Benchmark
+    version: v1.0.1

--- a/compliance/cis_eks/rules/cis_5_4_2/rule.rego
+++ b/compliance/cis_eks/rules/cis_5_4_2/rule.rego
@@ -1,6 +1,5 @@
 package compliance.cis_eks.rules.cis_5_4_2
 
-import data.compliance.cis_eks
 import data.compliance.cis_eks.data_adapter
 import data.compliance.lib.common
 
@@ -25,25 +24,4 @@ finding = result {
 			"endpoint_private_access": input.resource.Cluster.ResourcesVpcConfig.EndpointPrivateAccess,
 		},
 	}
-}
-
-metadata = {
-	"name": "Ensure clusters are created with Private Endpoint Enabled and Public Access Disabled",
-	"description": "Disable access to the Kubernetes API from outside the node network if it is not required.",
-	"rationale": `In a private cluster, the master node has two endpoints, a private and public endpoint.
-The private endpoint is the internal IP address of the master, behind an internal load balancer in the master's VPC network.
-Nodes communicate with the master using the private endpoint.
-The public endpoint enables the Kubernetes API to be accessed from outside the master's VPC network.
-Although Kubernetes API requires an authorized token to perform sensitive actions, a vulnerability could potentially expose the Kubernetes publically with unrestricted access.
-Additionally, an attacker may be able to identify the current cluster and Kubernetes API version and determine whether it is vulnerable to an attack.
-Unless required, disabling public endpoint will help prevent such threats, and require the attacker to be on the master's VPC network to perform any attack on the Kubernetes API.`,
-	"remediation": ``,
-	"tags": array.concat(cis_eks.default_tags, ["CIS 5.4.2", "Cluster Networking"]),
-	"default_value": "By default, the Private Endpoint is disabled.",
-	"benchmark": cis_eks.benchmark_metadata,
-	"impact": `Configure the EKS cluster endpoint to be private. See Modifying Cluster Endpoint Access for further information on this topic.
-1. Leave the cluster endpoint public and specify which CIDR blocks can communicate with the cluster endpoint.
-The blocks are effectively a whitelisted set of public IP addresses that are allowed to access the cluster endpoint.
-2. Configure public access with a set of whitelisted CIDR blocks and set private endpoint access to enabled.
-This will allow public access from a specific range of public IPs while forcing all network traffic between the kubelets (workers) and the Kubernetes API through the cross-account ENIs that get provisioned into the cluster VPC when the control plane is provisioned.`,
 }

--- a/compliance/cis_eks/rules/cis_5_4_3/data.yaml
+++ b/compliance/cis_eks/rules/cis_5_4_3/data.yaml
@@ -6,27 +6,20 @@ metadata:
   description: >
     Disable public IP addresses for cluster nodes, so that they only have
     private IP addresses.
-
     Private Nodes are nodes with no public IP addresses.
   rationale: >
     Disabling public IP addresses on cluster nodes restricts access to only
     internal networks,
-
     forcing attackers to obtain local network access before attempting to compromise the
-
     underlying Kubernetes hosts.
   audit: ""
   remediation: ""
   impact: >
     To enable Private Nodes, the cluster has to also be configured with a
     private master IP
-
     range and IP Aliasing enabled.
-
     Private Nodes do not have outbound access to the public internet. If you want to provide
-
     outbound Internet access for your private nodes, you can use Cloud NAT or you can
-
     manage your own NAT gateway.
   default_value: |
     By default, Private Nodes are disabled.

--- a/compliance/cis_eks/rules/cis_5_4_3/data.yaml
+++ b/compliance/cis_eks/rules/cis_5_4_3/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 13cd2e5b-53e5-571b-b1bf-23604af58b83
+  id: f026b2aa-c739-5512-8d7a-eaa21de507c6
   name: Ensure clusters are created with Private Nodes (Manual)
   profile_applicability: |
     * Level 1

--- a/compliance/cis_eks/rules/cis_5_4_3/data.yaml
+++ b/compliance/cis_eks/rules/cis_5_4_3/data.yaml
@@ -23,6 +23,7 @@ metadata:
     manage your own NAT gateway.
   default_value: |
     By default, Private Nodes are disabled.
+  references: ""
   section: Cluster Networking
   version: "1.0"
   tags:

--- a/compliance/cis_eks/rules/cis_5_4_3/data.yaml
+++ b/compliance/cis_eks/rules/cis_5_4_3/data.yaml
@@ -2,7 +2,7 @@ metadata:
   id: 13cd2e5b-53e5-571b-b1bf-23604af58b83
   name: Ensure clusters are created with Private Nodes (Manual)
   profile_applicability: |
-    • Level 1
+    * Level 1
   description: >
     Disable public IP addresses for cluster nodes, so that they only have
     private IP addresses.

--- a/compliance/cis_eks/rules/cis_5_4_3/data.yaml
+++ b/compliance/cis_eks/rules/cis_5_4_3/data.yaml
@@ -1,0 +1,42 @@
+metadata:
+  id: 13cd2e5b-53e5-571b-b1bf-23604af58b83
+  name: Ensure clusters are created with Private Nodes (Manual)
+  profile_applicability: |
+    • Level 1
+  description: >
+    Disable public IP addresses for cluster nodes, so that they only have
+    private IP addresses.
+
+    Private Nodes are nodes with no public IP addresses.
+  rationale: >
+    Disabling public IP addresses on cluster nodes restricts access to only
+    internal networks,
+
+    forcing attackers to obtain local network access before attempting to compromise the
+
+    underlying Kubernetes hosts.
+  audit: ""
+  remediation: ""
+  impact: >
+    To enable Private Nodes, the cluster has to also be configured with a
+    private master IP
+
+    range and IP Aliasing enabled.
+
+    Private Nodes do not have outbound access to the public internet. If you want to provide
+
+    outbound Internet access for your private nodes, you can use Cloud NAT or you can
+
+    manage your own NAT gateway.
+  default_value: |
+    By default, Private Nodes are disabled.
+  section: Cluster Networking
+  version: "1.0"
+  tags:
+  - CIS
+  - EKS
+  - CIS 5.4.3
+  - Cluster Networking
+  benchmark:
+    name: CIS Amazon Elastic Kubernetes Service (EKS) Benchmark
+    version: v1.0.1

--- a/compliance/cis_eks/rules/cis_5_4_3/rule.rego
+++ b/compliance/cis_eks/rules/cis_5_4_3/rule.rego
@@ -1,6 +1,5 @@
 package compliance.cis_eks.rules.cis_5_4_3
 
-import data.compliance.cis_eks
 import data.compliance.lib.common
 import data.compliance.lib.data_adapter
 
@@ -29,18 +28,4 @@ finding = result {
 		"evaluation": common.calculate_result(rule_evaluation),
 		"evidence": evidence,
 	}
-}
-
-metadata = {
-	"name": "Ensure clusters are created with Private Nodes",
-	"description": `Disable public IP addresses for cluster nodes, so that they only have private IP addresses.
-Private Nodes are nodes with no public IP addresses.`,
-	"rationale": `Disabling public IP addresses on cluster nodes restricts access to only internal networks, forcing attackers to obtain local network access before attempting to compromise the underlying Kubernetes hosts.`,
-	"remediation": "",
-	"tags": array.concat(cis_eks.default_tags, ["CIS 5.4.3", "Cluster Networking"]),
-	"default_value": "By default, Private Nodes are disabled.",
-	"benchmark": cis_eks.benchmark_metadata,
-	"impact": `To enable Private Nodes, the cluster has to also be configured with a private master IP range and IP Aliasing enabled.
-Private Nodes do not have outbound access to the public internet.
-If you want to provide outbound Internet access for your private nodes, you can use Cloud NAT or you can manage your own NAT gateway.`,
 }

--- a/compliance/cis_eks/rules/cis_5_4_5/data.yaml
+++ b/compliance/cis_eks/rules/cis_5_4_5/data.yaml
@@ -1,0 +1,23 @@
+metadata:
+  id: f74e62d4-6cff-5364-9a49-bdd8b595aa1b
+  name: Encrypt traffic to HTTPS load balancers with TLS certificates (Manual)
+  profile_applicability: |
+    • Level 2
+  description: >
+    Encrypt traffic to HTTPS load balancers using TLS certificates.  rationale: >
+  audit: ""
+  remediation: ""
+  impact: ""
+  default_value: ""
+  references: |
+    1. https://docs.aws.amazon.com/elasticloadbalancing/latest/userguide/data-protection.html
+  section: Cluster Networking
+  version: "1.0"
+  tags:
+    - CIS
+    - EKS
+    - CIS 5.4.5
+    - Cluster Networking
+  benchmark:
+    name: CIS Amazon Elastic Kubernetes Service (EKS) Benchmark
+    version: v1.0.1

--- a/compliance/cis_eks/rules/cis_5_4_5/data.yaml
+++ b/compliance/cis_eks/rules/cis_5_4_5/data.yaml
@@ -1,5 +1,5 @@
   metadata:
-    id: f74e62d4-6cff-5364-9a49-bdd8b595aa1b
+    id: 0b5e340f-9120-515a-b71a-72e43ed24941
     name: Encrypt traffic to HTTPS load balancers with TLS certificates (Manual)
     profile_applicability: |
       * Level 2

--- a/compliance/cis_eks/rules/cis_5_4_5/data.yaml
+++ b/compliance/cis_eks/rules/cis_5_4_5/data.yaml
@@ -1,23 +1,23 @@
   metadata:
-  id: f74e62d4-6cff-5364-9a49-bdd8b595aa1b
-  name: Encrypt traffic to HTTPS load balancers with TLS certificates (Manual)
-  profile_applicability: |
-    * Level 2
-  description: >
-    Encrypt traffic to HTTPS load balancers using TLS certificates.  rationale: >
-  audit: ""
-  remediation: ""
-  impact: ""
-  default_value: ""
-  references: |
-    1. https://docs.aws.amazon.com/elasticloadbalancing/latest/userguide/data-protection.html
-  section: Cluster Networking
-  version: "1.0"
-  tags:
-    - CIS
-    - EKS
-    - CIS 5.4.5
-    - Cluster Networking
-  benchmark:
-    name: CIS Amazon Elastic Kubernetes Service (EKS) Benchmark
-    version: v1.0.1
+    id: f74e62d4-6cff-5364-9a49-bdd8b595aa1b
+    name: Encrypt traffic to HTTPS load balancers with TLS certificates (Manual)
+    profile_applicability: |
+      * Level 2
+    description: >
+      Encrypt traffic to HTTPS load balancers using TLS certificates.  rationale: >
+    audit: ""
+    remediation: ""
+    impact: ""
+    default_value: ""
+    references: |
+      1. https://docs.aws.amazon.com/elasticloadbalancing/latest/userguide/data-protection.html
+    section: Cluster Networking
+    version: "1.0"
+    tags:
+      - CIS
+      - EKS
+      - CIS 5.4.5
+      - Cluster Networking
+    benchmark:
+      name: CIS Amazon Elastic Kubernetes Service (EKS) Benchmark
+      version: v1.0.1

--- a/compliance/cis_eks/rules/cis_5_4_5/data.yaml
+++ b/compliance/cis_eks/rules/cis_5_4_5/data.yaml
@@ -4,7 +4,10 @@
     profile_applicability: |
       * Level 2
     description: >
-      Encrypt traffic to HTTPS load balancers using TLS certificates.  rationale: >
+      Encrypt traffic to HTTPS load balancers using TLS certificates.
+    rationale: >
+      Encrypting traffic between users and your Kubernetes workload is fundamental to
+      protecting data sent over the web.
     audit: ""
     remediation: ""
     impact: ""

--- a/compliance/cis_eks/rules/cis_5_4_5/data.yaml
+++ b/compliance/cis_eks/rules/cis_5_4_5/data.yaml
@@ -1,8 +1,8 @@
-metadata:
+  metadata:
   id: f74e62d4-6cff-5364-9a49-bdd8b595aa1b
   name: Encrypt traffic to HTTPS load balancers with TLS certificates (Manual)
   profile_applicability: |
-    • Level 2
+    * Level 2
   description: >
     Encrypt traffic to HTTPS load balancers using TLS certificates.  rationale: >
   audit: ""

--- a/compliance/cis_eks/rules/cis_5_4_5/rule.rego
+++ b/compliance/cis_eks/rules/cis_5_4_5/rule.rego
@@ -1,6 +1,5 @@
 package compliance.cis_eks.rules.cis_5_4_5
 
-import data.compliance.cis_eks
 import data.compliance.cis_eks.data_adapter
 import data.compliance.lib.common
 
@@ -41,15 +40,4 @@ finding = result {
 		"evaluation": common.calculate_result(rule_evaluation),
 		"evidence": evidence,
 	}
-}
-
-metadata = {
-	"name": "Encrypt traffic to HTTPS load balancers with TLS certificates",
-	"description": "Encrypt traffic to HTTPS load balancers using TLS certificates.",
-	"rationale": `Encrypting traffic between users and your Kubernetes workload is fundamental to protecting data sent over the web.`,
-	"remediation": "",
-	"tags": array.concat(cis_eks.default_tags, ["CIS 5.4.5", "Cluster Networking"]),
-	"default_value": "",
-	"benchmark": cis_eks.benchmark_metadata,
-	"impact": "",
 }


### PR DESCRIPTION
We would like the EKS rules to support the new CSP rule format where the meta data is separated from the Rego rules.

- Closes: https://github.com/elastic/security-team/issues/3473