### PR TITLE
Update k8s rules from benchmark 1.6 to 1.20

### DIFF
--- a/compliance/cis_k8s/rules/cis_1_1_1/data.yaml
+++ b/compliance/cis_k8s/rules/cis_1_1_1/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 2097d102-0bab-5aa6-83ca-ef9381c31375
+  id: cb037139-0ed6-55e7-a1fe-ef005a98a812
   name: Ensure that the API server pod specification file permissions are set to
     644 or more restrictive (Automated)
   profile_applicability: |

--- a/compliance/cis_k8s/rules/cis_1_1_1/data.yaml
+++ b/compliance/cis_k8s/rules/cis_1_1_1/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 59b5a77b-b090-5630-9a33-73eb805b2d52
+  id: 2097d102-0bab-5aa6-83ca-ef9381c31375
   name: Ensure that the API server pod specification file permissions are set to
     644 or more restrictive (Automated)
   profile_applicability: |

--- a/compliance/cis_k8s/rules/cis_1_1_11/data.yaml
+++ b/compliance/cis_k8s/rules/cis_1_1_11/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: d81af4e9-3d92-5c77-adeb-1aee349b17f5
+  id: 80ebf80c-71cb-5cc7-a239-7f2b56fb084c
   name: Ensure that the etcd data directory permissions are set to 700 or more
     restrictive (Automated)
   profile_applicability: |

--- a/compliance/cis_k8s/rules/cis_1_1_11/data.yaml
+++ b/compliance/cis_k8s/rules/cis_1_1_11/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 80ebf80c-71cb-5cc7-a239-7f2b56fb084c
+  id: 564839fa-e3e8-52f3-b8db-b7f8ad9b4a59
   name: Ensure that the etcd data directory permissions are set to 700 or more
     restrictive (Automated)
   profile_applicability: |

--- a/compliance/cis_k8s/rules/cis_1_1_12/data.yaml
+++ b/compliance/cis_k8s/rules/cis_1_1_12/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: aec5c61d-09bd-5e64-92ba-886f1ceeacf8
+  id: 09c47abd-7b65-52a3-96d1-75a6d5963b96
   name: Ensure that the etcd data directory ownership is set to etcd:etcd (Automated)
   profile_applicability: |
     * Level 1 - Master Node

--- a/compliance/cis_k8s/rules/cis_1_1_12/data.yaml
+++ b/compliance/cis_k8s/rules/cis_1_1_12/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 09c47abd-7b65-52a3-96d1-75a6d5963b96
+  id: f76659e0-71ff-572a-9c9c-3d18c3a90b90
   name: Ensure that the etcd data directory ownership is set to etcd:etcd (Automated)
   profile_applicability: |
     * Level 1 - Master Node

--- a/compliance/cis_k8s/rules/cis_1_1_13/data.yaml
+++ b/compliance/cis_k8s/rules/cis_1_1_13/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 1aa16467-18ce-5ba6-8e6a-1f6b69acbfa0
+  id: 240c94b0-c425-5d08-9c05-09e90e9e349e
   name: Ensure that the admin.conf file permissions are set to 644 or more
     restrictive (Automated)
   profile_applicability: |

--- a/compliance/cis_k8s/rules/cis_1_1_13/data.yaml
+++ b/compliance/cis_k8s/rules/cis_1_1_13/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 240c94b0-c425-5d08-9c05-09e90e9e349e
+  id: 854cf350-9ce7-5c93-b934-d1c8957d1a47
   name: Ensure that the admin.conf file permissions are set to 644 or more
     restrictive (Automated)
   profile_applicability: |

--- a/compliance/cis_k8s/rules/cis_1_1_14/data.yaml
+++ b/compliance/cis_k8s/rules/cis_1_1_14/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 30c23e9a-f1b4-559c-a06f-6fdd0a216cec
+  id: d0cee447-3449-54a7-af09-eb48f60d0b1f
   name: Ensure that the admin.conf file ownership is set to root:root (Automated)
   profile_applicability: |
     * Level 1 - Master Node

--- a/compliance/cis_k8s/rules/cis_1_1_14/data.yaml
+++ b/compliance/cis_k8s/rules/cis_1_1_14/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: d0cee447-3449-54a7-af09-eb48f60d0b1f
+  id: 22e49e64-aa12-5a88-9bd2-eefb2423261c
   name: Ensure that the admin.conf file ownership is set to root:root (Automated)
   profile_applicability: |
     * Level 1 - Master Node

--- a/compliance/cis_k8s/rules/cis_1_1_15/data.yaml
+++ b/compliance/cis_k8s/rules/cis_1_1_15/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: e41f17bd-8b95-57b9-b0d5-1f6f4ab25cd2
+  id: 4b6519b2-7ab1-58b4-a168-7fb7e8c007d3
   name: Ensure that the scheduler.conf file permissions are set to 644 or more
     restrictive (Automated)
   profile_applicability: |

--- a/compliance/cis_k8s/rules/cis_1_1_15/data.yaml
+++ b/compliance/cis_k8s/rules/cis_1_1_15/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 28f4a3c7-17fa-55be-a527-9561f4d092bc
+  id: e41f17bd-8b95-57b9-b0d5-1f6f4ab25cd2
   name: Ensure that the scheduler.conf file permissions are set to 644 or more
     restrictive (Automated)
   profile_applicability: |

--- a/compliance/cis_k8s/rules/cis_1_1_16/data.yaml
+++ b/compliance/cis_k8s/rules/cis_1_1_16/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: e9505590-cf60-5cee-9ad4-6c0d9a18956d
+  id: 9179f7df-2e49-5a05-9a49-0e41d806ce07
   name: Ensure that the scheduler.conf file ownership is set to root:root (Automated)
   profile_applicability: |
     * Level 1 - Master Node

--- a/compliance/cis_k8s/rules/cis_1_1_16/data.yaml
+++ b/compliance/cis_k8s/rules/cis_1_1_16/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: e76bec57-8d79-5222-a764-7b92940a142e
+  id: e9505590-cf60-5cee-9ad4-6c0d9a18956d
   name: Ensure that the scheduler.conf file ownership is set to root:root (Automated)
   profile_applicability: |
     * Level 1 - Master Node

--- a/compliance/cis_k8s/rules/cis_1_1_17/data.yaml
+++ b/compliance/cis_k8s/rules/cis_1_1_17/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 1c5bee8d-c2a8-52a5-bdb7-811d84f9fce1
+  id: 43b1fed3-bb92-5c04-b28b-cca9ba326d78
   name:
     Ensure that the controller-manager.conf file permissions are set to 644 or
     more restrictive (Automated)

--- a/compliance/cis_k8s/rules/cis_1_1_17/data.yaml
+++ b/compliance/cis_k8s/rules/cis_1_1_17/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 43b1fed3-bb92-5c04-b28b-cca9ba326d78
+  id: a7934997-ab5f-5ca0-b33c-3b4cb7d6cdbc
   name:
     Ensure that the controller-manager.conf file permissions are set to 644 or
     more restrictive (Automated)

--- a/compliance/cis_k8s/rules/cis_1_1_18/data.yaml
+++ b/compliance/cis_k8s/rules/cis_1_1_18/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: bfd0bb4e-723e-5b06-8406-9deb0df21a0a
+  id: ff5979ab-a8a2-59cf-bd5d-9710467cd26d
   name:
     Ensure that the controller-manager.conf file ownership is set to root:root
     (Automated)

--- a/compliance/cis_k8s/rules/cis_1_1_18/data.yaml
+++ b/compliance/cis_k8s/rules/cis_1_1_18/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 2b17fa8d-8ec5-5f77-9555-f567cf67b317
+  id: bfd0bb4e-723e-5b06-8406-9deb0df21a0a
   name:
     Ensure that the controller-manager.conf file ownership is set to root:root
     (Automated)

--- a/compliance/cis_k8s/rules/cis_1_1_19/data.yaml
+++ b/compliance/cis_k8s/rules/cis_1_1_19/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: d24877cb-9be2-560b-af7f-048e4403f0de
+  id: 5b3c8400-8607-5a70-8f8d-1c2371158cab
   name: Ensure that the Kubernetes PKI directory and file ownership is set to
     root:root (Automated)
   profile_applicability: |

--- a/compliance/cis_k8s/rules/cis_1_1_19/data.yaml
+++ b/compliance/cis_k8s/rules/cis_1_1_19/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 5b3c8400-8607-5a70-8f8d-1c2371158cab
+  id: 905adab5-b2a6-587e-b67f-bb21c7853e9e
   name: Ensure that the Kubernetes PKI directory and file ownership is set to
     root:root (Automated)
   profile_applicability: |

--- a/compliance/cis_k8s/rules/cis_1_1_2/data.yaml
+++ b/compliance/cis_k8s/rules/cis_1_1_2/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: d486430b-7d20-533b-9cd3-56c66c99d178
+  id: 8f32167d-dfc6-59ee-9c87-8a2064aca533
   name: Ensure that the API server pod specification file ownership is set
     to root:root (Automated)
   profile_applicability: |

--- a/compliance/cis_k8s/rules/cis_1_1_2/data.yaml
+++ b/compliance/cis_k8s/rules/cis_1_1_2/data.yaml
@@ -1,7 +1,7 @@
 metadata:
   id: 9f318d4d-2451-574a-99dc-838ed213f09b
   name: Ensure that the API server pod specification file ownership is set
-    toroot:root (Automated)
+    to root:root (Automated)
   profile_applicability: |
     * Level 1 - Master Node
   description: >

--- a/compliance/cis_k8s/rules/cis_1_1_2/data.yaml
+++ b/compliance/cis_k8s/rules/cis_1_1_2/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 9f318d4d-2451-574a-99dc-838ed213f09b
+  id: d486430b-7d20-533b-9cd3-56c66c99d178
   name: Ensure that the API server pod specification file ownership is set
     to root:root (Automated)
   profile_applicability: |

--- a/compliance/cis_k8s/rules/cis_1_1_3/data.yaml
+++ b/compliance/cis_k8s/rules/cis_1_1_3/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: d158ac41-2286-5e67-9ce2-9b80f644b13b
+  id: 8f29fea4-cdfb-51c3-a835-a02118f030f4
   name:
     Ensure that the controller manager pod specification file permissions are
     set to 644 or more restrictive (Automated)

--- a/compliance/cis_k8s/rules/cis_1_1_3/data.yaml
+++ b/compliance/cis_k8s/rules/cis_1_1_3/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 8f29fea4-cdfb-51c3-a835-a02118f030f4
+  id: ab32940a-4fa1-5960-aba4-7307daa97b75
   name:
     Ensure that the controller manager pod specification file permissions are
     set to 644 or more restrictive (Automated)

--- a/compliance/cis_k8s/rules/cis_1_1_4/data.yaml
+++ b/compliance/cis_k8s/rules/cis_1_1_4/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 8085df96-208e-5887-ba64-d538aed3d129
+  id: 64fd497e-a0f1-5563-bda2-b431b0455948
   name:
     Ensure that the controller manager pod specification file ownership is set
     to root:root (Automated)

--- a/compliance/cis_k8s/rules/cis_1_1_4/data.yaml
+++ b/compliance/cis_k8s/rules/cis_1_1_4/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 64fd497e-a0f1-5563-bda2-b431b0455948
+  id: c7843101-b3fd-5984-b92b-08867162758b
   name:
     Ensure that the controller manager pod specification file ownership is set
     to root:root (Automated)

--- a/compliance/cis_k8s/rules/cis_1_1_5/data.yaml
+++ b/compliance/cis_k8s/rules/cis_1_1_5/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: b40c356d-df14-5e22-9cac-14b3c556bf55
+  id: 9fea8ee2-ca53-5721-aba3-663bd034deb3
   name: Ensure that the scheduler pod specification file permissions are set to
     644 or more restrictive (Automated)
   profile_applicability: |

--- a/compliance/cis_k8s/rules/cis_1_1_5/data.yaml
+++ b/compliance/cis_k8s/rules/cis_1_1_5/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 4bd09b51-e1ab-5b44-9df5-7dc2d4207cfb
+  id: b40c356d-df14-5e22-9cac-14b3c556bf55
   name: Ensure that the scheduler pod specification file permissions are set to
     644 or more restrictive (Automated)
   profile_applicability: |

--- a/compliance/cis_k8s/rules/cis_1_1_6/data.yaml
+++ b/compliance/cis_k8s/rules/cis_1_1_6/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: a92c7d1c-1fcf-5597-ba38-6cb9c024d213
+  id: 25f94b8a-c894-5bde-a5d5-f7f9d64a6c32
   name: Ensure that the scheduler pod specification file ownership is set
     to root:root (Automated)
   profile_applicability: |

--- a/compliance/cis_k8s/rules/cis_1_1_6/data.yaml
+++ b/compliance/cis_k8s/rules/cis_1_1_6/data.yaml
@@ -1,7 +1,7 @@
 metadata:
   id: a92c7d1c-1fcf-5597-ba38-6cb9c024d213
   name: Ensure that the scheduler pod specification file ownership is set
-    toroot:root (Automated)
+    to root:root (Automated)
   profile_applicability: |
     * Level 1 - Master Node
   description: >

--- a/compliance/cis_k8s/rules/cis_1_1_6/data.yaml
+++ b/compliance/cis_k8s/rules/cis_1_1_6/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 25f94b8a-c894-5bde-a5d5-f7f9d64a6c32
+  id: a1b8fd2b-2dcc-525f-a3ec-8439a84e8585
   name: Ensure that the scheduler pod specification file ownership is set
     to root:root (Automated)
   profile_applicability: |

--- a/compliance/cis_k8s/rules/cis_1_1_7/data.yaml
+++ b/compliance/cis_k8s/rules/cis_1_1_7/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 8d55e4c0-bb21-515f-ad9c-e99ad82bbcdd
+  id: e04fb8ba-dba6-59d2-b3dc-c4906b37f0a7
   name:
     Ensure that the etcd pod specification file permissions are set to 644 or
     more restrictive (Automated)

--- a/compliance/cis_k8s/rules/cis_1_1_7/data.yaml
+++ b/compliance/cis_k8s/rules/cis_1_1_7/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 02ec3af8-bd6d-58a3-857f-39b5744c6428
+  id: 8d55e4c0-bb21-515f-ad9c-e99ad82bbcdd
   name:
     Ensure that the etcd pod specification file permissions are set to 644 or
     more restrictive (Automated)

--- a/compliance/cis_k8s/rules/cis_1_1_8/data.yaml
+++ b/compliance/cis_k8s/rules/cis_1_1_8/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: c4183c2e-8a98-5fad-bcd7-37b4acd44dbf
+  id: 512cd755-c474-5da5-83fd-73f8af34d837
   name:
     Ensure that the etcd pod specification file ownership is set to root:root
     (Automated)

--- a/compliance/cis_k8s/rules/cis_1_1_8/data.yaml
+++ b/compliance/cis_k8s/rules/cis_1_1_8/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 512cd755-c474-5da5-83fd-73f8af34d837
+  id: ee8e3ec7-4850-5d82-a86c-41a40d46ba0e
   name:
     Ensure that the etcd pod specification file ownership is set to root:root
     (Automated)

--- a/compliance/cis_k8s/rules/cis_1_2_10/data.yaml
+++ b/compliance/cis_k8s/rules/cis_1_2_10/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: cd0f2309-6bab-5b1d-a95b-75c5058db77a
+  id: 89fcd9f5-ebc9-56b1-b34e-89dde7242104
   name: Ensure that the admission control plugin AlwaysAdmit is not set (Automated)
   profile_applicability: |
     * Level 1 - Master Node

--- a/compliance/cis_k8s/rules/cis_1_2_10/data.yaml
+++ b/compliance/cis_k8s/rules/cis_1_2_10/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 89fcd9f5-ebc9-56b1-b34e-89dde7242104
+  id: ea8d9694-1aed-5e7a-91d0-598b397f0218
   name: Ensure that the admission control plugin AlwaysAdmit is not set (Automated)
   profile_applicability: |
     * Level 1 - Master Node

--- a/compliance/cis_k8s/rules/cis_1_2_13/data.yaml
+++ b/compliance/cis_k8s/rules/cis_1_2_13/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: a6d7137d-334e-5a65-8f11-51df653cfb63
+  id: cf6ebe82-9367-5b8e-a117-c81ab11ba7d4
   name: Ensure that the admission control plugin ServiceAccount is set (Automated)
   profile_applicability: |
     * Level 1 - Master Node

--- a/compliance/cis_k8s/rules/cis_1_2_13/data.yaml
+++ b/compliance/cis_k8s/rules/cis_1_2_13/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 554702a0-63bf-500f-ae7a-c73ff746c15f
+  id: a6d7137d-334e-5a65-8f11-51df653cfb63
   name: Ensure that the admission control plugin ServiceAccount is set (Automated)
   profile_applicability: |
     * Level 1 - Master Node

--- a/compliance/cis_k8s/rules/cis_1_2_13/data.yaml
+++ b/compliance/cis_k8s/rules/cis_1_2_13/data.yaml
@@ -1,42 +1,36 @@
 metadata:
-  id: 9ad692c7-e8ee-5633-ac83-d7911467c2c0
-  name: Ensure that the admission control plugin SecurityContextDeny is set if
-    PodSecurityPolicy is not used (Manual)
+  id: 554702a0-63bf-500f-ae7a-c73ff746c15f
+  name: Ensure that the admission control plugin ServiceAccount is set (Automated)
   profile_applicability: |
     * Level 1 - Master Node
-  description: >
-    The SecurityContextDeny admission controller can be used to deny pods which
-    make use of
-    some SecurityContext fields which could allow for privilege escalation in the cluster. This
-    should be used where PodSecurityPolicy is not in place within the cluster.
+  description: |
+    Automate service accounts management.
   rationale: >
-    SecurityContextDeny can be used to provide a layer of security for clusters
-    which do not
-    have PodSecurityPolicies enabled.
+    When you create a pod, if you do not specify a service account, it is
+    automatically assigned the default service account in the same namespace.
+    You should create your own service account and let the API server manage its
+    security tokens.
   audit: |
     Run the following command on the master node:
     ```
     ps -ef | grep kube-apiserver
     ```
-    Verify that the `--enable-admission-plugins` argument is set to a value that includes
-    `SecurityContextDeny`, if `PodSecurityPolicy` is not included.
+    Verify that the `--disable-admission-plugins` argument is set to a value that does not
+    includes `ServiceAccount`.
   remediation: |
-    Edit the API server pod specification file `/etc/kubernetes/manifests/kube-apiserver.yaml`
-    on the master node and set the `--enable-admission-plugins` parameter
-    to include `SecurityContextDeny`, unless `PodSecurityPolicy` is already in place.
-    ```
-    --enable-admission-plugins=...,SecurityContextDeny,...
-    ```
-  impact: >
-    This admission controller should only be used where Pod Security Policies
-    cannot be used
-    on the cluster, as it can interact poorly with certain Pod Security Policies
+    Follow the documentation and create `ServiceAccount` objects as per your
+    environment.
+    Then, edit the API server pod specification file `/etc/kubernetes/manifests/kube-apiserver.yaml` 
+    on the master node and ensure that the `--disable-admission-plugins`
+    parameter is set to a value that does not include `ServiceAccount`.
+  impact: |
+    None.
   default_value: |
-    By default, `SecurityContextDeny` is not set.
+    By default, `ServiceAccount` is set.
   references: |
     1. [https://kubernetes.io/docs/admin/kube-apiserver/](https://kubernetes.io/docs/admin/kube-apiserver/)
-    2. [https://kubernetes.io/docs/admin/admission-controllers/#securitycontextdeny](https://kubernetes.io/docs/admin/admission-controllers/#securitycontextdeny)
-    3. [https://kubernetes.io/docs/user-guide/pod-security-policy/#working-with-rbac](https://kubernetes.io/docs/user-guide/pod-security-policy/#working-with-rbac)
+    2. [https://kubernetes.io/docs/admin/admission-controllers/#serviceaccount](https://kubernetes.io/docs/admin/admission-controllers/#serviceaccount)
+    3. [https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/](https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/)
   section: API Server
   version: "1.0"
   tags:

--- a/compliance/cis_k8s/rules/cis_1_2_14/data.yaml
+++ b/compliance/cis_k8s/rules/cis_1_2_14/data.yaml
@@ -1,36 +1,36 @@
 metadata:
-  id: 554702a0-63bf-500f-ae7a-c73ff746c15f
-  name: Ensure that the admission control plugin ServiceAccount is set (Automated)
+  id: f2506779-38af-5f7c-9928-5efb63c2b142
+  name: Ensure that the admission control plugin NamespaceLifecycle is set
+    (Automated)
   profile_applicability: |
     * Level 1 - Master Node
   description: |
-    Automate service accounts management.
+    Reject creating objects in a namespace that is undergoing termination.
   rationale: >
-    When you create a pod, if you do not specify a service account, it is
-    automatically assigned the default service account in the same namespace.
-    You should create your own service account and let the API server manage its
-    security tokens.
+    Setting admission control policy to `NamespaceLifecycle` ensures that
+    objects cannot be created in non-existent namespaces, and that namespaces
+    undergoing termination are not used for creating the new objects. This is
+    recommended to enforce the integrity of the namespace termination process
+    and also for the availability of the newer objects.
   audit: |
     Run the following command on the master node:
     ```
     ps -ef | grep kube-apiserver
     ```
     Verify that the `--disable-admission-plugins` argument is set to a value that does not
-    includes `ServiceAccount`.
+    include `NamespaceLifecycle`.
   remediation: |
-    Follow the documentation and create `ServiceAccount` objects as per your
-    environment.
-    Then, edit the API server pod specification file `/etc/kubernetes/manifests/kube-apiserver.yaml` 
-    on the master node and ensure that the `--disable-admission-plugins`
-    parameter is set to a value that does not include `ServiceAccount`.
+    Edit the API server pod specification file
+    `/etc/kubernetes/manifests/kube-apiserver.yaml` 
+    on the master node and set the `--disable-admission-plugins` parameter
+    to ensure it does not include `NamespaceLifecycle`.
   impact: |
-    None.
+    None
   default_value: |
-    By default, `ServiceAccount` is set.
+    By default, `NamespaceLifecycle` is set.
   references: |
     1. [https://kubernetes.io/docs/admin/kube-apiserver/](https://kubernetes.io/docs/admin/kube-apiserver/)
-    2. [https://kubernetes.io/docs/admin/admission-controllers/#serviceaccount](https://kubernetes.io/docs/admin/admission-controllers/#serviceaccount)
-    3. [https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/](https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/)
+    2. [https://kubernetes.io/docs/admin/admission-controllers/#namespacelifecycle](https://kubernetes.io/docs/admin/admission-controllers/#namespacelifecycle)
   section: API Server
   version: "1.0"
   tags:

--- a/compliance/cis_k8s/rules/cis_1_2_14/data.yaml
+++ b/compliance/cis_k8s/rules/cis_1_2_14/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: f2506779-38af-5f7c-9928-5efb63c2b142
+  id: a564ee39-c194-57b2-8ac1-608c134d2151
   name: Ensure that the admission control plugin NamespaceLifecycle is set
     (Automated)
   profile_applicability: |

--- a/compliance/cis_k8s/rules/cis_1_2_14/data.yaml
+++ b/compliance/cis_k8s/rules/cis_1_2_14/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: a564ee39-c194-57b2-8ac1-608c134d2151
+  id: 554a999e-c11a-5c1c-aa53-2badd123c122
   name: Ensure that the admission control plugin NamespaceLifecycle is set
     (Automated)
   profile_applicability: |

--- a/compliance/cis_k8s/rules/cis_1_2_15/data.yaml
+++ b/compliance/cis_k8s/rules/cis_1_2_15/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 2b2a4b02-652d-5398-9571-09b419617bd0
+  id: 01e7ea09-0a7c-5b7e-939b-6224ae702ddf
   name: Ensure that the admission control plugin PodSecurityPolicy is set (Automated)
   profile_applicability: |
     * Level 1 - Master Node

--- a/compliance/cis_k8s/rules/cis_1_2_15/data.yaml
+++ b/compliance/cis_k8s/rules/cis_1_2_15/data.yaml
@@ -1,36 +1,48 @@
 metadata:
-  id: f2506779-38af-5f7c-9928-5efb63c2b142
-  name: Ensure that the admission control plugin NamespaceLifecycle is set
-    (Automated)
+  id: 2b2a4b02-652d-5398-9571-09b419617bd0
+  name: Ensure that the admission control plugin PodSecurityPolicy is set (Automated)
   profile_applicability: |
     * Level 1 - Master Node
   description: |
-    Reject creating objects in a namespace that is undergoing termination.
-  rationale: >
-    Setting admission control policy to `NamespaceLifecycle` ensures that
-    objects cannot be created in non-existent namespaces, and that namespaces
-    undergoing termination are not used for creating the new objects. This is
-    recommended to enforce the integrity of the namespace termination process
-    and also for the availability of the newer objects.
+    Reject creating pods that do not match Pod Security Policies.
+  rationale: |
+    A Pod Security Policy is a cluster-level resource that controls the actions
+    that a pod can perform and what it has the ability to access. The
+    `PodSecurityPolicy` objects define a set of conditions that a pod must run
+    with in order to be accepted into the system. Pod Security Policies are
+    comprised of settings and strategies that control the security features a
+    pod has access to and hence this must be used to control pod access
+    permissions.
+    **Note:** When the PodSecurityPolicy admission plugin is in
+    use, there needs to be at least one PodSecurityPolicy in place for ANY pods
+    to be admitted. See section 5.2 for recommendations on PodSecurityPolicy
+    settings.
   audit: |
     Run the following command on the master node:
     ```
     ps -ef | grep kube-apiserver
     ```
-    Verify that the `--disable-admission-plugins` argument is set to a value that does not
-    include `NamespaceLifecycle`.
+    Verify that the `--enable-admission-plugins` argument is set to a value that includes
+    `PodSecurityPolicy`.
   remediation: |
-    Edit the API server pod specification file
-    `/etc/kubernetes/manifests/kube-apiserver.yaml` 
-    on the master node and set the `--disable-admission-plugins` parameter
-    to ensure it does not include `NamespaceLifecycle`.
-  impact: |
-    None
+    Follow the documentation and create Pod Security Policy objects as per your
+    environment.
+    Then, edit the API server pod specification file `/etc/kubernetes/manifests/kube-apiserver.yaml` 
+    on the master node and set the --enable-admission-plugins parameter
+    to a value that includes `PodSecurityPolicy`:
+    ```
+    --enable-admission-plugins=...,PodSecurityPolicy,...
+    ```
+    Then restart the API Server.
+  impact: >
+    The policy objects must be created and granted before pod creation would be
+    allowed.
   default_value: |
-    By default, `NamespaceLifecycle` is set.
+    By default, `PodSecurityPolicy` is not set.
   references: |
     1. [https://kubernetes.io/docs/admin/kube-apiserver/](https://kubernetes.io/docs/admin/kube-apiserver/)
-    2. [https://kubernetes.io/docs/admin/admission-controllers/#namespacelifecycle](https://kubernetes.io/docs/admin/admission-controllers/#namespacelifecycle)
+    2. [https://kubernetes.io/docs/admin/admission-controllers/#podsecuritypolicy](https://kubernetes.io/docs/admin/admission-controllers/#podsecuritypolicy)
+    3. [https://kubernetes.io/docs/concepts/policy/pod-security-policy/#enabling-pod-security-policies](https://kubernetes.io/docs/concepts/policy/pod-security-policy/#enabling-pod-security-policies)
   section: API Server
   version: "1.0"
   tags:

--- a/compliance/cis_k8s/rules/cis_1_2_15/data.yaml
+++ b/compliance/cis_k8s/rules/cis_1_2_15/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 01e7ea09-0a7c-5b7e-939b-6224ae702ddf
+  id: b38c72df-213c-5ab6-8f1d-d733dda8998d
   name: Ensure that the admission control plugin PodSecurityPolicy is set (Automated)
   profile_applicability: |
     * Level 1 - Master Node

--- a/compliance/cis_k8s/rules/cis_1_2_16/data.yaml
+++ b/compliance/cis_k8s/rules/cis_1_2_16/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: be41f82a-c318-51ce-a145-130e2a5583e2
+  id: f9863b0b-a309-58e5-b882-a462cb4b9731
   name: Ensure that the admission control plugin NodeRestriction is set (Automated)
   profile_applicability: |
     * Level 1 - Master Node

--- a/compliance/cis_k8s/rules/cis_1_2_16/data.yaml
+++ b/compliance/cis_k8s/rules/cis_1_2_16/data.yaml
@@ -1,48 +1,41 @@
 metadata:
-  id: 2b2a4b02-652d-5398-9571-09b419617bd0
-  name: Ensure that the admission control plugin PodSecurityPolicy is set (Automated)
+  id: bbf34c25-a149-5f8a-b452-f5fad717352a
+  name: Ensure that the admission control plugin NodeRestriction is set (Automated)
   profile_applicability: |
     * Level 1 - Master Node
   description: |
-    Reject creating pods that do not match Pod Security Policies.
-  rationale: |
-    A Pod Security Policy is a cluster-level resource that controls the actions
-    that a pod can perform and what it has the ability to access. The
-    `PodSecurityPolicy` objects define a set of conditions that a pod must run
-    with in order to be accepted into the system. Pod Security Policies are
-    comprised of settings and strategies that control the security features a
-    pod has access to and hence this must be used to control pod access
-    permissions.
-    **Note:** When the PodSecurityPolicy admission plugin is in
-    use, there needs to be at least one PodSecurityPolicy in place for ANY pods
-    to be admitted. See section 5.2 for recommendations on PodSecurityPolicy
-    settings.
+    Limit the `Node` and `Pod` objects that a kubelet could modify.
+  rationale: >
+    Using the `NodeRestriction` plug-in ensures that the kubelet is restricted
+    to the `Node` and Pod objects that it could modify as defined. Such kubelets
+    will only be allowed to modify their own `Node` API object, and only modify
+    `Pod` API objects that are bound to their node.
   audit: |
     Run the following command on the master node:
     ```
     ps -ef | grep kube-apiserver
     ```
     Verify that the `--enable-admission-plugins` argument is set to a value that includes
-    `PodSecurityPolicy`.
+    `NodeRestriction`.
   remediation: |
-    Follow the documentation and create Pod Security Policy objects as per your
-    environment.
+    Follow the Kubernetes documentation and configure `NodeRestriction` plug-in
+    on
+    kubelets.
     Then, edit the API server pod specification file `/etc/kubernetes/manifests/kube-apiserver.yaml` 
-    on the master node and set the --enable-admission-plugins parameter
-    to a value that includes `PodSecurityPolicy`:
+    on the master node and set the `--enable-admission-plugins` parameter
+    to a value that includes `NodeRestriction`.
     ```
-    --enable-admission-plugins=...,PodSecurityPolicy,...
+    --enable-admission-plugins=...,NodeRestriction,...
     ```
-    Then restart the API Server.
-  impact: >
-    The policy objects must be created and granted before pod creation would be
-    allowed.
+  impact: |
+    None
   default_value: |
-    By default, `PodSecurityPolicy` is not set.
+    By default, `NodeRestriction` is not set.
   references: |
     1. [https://kubernetes.io/docs/admin/kube-apiserver/](https://kubernetes.io/docs/admin/kube-apiserver/)
-    2. [https://kubernetes.io/docs/admin/admission-controllers/#podsecuritypolicy](https://kubernetes.io/docs/admin/admission-controllers/#podsecuritypolicy)
-    3. [https://kubernetes.io/docs/concepts/policy/pod-security-policy/#enabling-pod-security-policies](https://kubernetes.io/docs/concepts/policy/pod-security-policy/#enabling-pod-security-policies)
+    2. [https://kubernetes.io/docs/admin/admission-controllers/#noderestriction](https://kubernetes.io/docs/admin/admission-controllers/#noderestriction)
+    3. [https://kubernetes.io/docs/admin/authorization/node/](https://kubernetes.io/docs/admin/authorization/node/)
+    4. [https://acotten.com/post/kube17-security](https://acotten.com/post/kube17-security)
   section: API Server
   version: "1.0"
   tags:

--- a/compliance/cis_k8s/rules/cis_1_2_16/data.yaml
+++ b/compliance/cis_k8s/rules/cis_1_2_16/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: bbf34c25-a149-5f8a-b452-f5fad717352a
+  id: be41f82a-c318-51ce-a145-130e2a5583e2
   name: Ensure that the admission control plugin NodeRestriction is set (Automated)
   profile_applicability: |
     * Level 1 - Master Node

--- a/compliance/cis_k8s/rules/cis_1_2_17/data.yaml
+++ b/compliance/cis_k8s/rules/cis_1_2_17/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 40fe9500-a770-533b-9db1-f584385c8c5e
+  id: fc3238f2-44b6-501d-b5c8-d88df0611d65
   name: Ensure that the --insecure-bind-address argument is not set (Automated)
   profile_applicability: |
     * Level 1 - Master Node

--- a/compliance/cis_k8s/rules/cis_1_2_17/data.yaml
+++ b/compliance/cis_k8s/rules/cis_1_2_17/data.yaml
@@ -1,41 +1,34 @@
 metadata:
-  id: bbf34c25-a149-5f8a-b452-f5fad717352a
-  name: Ensure that the admission control plugin NodeRestriction is set (Automated)
+  id: 40fe9500-a770-533b-9db1-f584385c8c5e
+  name: Ensure that the --insecure-bind-address argument is not set (Automated)
   profile_applicability: |
     * Level 1 - Master Node
   description: |
-    Limit the `Node` and `Pod` objects that a kubelet could modify.
+    Do not bind the insecure API service.
   rationale: >
-    Using the `NodeRestriction` plug-in ensures that the kubelet is restricted
-    to the `Node` and Pod objects that it could modify as defined. Such kubelets
-    will only be allowed to modify their own `Node` API object, and only modify
-    `Pod` API objects that are bound to their node.
+    If you bind the apiserver to an insecure address, basically anyone who could
+    connect to it over the insecure port, would have unauthenticated and
+    unencrypted access to your master node. The apiserver doesn't do any
+    authentication checking for insecure binds and traffic to the Insecure API
+    port is not encrpyted, allowing attackers to potentially read sensitive data
+    in transit.
   audit: |
     Run the following command on the master node:
     ```
     ps -ef | grep kube-apiserver
     ```
-    Verify that the `--enable-admission-plugins` argument is set to a value that includes
-    `NodeRestriction`.
+    Verify that the `--insecure-bind-address` argument does not exist.
   remediation: |
-    Follow the Kubernetes documentation and configure `NodeRestriction` plug-in
-    on
-    kubelets.
-    Then, edit the API server pod specification file `/etc/kubernetes/manifests/kube-apiserver.yaml` 
-    on the master node and set the `--enable-admission-plugins` parameter
-    to a value that includes `NodeRestriction`.
-    ```
-    --enable-admission-plugins=...,NodeRestriction,...
-    ```
+    Edit the API server pod specification file
+    `/etc/kubernetes/manifests/kube-apiserver.yaml` 
+    on the master node and remove the `--insecure-bind-address`
+    parameter.
   impact: |
-    None
+    Connections to the API server will require valid authentication credentials.
   default_value: |
-    By default, `NodeRestriction` is not set.
+    By default, the insecure bind address is not set.
   references: |
     1. [https://kubernetes.io/docs/admin/kube-apiserver/](https://kubernetes.io/docs/admin/kube-apiserver/)
-    2. [https://kubernetes.io/docs/admin/admission-controllers/#noderestriction](https://kubernetes.io/docs/admin/admission-controllers/#noderestriction)
-    3. [https://kubernetes.io/docs/admin/authorization/node/](https://kubernetes.io/docs/admin/authorization/node/)
-    4. [https://acotten.com/post/kube17-security](https://acotten.com/post/kube17-security)
   section: API Server
   version: "1.0"
   tags:

--- a/compliance/cis_k8s/rules/cis_1_2_17/data.yaml
+++ b/compliance/cis_k8s/rules/cis_1_2_17/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: fc3238f2-44b6-501d-b5c8-d88df0611d65
+  id: d1ce21d2-3345-5c0a-a41a-5f572cc431f6
   name: Ensure that the --insecure-bind-address argument is not set (Automated)
   profile_applicability: |
     * Level 1 - Master Node

--- a/compliance/cis_k8s/rules/cis_1_2_18/data.yaml
+++ b/compliance/cis_k8s/rules/cis_1_2_18/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 1685e5fb-2df6-5484-a7eb-274530fb86fe
+  id: 50ae51db-6bd4-5b20-92c9-fe83fed7efa5
   name: Ensure that the --insecure-port argument is set to 0 (Automated)
   profile_applicability: |
     * Level 1 - Master Node

--- a/compliance/cis_k8s/rules/cis_1_2_18/data.yaml
+++ b/compliance/cis_k8s/rules/cis_1_2_18/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 4c3550cf-a3f8-5384-8ada-ec7c383c4f36
+  id: 1685e5fb-2df6-5484-a7eb-274530fb86fe
   name: Ensure that the --insecure-port argument is set to 0 (Automated)
   profile_applicability: |
     * Level 1 - Master Node

--- a/compliance/cis_k8s/rules/cis_1_2_18/data.yaml
+++ b/compliance/cis_k8s/rules/cis_1_2_18/data.yaml
@@ -1,32 +1,36 @@
 metadata:
-  id: 40fe9500-a770-533b-9db1-f584385c8c5e
-  name: Ensure that the --insecure-bind-address argument is not set (Automated)
+  id: 4c3550cf-a3f8-5384-8ada-ec7c383c4f36
+  name: Ensure that the --insecure-port argument is set to 0 (Automated)
   profile_applicability: |
     * Level 1 - Master Node
   description: |
-    Do not bind the insecure API service.
+    Do not bind to insecure port.
   rationale: >
-    If you bind the apiserver to an insecure address, basically anyone who could
-    connect to it over the insecure port, would have unauthenticated and
-    unencrypted access to your master node. The apiserver doesn't do any
-    authentication checking for insecure binds and traffic to the Insecure API
-    port is not encrpyted, allowing attackers to potentially read sensitive data
-    in transit.
+    Setting up the apiserver to serve on an insecure port would allow
+    unauthenticated and unencrypted access to your master node. This would allow
+    attackers who could access this port, to easily take control of the cluster.
   audit: |
     Run the following command on the master node:
     ```
     ps -ef | grep kube-apiserver
     ```
-    Verify that the `--insecure-bind-address` argument does not exist.
+    Verify that the `--insecure-port` argument is set to `0`.
   remediation: |
     Edit the API server pod specification file
     `/etc/kubernetes/manifests/kube-apiserver.yaml` 
-    on the master node and remove the `--insecure-bind-address`
-    parameter.
+    on the master node and set the below parameter.
+    ```
+    --insecure-port=0
+    ```
   impact: |
-    Connections to the API server will require valid authentication credentials.
+    All components that use the API must connect via the secured port,
+    authenticate themselves, and be authorized to use the API. This includes: 
+    * kube-controller-manager 
+    * kube-proxy 
+    * kube-scheduler 
+    * kubelets
   default_value: |
-    By default, the insecure bind address is not set.
+    By default, the insecure port is set to 8080.
   references: |
     1. [https://kubernetes.io/docs/admin/kube-apiserver/](https://kubernetes.io/docs/admin/kube-apiserver/)
   section: API Server

--- a/compliance/cis_k8s/rules/cis_1_2_19/data.yaml
+++ b/compliance/cis_k8s/rules/cis_1_2_19/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 9c1f03c9-5153-563d-8a60-9308e101b722
+  id: 2c7c9ced-5a86-5a72-9688-4bc6a75ce89a
   name: Ensure that the --secure-port argument is not set to 0 (Automated)
   profile_applicability: |
     * Level 1 - Master Node

--- a/compliance/cis_k8s/rules/cis_1_2_19/data.yaml
+++ b/compliance/cis_k8s/rules/cis_1_2_19/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 0cda5474-0196-500b-b349-8cddf1c8adea
+  id: 9c1f03c9-5153-563d-8a60-9308e101b722
   name: Ensure that the --secure-port argument is not set to 0 (Automated)
   profile_applicability: |
     * Level 1 - Master Node

--- a/compliance/cis_k8s/rules/cis_1_2_19/data.yaml
+++ b/compliance/cis_k8s/rules/cis_1_2_19/data.yaml
@@ -1,36 +1,30 @@
 metadata:
-  id: 4c3550cf-a3f8-5384-8ada-ec7c383c4f36
-  name: Ensure that the --insecure-port argument is set to 0 (Automated)
+  id: 0cda5474-0196-500b-b349-8cddf1c8adea
+  name: Ensure that the --secure-port argument is not set to 0 (Automated)
   profile_applicability: |
     * Level 1 - Master Node
   description: |
-    Do not bind to insecure port.
+    Do not disable the secure port.
   rationale: >
-    Setting up the apiserver to serve on an insecure port would allow
-    unauthenticated and unencrypted access to your master node. This would allow
-    attackers who could access this port, to easily take control of the cluster.
+    The secure port is used to serve https with authentication and
+    authorization. If you disable it, no https traffic is served and all traffic
+    is served unencrypted.
   audit: |
     Run the following command on the master node:
     ```
     ps -ef | grep kube-apiserver
     ```
-    Verify that the `--insecure-port` argument is set to `0`.
+    Verify that the `--secure-port` argument is either not set or is set to an integer value
+    between 1 and 65535.
   remediation: |
     Edit the API server pod specification file
     `/etc/kubernetes/manifests/kube-apiserver.yaml` 
-    on the master node and set the below parameter.
-    ```
-    --insecure-port=0
-    ```
+    on the master node and either remove the `--secure-port` parameter or
+    set it to a different (non-zero) desired port.
   impact: |
-    All components that use the API must connect via the secured port,
-    authenticate themselves, and be authorized to use the API. This includes: 
-    * kube-controller-manager 
-    * kube-proxy 
-    * kube-scheduler 
-    * kubelets
+    You need to set the API Server up with the right TLS certificates.
   default_value: |
-    By default, the insecure port is set to 8080.
+    By default, port 6443 is used as the secure port.
   references: |
     1. [https://kubernetes.io/docs/admin/kube-apiserver/](https://kubernetes.io/docs/admin/kube-apiserver/)
   section: API Server

--- a/compliance/cis_k8s/rules/cis_1_2_2/data.yaml
+++ b/compliance/cis_k8s/rules/cis_1_2_2/data.yaml
@@ -1,37 +1,36 @@
 metadata:
-  id: ee6dc700-33d2-5799-91cb-fa397106db2d
-  name: Ensure that the --basic-auth-file argument is not set (Automated)
+  id: 6c595b13-8d46-5c74-9d49-d6c023303be5
+  name: Ensure that the --token-auth-file parameter is not set (Automated)
   profile_applicability: |
     * Level 1 - Master Node
   description: |
-    Do not use basic authentication.
+    Do not use token based authentication.
   rationale: >
-    Basic authentication uses plaintext credentials for authentication.
-    Currently, the basic authentication credentials last indefinitely, and the
-    password cannot be changed without restarting the API server. The basic
-    authentication is currently supported for convenience. Hence, basic
-    authentication should not be used.
+    The token-based authentication utilizes static tokens to authenticate
+    requests to the apiserver. The tokens are stored in clear-text in a file on
+    the apiserver, and cannot be revoked or rotated without restarting the
+    apiserver. Hence, do not use static token-based authentication.
   audit: |
     Run the following command on the master node:
     ```
     ps -ef | grep kube-apiserver
     ```
-    Verify that the `--basic-auth-file` argument does not exist.
+    Verify that the `--token-auth-file` argument does not exist.
   remediation: |
     Follow the documentation and configure alternate mechanisms for
     authentication. Then,
-    edit the API server pod specification file `/etc/kubernetes/manifests/kube-apiserver.yaml`
-    on the master node and remove the `--basic-auth-file=<filename>`
+    edit the API server pod specification file `/etc/kubernetes/manifests/kube-apiserver.yaml` 
+    on the master node and remove the `--token-auth-file=<filename>`
     parameter.
   impact: >
     You will have to configure and use alternate authentication mechanisms such
-    as tokens and certificates. Username and password for basic authentication
-    could no longer be used.
+    as
+    certificates. Static token based authentication could not be used.
   default_value: |
-    By default, basic authentication is not set.
+    By default, `--token-auth-file` argument is not set.
   references: |
-    1. [https://kubernetes.io/docs/admin/kube-apiserver/](https://kubernetes.io/docs/admin/kube-apiserver/)
-    2. [https://kubernetes.io/docs/admin/authentication/#static-password-file](https://kubernetes.io/docs/admin/authentication/#static-password-file)
+    1. [https://kubernetes.io/docs/admin/authentication/#static-token-file](https://kubernetes.io/docs/admin/authentication/#static-token-file)
+    2. [https://kubernetes.io/docs/admin/kube-apiserver/](https://kubernetes.io/docs/admin/kube-apiserver/)
   section: API Server
   version: "1.0"
   tags:

--- a/compliance/cis_k8s/rules/cis_1_2_2/data.yaml
+++ b/compliance/cis_k8s/rules/cis_1_2_2/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 012b9ce0-7354-50aa-85dc-c9a433c872a8
+  id: 06391584-8964-5a71-9243-55396a3a01e7
   name: Ensure that the --token-auth-file parameter is not set (Automated)
   profile_applicability: |
     * Level 1 - Master Node

--- a/compliance/cis_k8s/rules/cis_1_2_2/data.yaml
+++ b/compliance/cis_k8s/rules/cis_1_2_2/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 6c595b13-8d46-5c74-9d49-d6c023303be5
+  id: 012b9ce0-7354-50aa-85dc-c9a433c872a8
   name: Ensure that the --token-auth-file parameter is not set (Automated)
   profile_applicability: |
     * Level 1 - Master Node

--- a/compliance/cis_k8s/rules/cis_1_2_20/data.yaml
+++ b/compliance/cis_k8s/rules/cis_1_2_20/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: fb1fff6d-2d6a-5d23-92a1-fdb7c4f28ddf
+  id: c24bf963-7d41-5b4f-9724-c53133a6d495
   name: Ensure that the --profiling argument is set to false (Automated)
   profile_applicability: |
     * Level 1 - Master Node

--- a/compliance/cis_k8s/rules/cis_1_2_20/data.yaml
+++ b/compliance/cis_k8s/rules/cis_1_2_20/data.yaml
@@ -1,32 +1,36 @@
 metadata:
-  id: 0cda5474-0196-500b-b349-8cddf1c8adea
-  name: Ensure that the --secure-port argument is not set to 0 (Automated)
+  id: 3a6adba9-dd4d-562c-a861-60eee7309f07
+  name: Ensure that the --profiling argument is set to false (Automated)
   profile_applicability: |
     * Level 1 - Master Node
   description: |
-    Do not disable the secure port.
+    Disable profiling, if not needed.
   rationale: >
-    The secure port is used to serve https with authentication and
-    authorization. If you disable it, no https traffic is served and all traffic
-    is served unencrypted.
+    Profiling allows for the identification of specific performance bottlenecks.
+    It generates a significant amount of program data that could potentially be
+    exploited to uncover system and program details. If you are not experiencing
+    any bottlenecks and do not need the profiler for troubleshooting purposes,
+    it is recommended to turn it off to reduce the potential attack surface.
   audit: |
     Run the following command on the master node:
     ```
     ps -ef | grep kube-apiserver
     ```
-    Verify that the `--secure-port` argument is either not set or is set to an integer value
-    between 1 and 65535.
+    Verify that the `--profiling` argument is set to `false`.
   remediation: |
     Edit the API server pod specification file
     `/etc/kubernetes/manifests/kube-apiserver.yaml` 
-    on the master node and either remove the `--secure-port` parameter or
-    set it to a different (non-zero) desired port.
+    on the master node and set the below parameter.
+    ```
+    --profiling=false
+    ```
   impact: |
-    You need to set the API Server up with the right TLS certificates.
+    Profiling information would not be available.
   default_value: |
-    By default, port 6443 is used as the secure port.
+    By default, profiling is enabled.
   references: |
     1. [https://kubernetes.io/docs/admin/kube-apiserver/](https://kubernetes.io/docs/admin/kube-apiserver/)
+    2. [https://github.com/kubernetes/community/blob/master/contributors/devel/profiling.md](https://github.com/kubernetes/community/blob/master/contributors/devel/profiling.md)
   section: API Server
   version: "1.0"
   tags:

--- a/compliance/cis_k8s/rules/cis_1_2_20/data.yaml
+++ b/compliance/cis_k8s/rules/cis_1_2_20/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 3a6adba9-dd4d-562c-a861-60eee7309f07
+  id: fb1fff6d-2d6a-5d23-92a1-fdb7c4f28ddf
   name: Ensure that the --profiling argument is set to false (Automated)
   profile_applicability: |
     * Level 1 - Master Node

--- a/compliance/cis_k8s/rules/cis_1_2_21/data.yaml
+++ b/compliance/cis_k8s/rules/cis_1_2_21/data.yaml
@@ -1,36 +1,40 @@
 metadata:
-  id: 3a6adba9-dd4d-562c-a861-60eee7309f07
-  name: Ensure that the --profiling argument is set to false (Automated)
+  id: dbea59ce-10c6-5cfe-a223-8e8aa5996730
+  name: Ensure that the --audit-log-path argument is set (Automated)
   profile_applicability: |
     * Level 1 - Master Node
-  description: |
-    Disable profiling, if not needed.
+  description: >
+    Enable auditing on the Kubernetes API Server and set the desired audit log
+    path.
   rationale: >
-    Profiling allows for the identification of specific performance bottlenecks.
-    It generates a significant amount of program data that could potentially be
-    exploited to uncover system and program details. If you are not experiencing
-    any bottlenecks and do not need the profiler for troubleshooting purposes,
-    it is recommended to turn it off to reduce the potential attack surface.
+    Auditing the Kubernetes API Server provides a security-relevant
+    chronological set of records documenting the sequence of activities that
+    have affected system by individual users, administrators or other components
+    of the system. Even though currently, Kubernetes provides only basic audit
+    capabilities, it should be enabled. You can enable it by setting an
+    appropriate audit log path.
   audit: |
     Run the following command on the master node:
     ```
     ps -ef | grep kube-apiserver
     ```
-    Verify that the `--profiling` argument is set to `false`.
+    Verify that the `--audit-log-path` argument is set as appropriate.
   remediation: |
     Edit the API server pod specification file
     `/etc/kubernetes/manifests/kube-apiserver.yaml` 
-    on the master node and set the below parameter.
+    on the master node and set the `--audit-log-path` parameter to a suitable
+    path and file where you would like audit logs to be written, for example:
     ```
-    --profiling=false
+    --audit-log-path=/var/log/apiserver/audit.log
     ```
   impact: |
-    Profiling information would not be available.
+    None
   default_value: |
-    By default, profiling is enabled.
+    By default, auditing is not enabled.
   references: |
     1. [https://kubernetes.io/docs/admin/kube-apiserver/](https://kubernetes.io/docs/admin/kube-apiserver/)
-    2. [https://github.com/kubernetes/community/blob/master/contributors/devel/profiling.md](https://github.com/kubernetes/community/blob/master/contributors/devel/profiling.md)
+    2. [https://kubernetes.io/docs/concepts/cluster-administration/audit/](https://kubernetes.io/docs/concepts/cluster-administration/audit/)
+    3. [https://github.com/kubernetes/features/issues/22](https://github.com/kubernetes/features/issues/22)
   section: API Server
   version: "1.0"
   tags:

--- a/compliance/cis_k8s/rules/cis_1_2_21/data.yaml
+++ b/compliance/cis_k8s/rules/cis_1_2_21/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: e05c6215-48b9-5faf-98ce-da785e2cf5c1
+  id: 8c7d61f2-700a-5822-8f6b-e36ad193f83e
   name: Ensure that the --audit-log-path argument is set (Automated)
   profile_applicability: |
     * Level 1 - Master Node

--- a/compliance/cis_k8s/rules/cis_1_2_21/data.yaml
+++ b/compliance/cis_k8s/rules/cis_1_2_21/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: dbea59ce-10c6-5cfe-a223-8e8aa5996730
+  id: e05c6215-48b9-5faf-98ce-da785e2cf5c1
   name: Ensure that the --audit-log-path argument is set (Automated)
   profile_applicability: |
     * Level 1 - Master Node

--- a/compliance/cis_k8s/rules/cis_1_2_22/data.yaml
+++ b/compliance/cis_k8s/rules/cis_1_2_22/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: a8baf73d-849a-56d9-98f9-2bed9cc92875
+  id: 46915475-4d12-5d36-87f7-1c945933fa53
   name:
     Ensure that the --audit-log-maxage argument is set to 30 or as appropriate
     (Automated)

--- a/compliance/cis_k8s/rules/cis_1_2_22/data.yaml
+++ b/compliance/cis_k8s/rules/cis_1_2_22/data.yaml
@@ -1,31 +1,30 @@
 metadata:
-  id: dbea59ce-10c6-5cfe-a223-8e8aa5996730
-  name: Ensure that the --audit-log-path argument is set (Automated)
+  id: a8baf73d-849a-56d9-98f9-2bed9cc92875
+  name:
+    Ensure that the --audit-log-maxage argument is set to 30 or as appropriate
+    (Automated)
   profile_applicability: |
     * Level 1 - Master Node
-  description: >
-    Enable auditing on the Kubernetes API Server and set the desired audit log
-    path.
+  description: |
+    Retain the logs for at least 30 days or as appropriate.
   rationale: >
-    Auditing the Kubernetes API Server provides a security-relevant
-    chronological set of records documenting the sequence of activities that
-    have affected system by individual users, administrators or other components
-    of the system. Even though currently, Kubernetes provides only basic audit
-    capabilities, it should be enabled. You can enable it by setting an
-    appropriate audit log path.
+    Retaining logs for at least 30 days ensures that you can go back in time and
+    investigate or
+    correlate any events. Set your audit log retention period to 30 days or as per your business
+    requirements.
   audit: |
     Run the following command on the master node:
     ```
     ps -ef | grep kube-apiserver
     ```
-    Verify that the `--audit-log-path` argument is set as appropriate.
+    Verify that the `--audit-log-maxage` argument is set to `30` or as appropriate.
   remediation: |
     Edit the API server pod specification file
     `/etc/kubernetes/manifests/kube-apiserver.yaml` 
-    on the master node and set the `--audit-log-path` parameter to a suitable
-    path and file where you would like audit logs to be written, for example:
+    on the master node and set the `--audit-log-maxage` parameter to 30 or
+    as an appropriate number of days:
     ```
-    --audit-log-path=/var/log/apiserver/audit.log
+    --audit-log-maxage=30
     ```
   impact: |
     None

--- a/compliance/cis_k8s/rules/cis_1_2_22/data.yaml
+++ b/compliance/cis_k8s/rules/cis_1_2_22/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 46915475-4d12-5d36-87f7-1c945933fa53
+  id: 26238d57-74fd-52a4-af97-7bb8ff60f0b3
   name:
     Ensure that the --audit-log-maxage argument is set to 30 or as appropriate
     (Automated)

--- a/compliance/cis_k8s/rules/cis_1_2_23/data.yaml
+++ b/compliance/cis_k8s/rules/cis_1_2_23/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: b1603a8d-b5e0-5517-b74c-69fb641cdd13
+  id: d38c12e3-ea42-5104-95be-b02fe0751193
   name: Ensure that the --audit-log-maxbackup argument is set to 10 or as
     appropriate (Automated)
   profile_applicability: |

--- a/compliance/cis_k8s/rules/cis_1_2_23/data.yaml
+++ b/compliance/cis_k8s/rules/cis_1_2_23/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 78d44045-eb34-5c51-b78f-51d7e0f3d530
+  id: b1603a8d-b5e0-5517-b74c-69fb641cdd13
   name: Ensure that the --audit-log-maxbackup argument is set to 10 or as
     appropriate (Automated)
   profile_applicability: |

--- a/compliance/cis_k8s/rules/cis_1_2_23/data.yaml
+++ b/compliance/cis_k8s/rules/cis_1_2_23/data.yaml
@@ -1,30 +1,30 @@
 metadata:
-  id: a8baf73d-849a-56d9-98f9-2bed9cc92875
-  name:
-    Ensure that the --audit-log-maxage argument is set to 30 or as appropriate
-    (Automated)
+  id: 78d44045-eb34-5c51-b78f-51d7e0f3d530
+  name: Ensure that the --audit-log-maxbackup argument is set to 10 or as
+    appropriate (Automated)
   profile_applicability: |
     * Level 1 - Master Node
   description: |
-    Retain the logs for at least 30 days or as appropriate.
+    Retain 10 or an appropriate number of old log files.
   rationale: >
-    Retaining logs for at least 30 days ensures that you can go back in time and
-    investigate or
-    correlate any events. Set your audit log retention period to 30 days or as per your business
-    requirements.
+    Kubernetes automatically rotates the log files. Retaining old log files
+    ensures that you would have sufficient log data available for carrying out
+    any investigation or correlation. For example, if you have set file size of
+    100 MB and the number of old log files to keep as 10, you would approximate
+    have 1 GB of log data that you could potentially use for your analysis.
   audit: |
     Run the following command on the master node:
     ```
     ps -ef | grep kube-apiserver
     ```
-    Verify that the `--audit-log-maxage` argument is set to `30` or as appropriate.
+    Verify that the `--audit-log-maxbackup` argument is set to `10` or as appropriate.
   remediation: |
     Edit the API server pod specification file
     `/etc/kubernetes/manifests/kube-apiserver.yaml` 
-    on the master node and set the `--audit-log-maxage` parameter to 30 or
-    as an appropriate number of days:
+    on the master node and set the `--audit-log-maxbackup` parameter to 10
+    or to an appropriate value.
     ```
-    --audit-log-maxage=30
+    --audit-log-maxbackup=10
     ```
   impact: |
     None

--- a/compliance/cis_k8s/rules/cis_1_2_24/data.yaml
+++ b/compliance/cis_k8s/rules/cis_1_2_24/data.yaml
@@ -1,30 +1,30 @@
 metadata:
-  id: 78d44045-eb34-5c51-b78f-51d7e0f3d530
-  name: Ensure that the --audit-log-maxbackup argument is set to 10 or as
+  id: fb1ee6c2-003d-54eb-9014-fa7ac99f5551
+  name: Ensure that the --audit-log-maxsize argument is set to 100 or as
     appropriate (Automated)
   profile_applicability: |
     * Level 1 - Master Node
   description: |
-    Retain 10 or an appropriate number of old log files.
+    Rotate log files on reaching 100 MB or as appropriate.
   rationale: >
     Kubernetes automatically rotates the log files. Retaining old log files
     ensures that you would have sufficient log data available for carrying out
-    any investigation or correlation. For example, if you have set file size of
-    100 MB and the number of old log files to keep as 10, you would approximate
-    have 1 GB of log data that you could potentially use for your analysis.
+    any investigation or correlation. If you have set file size of 100 MB and
+    the number of old log files to keep as 10, you would approximate have 1 GB
+    of log data that you could potentially use for your analysis.
   audit: |
     Run the following command on the master node:
     ```
     ps -ef | grep kube-apiserver
     ```
-    Verify that the `--audit-log-maxbackup` argument is set to `10` or as appropriate.
+    Verify that the `--audit-log-maxsize` argument is set to `100` or as appropriate.
   remediation: |
     Edit the API server pod specification file
     `/etc/kubernetes/manifests/kube-apiserver.yaml` 
-    on the master node and set the `--audit-log-maxbackup` parameter to 10
-    or to an appropriate value.
+    on the master node and set the `--audit-log-maxsize` parameter to an
+    appropriate size in MB. For example, to set it as 100 MB:
     ```
-    --audit-log-maxbackup=10
+    --audit-log-maxsize=100
     ```
   impact: |
     None

--- a/compliance/cis_k8s/rules/cis_1_2_24/data.yaml
+++ b/compliance/cis_k8s/rules/cis_1_2_24/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: cfb09d6e-73c6-5b9e-8c1d-7626e89c3ff7
+  id: 48f54c21-ebec-5812-ad39-ec3ab5cb53db
   name: Ensure that the --audit-log-maxsize argument is set to 100 or as
     appropriate (Automated)
   profile_applicability: |

--- a/compliance/cis_k8s/rules/cis_1_2_24/data.yaml
+++ b/compliance/cis_k8s/rules/cis_1_2_24/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: fb1ee6c2-003d-54eb-9014-fa7ac99f5551
+  id: cfb09d6e-73c6-5b9e-8c1d-7626e89c3ff7
   name: Ensure that the --audit-log-maxsize argument is set to 100 or as
     appropriate (Automated)
   profile_applicability: |

--- a/compliance/cis_k8s/rules/cis_1_2_25/data.yaml
+++ b/compliance/cis_k8s/rules/cis_1_2_25/data.yaml
@@ -1,6 +1,6 @@
 metadata:
   id: 05be3248-f136-5e7c-99fa-3b40f0b1d0dc
-  name: Ensure that the --request-timeout argument is set as appropriate (Automated)
+  name: Ensure that the --request-timeout argument is set as appropriate (Manual)
   profile_applicability: |
     * Level 1 - Master Node
   description: |

--- a/compliance/cis_k8s/rules/cis_1_2_25/data.yaml
+++ b/compliance/cis_k8s/rules/cis_1_2_25/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 3c53340a-6a9c-56f8-824a-0e9241adc176
+  id: fcd7d8c6-5ef3-591d-81cf-8f37cf1e75c3
   name: Ensure that the --request-timeout argument is set as appropriate (Manual)
   profile_applicability: |
     * Level 1 - Master Node

--- a/compliance/cis_k8s/rules/cis_1_2_25/data.yaml
+++ b/compliance/cis_k8s/rules/cis_1_2_25/data.yaml
@@ -1,39 +1,41 @@
 metadata:
-  id: fb1ee6c2-003d-54eb-9014-fa7ac99f5551
-  name: Ensure that the --audit-log-maxsize argument is set to 100 or as
-    appropriate (Automated)
+  id: 05be3248-f136-5e7c-99fa-3b40f0b1d0dc
+  name: Ensure that the --request-timeout argument is set as appropriate (Automated)
   profile_applicability: |
     * Level 1 - Master Node
   description: |
-    Rotate log files on reaching 100 MB or as appropriate.
+    Set global request timeout for API server requests as appropriate.
   rationale: >
-    Kubernetes automatically rotates the log files. Retaining old log files
-    ensures that you would have sufficient log data available for carrying out
-    any investigation or correlation. If you have set file size of 100 MB and
-    the number of old log files to keep as 10, you would approximate have 1 GB
-    of log data that you could potentially use for your analysis.
+    Setting global request timeout allows extending the API server request
+    timeout limit to a duration appropriate to the user's connection speed. By
+    default, it is set to 60 seconds which might be problematic on slower
+    connections making cluster resources inaccessible once the data volume for
+    requests exceeds what can be transmitted in 60 seconds. But, setting this
+    timeout limit to be too large can exhaust the API server resources making it
+    prone to Denial-of-Service attack. Hence, it is recommended to set this
+    limit as appropriate and change the default limit of 60 seconds only if
+    needed.
   audit: |
     Run the following command on the master node:
     ```
     ps -ef | grep kube-apiserver
     ```
-    Verify that the `--audit-log-maxsize` argument is set to `100` or as appropriate.
+    Verify that the `--request-timeout` argument is either not set or set to an appropriate
+    value.
   remediation: |
     Edit the API server pod specification file
     `/etc/kubernetes/manifests/kube-apiserver.yaml` 
-    on the master node and set the `--audit-log-maxsize` parameter to an
-    appropriate size in MB. For example, to set it as 100 MB:
+    and set the below parameter as appropriate and if needed. For example,
     ```
-    --audit-log-maxsize=100
+    --request-timeout=300s
     ```
   impact: |
     None
   default_value: |
-    By default, auditing is not enabled.
+    By default, `--request-timeout` is set to 60 seconds.
   references: |
     1. [https://kubernetes.io/docs/admin/kube-apiserver/](https://kubernetes.io/docs/admin/kube-apiserver/)
-    2. [https://kubernetes.io/docs/concepts/cluster-administration/audit/](https://kubernetes.io/docs/concepts/cluster-administration/audit/)
-    3. [https://github.com/kubernetes/features/issues/22](https://github.com/kubernetes/features/issues/22)
+    2. [https://github.com/kubernetes/kubernetes/pull/51415](https://github.com/kubernetes/kubernetes/pull/51415)
   section: API Server
   version: "1.0"
   tags:

--- a/compliance/cis_k8s/rules/cis_1_2_25/data.yaml
+++ b/compliance/cis_k8s/rules/cis_1_2_25/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 05be3248-f136-5e7c-99fa-3b40f0b1d0dc
+  id: 3c53340a-6a9c-56f8-824a-0e9241adc176
   name: Ensure that the --request-timeout argument is set as appropriate (Manual)
   profile_applicability: |
     * Level 1 - Master Node

--- a/compliance/cis_k8s/rules/cis_1_2_26/data.yaml
+++ b/compliance/cis_k8s/rules/cis_1_2_26/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: aae399a2-5b38-51f6-8f69-bc238eab7b4f
+  id: de9f92dc-97e6-56a8-a791-5a1720cdebc9
   name: Ensure that the --service-account-lookup argument is set to true (Automated)
   profile_applicability: |
     * Level 1 - Master Node

--- a/compliance/cis_k8s/rules/cis_1_2_26/data.yaml
+++ b/compliance/cis_k8s/rules/cis_1_2_26/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: de9f92dc-97e6-56a8-a791-5a1720cdebc9
+  id: 29cf65bd-37d9-525b-a009-30bad14c5a42
   name: Ensure that the --service-account-lookup argument is set to true (Automated)
   profile_applicability: |
     * Level 1 - Master Node

--- a/compliance/cis_k8s/rules/cis_1_2_26/data.yaml
+++ b/compliance/cis_k8s/rules/cis_1_2_26/data.yaml
@@ -1,41 +1,40 @@
 metadata:
-  id: 05be3248-f136-5e7c-99fa-3b40f0b1d0dc
-  name: Ensure that the --request-timeout argument is set as appropriate (Automated)
+  id: aae399a2-5b38-51f6-8f69-bc238eab7b4f
+  name: Ensure that the --service-account-lookup argument is set to true (Automated)
   profile_applicability: |
     * Level 1 - Master Node
   description: |
-    Set global request timeout for API server requests as appropriate.
+    Validate service account before validating token.
   rationale: >
-    Setting global request timeout allows extending the API server request
-    timeout limit to a duration appropriate to the user's connection speed. By
-    default, it is set to 60 seconds which might be problematic on slower
-    connections making cluster resources inaccessible once the data volume for
-    requests exceeds what can be transmitted in 60 seconds. But, setting this
-    timeout limit to be too large can exhaust the API server resources making it
-    prone to Denial-of-Service attack. Hence, it is recommended to set this
-    limit as appropriate and change the default limit of 60 seconds only if
-    needed.
+    If `--service-account-lookup` is not enabled, the apiserver only verifies
+    that the authentication token is valid, and does not validate that the
+    service account token mentioned in the request is actually present in etcd.
+    This allows using a service account token even after the corresponding
+    service account is deleted. This is an example of time of check to time of
+    use security issue.
   audit: |
     Run the following command on the master node:
     ```
     ps -ef | grep kube-apiserver
     ```
-    Verify that the `--request-timeout` argument is either not set or set to an appropriate
-    value.
+    Verify that if the `--service-account-lookup` argument exists it is set to `true`.
   remediation: |
     Edit the API server pod specification file
     `/etc/kubernetes/manifests/kube-apiserver.yaml` 
-    and set the below parameter as appropriate and if needed. For example,
+    on the master node and set the below parameter.
     ```
-    --request-timeout=300s
+    --service-account-lookup=true
     ```
+    Alternatively, you can delete the `--service-account-lookup` parameter from this file so
+    that the default takes effect.
   impact: |
     None
   default_value: |
-    By default, `--request-timeout` is set to 60 seconds.
+    By default, `--service-account-lookup` argument is set to `true`.
   references: |
     1. [https://kubernetes.io/docs/admin/kube-apiserver/](https://kubernetes.io/docs/admin/kube-apiserver/)
-    2. [https://github.com/kubernetes/kubernetes/pull/51415](https://github.com/kubernetes/kubernetes/pull/51415)
+    2. [https://github.com/kubernetes/kubernetes/issues/24167](https://github.com/kubernetes/kubernetes/issues/24167)
+    3. [https://en.wikipedia.org/wiki/Time_of_check_to_time_of_use](https://en.wikipedia.org/wiki/Time_of_check_to_time_of_use)
   section: API Server
   version: "1.0"
   tags:

--- a/compliance/cis_k8s/rules/cis_1_2_27/data.yaml
+++ b/compliance/cis_k8s/rules/cis_1_2_27/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: d368c359-89b4-5d61-9c34-bdfd6b878784
+  id: 4258b4e5-2fed-59c6-8242-a589d249c734
   name:
     Ensure that the --service-account-key-file argument is set as appropriate
     (Automated)

--- a/compliance/cis_k8s/rules/cis_1_2_27/data.yaml
+++ b/compliance/cis_k8s/rules/cis_1_2_27/data.yaml
@@ -1,40 +1,43 @@
 metadata:
-  id: aae399a2-5b38-51f6-8f69-bc238eab7b4f
-  name: Ensure that the --service-account-lookup argument is set to true (Automated)
+  id: d368c359-89b4-5d61-9c34-bdfd6b878784
+  name:
+    Ensure that the --service-account-key-file argument is set as appropriate
+    (Automated)
   profile_applicability: |
     * Level 1 - Master Node
-  description: |
-    Validate service account before validating token.
+  description: >
+    Explicitly set a service account public key file for service accounts on the
+    apiserver.
   rationale: >
-    If `--service-account-lookup` is not enabled, the apiserver only verifies
-    that the authentication token is valid, and does not validate that the
-    service account token mentioned in the request is actually present in etcd.
-    This allows using a service account token even after the corresponding
-    service account is deleted. This is an example of time of check to time of
-    use security issue.
+    By default, if no `--service-account-key-file` is specified to the
+    apiserver, it uses the private key from the TLS serving certificate to
+    verify service account tokens. To ensure that the keys for service account
+    tokens could be rotated as needed, a separate public/private key pair should
+    be used for signing service account tokens. Hence, the public key should be
+    specified to the apiserver with `--service-account-key-file`.
   audit: |
     Run the following command on the master node:
     ```
     ps -ef | grep kube-apiserver
     ```
-    Verify that if the `--service-account-lookup` argument exists it is set to `true`.
+    Verify that the `--service-account-key-file` argument exists and is set as appropriate.
   remediation: |
     Edit the API server pod specification file
     `/etc/kubernetes/manifests/kube-apiserver.yaml` 
-    on the master node and set the below parameter.
+    on the master node and set the `--service-account-key-file` parameter
+    to the public key file for service accounts:
     ```
-    --service-account-lookup=true
+    --service-account-key-file=<filename>
     ```
-    Alternatively, you can delete the `--service-account-lookup` parameter from this file so
-    that the default takes effect.
-  impact: |
-    None
+  impact: >
+    The corresponding private key must be provided to the controller manager.
+    You would need to securely maintain the key file and rotate the keys based
+    on your organization's key rotation policy.
   default_value: |
-    By default, `--service-account-lookup` argument is set to `true`.
+    By default, `--service-account-key-file` argument is not set.
   references: |
     1. [https://kubernetes.io/docs/admin/kube-apiserver/](https://kubernetes.io/docs/admin/kube-apiserver/)
     2. [https://github.com/kubernetes/kubernetes/issues/24167](https://github.com/kubernetes/kubernetes/issues/24167)
-    3. [https://en.wikipedia.org/wiki/Time_of_check_to_time_of_use](https://en.wikipedia.org/wiki/Time_of_check_to_time_of_use)
   section: API Server
   version: "1.0"
   tags:

--- a/compliance/cis_k8s/rules/cis_1_2_27/data.yaml
+++ b/compliance/cis_k8s/rules/cis_1_2_27/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 4258b4e5-2fed-59c6-8242-a589d249c734
+  id: 6444a17a-15d5-5ed2-87de-4b1c7459546f
   name:
     Ensure that the --service-account-key-file argument is set as appropriate
     (Automated)

--- a/compliance/cis_k8s/rules/cis_1_2_28/data.yaml
+++ b/compliance/cis_k8s/rules/cis_1_2_28/data.yaml
@@ -1,43 +1,42 @@
 metadata:
-  id: d368c359-89b4-5d61-9c34-bdfd6b878784
-  name:
-    Ensure that the --service-account-key-file argument is set as appropriate
-    (Automated)
+  id: aa64ec3d-5aee-51aa-9731-d939e9d49d39
+  name: Ensure that the --etcd-certfile and --etcd-keyfile arguments are set as
+    appropriate (Automated)
   profile_applicability: |
     * Level 1 - Master Node
   description: >
-    Explicitly set a service account public key file for service accounts on the
-    apiserver.
+    etcd should be configured to make use of TLS encryption for client
+    connections.
   rationale: >
-    By default, if no `--service-account-key-file` is specified to the
-    apiserver, it uses the private key from the TLS serving certificate to
-    verify service account tokens. To ensure that the keys for service account
-    tokens could be rotated as needed, a separate public/private key pair should
-    be used for signing service account tokens. Hence, the public key should be
-    specified to the apiserver with `--service-account-key-file`.
+    etcd is a highly-available key value store used by Kubernetes deployments
+    for persistent storage of all of its REST API objects. These objects are
+    sensitive in nature and should be protected by client authentication. This
+    requires the API server to identify itself to the etcd server using a client
+    certificate and key.
   audit: |
     Run the following command on the master node:
     ```
     ps -ef | grep kube-apiserver
     ```
-    Verify that the `--service-account-key-file` argument exists and is set as appropriate.
+    Verify that the `--etcd-certfile` and `--etcd-keyfile` arguments exist and they are set as
+    appropriate.
   remediation: |
-    Edit the API server pod specification file
-    `/etc/kubernetes/manifests/kube-apiserver.yaml` 
-    on the master node and set the `--service-account-key-file` parameter
-    to the public key file for service accounts:
+    Follow the Kubernetes documentation and set up the TLS connection between
+    the
+    apiserver and etcd. Then, edit the API server pod specification file
+    `/etc/kubernetes/manifests/kube-apiserver.yaml` on the master node and set the etcd
+    certificate and key file parameters.
     ```
-    --service-account-key-file=<filename>
+    --etcd-certfile=<path/to/client-certificate-file>
+    --etcd-keyfile=<path/to/client-key-file>
     ```
-  impact: >
-    The corresponding private key must be provided to the controller manager.
-    You would need to securely maintain the key file and rotate the keys based
-    on your organization's key rotation policy.
+  impact: |
+    TLS and client certificate authentication must be configured for etcd.
   default_value: |
-    By default, `--service-account-key-file` argument is not set.
+    By default, `--etcd-certfile` and `--etcd-keyfile` arguments are not set
   references: |
     1. [https://kubernetes.io/docs/admin/kube-apiserver/](https://kubernetes.io/docs/admin/kube-apiserver/)
-    2. [https://github.com/kubernetes/kubernetes/issues/24167](https://github.com/kubernetes/kubernetes/issues/24167)
+    2. [https://coreos.com/etcd/docs/latest/op-guide/security.html](https://coreos.com/etcd/docs/latest/op-guide/security.html)
   section: API Server
   version: "1.0"
   tags:

--- a/compliance/cis_k8s/rules/cis_1_2_28/data.yaml
+++ b/compliance/cis_k8s/rules/cis_1_2_28/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: aa65731c-76ce-5b58-8601-e41962eb507f
+  id: 78949fac-139e-5be8-93f5-05d643ef9cb8
   name: Ensure that the --etcd-certfile and --etcd-keyfile arguments are set as
     appropriate (Automated)
   profile_applicability: |

--- a/compliance/cis_k8s/rules/cis_1_2_28/data.yaml
+++ b/compliance/cis_k8s/rules/cis_1_2_28/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: aa64ec3d-5aee-51aa-9731-d939e9d49d39
+  id: aa65731c-76ce-5b58-8601-e41962eb507f
   name: Ensure that the --etcd-certfile and --etcd-keyfile arguments are set as
     appropriate (Automated)
   profile_applicability: |

--- a/compliance/cis_k8s/rules/cis_1_2_29/data.yaml
+++ b/compliance/cis_k8s/rules/cis_1_2_29/data.yaml
@@ -1,42 +1,41 @@
 metadata:
-  id: aa64ec3d-5aee-51aa-9731-d939e9d49d39
-  name: Ensure that the --etcd-certfile and --etcd-keyfile arguments are set as
-    appropriate (Automated)
+  id: 4dbe7add-e373-5280-84e4-6fdf80409b8e
+  name: Ensure that the --tls-cert-file and --tls-private-key-file arguments are
+    set as appropriate (Automated)
   profile_applicability: |
     * Level 1 - Master Node
-  description: >
-    etcd should be configured to make use of TLS encryption for client
-    connections.
+  description: |
+    Setup TLS connection on the API server.
   rationale: >
-    etcd is a highly-available key value store used by Kubernetes deployments
-    for persistent storage of all of its REST API objects. These objects are
-    sensitive in nature and should be protected by client authentication. This
-    requires the API server to identify itself to the etcd server using a client
-    certificate and key.
+    API server communication contains sensitive parameters that should remain
+    encrypted in transit. Configure the API server to serve only HTTPS traffic.
   audit: |
     Run the following command on the master node:
     ```
     ps -ef | grep kube-apiserver
     ```
-    Verify that the `--etcd-certfile` and `--etcd-keyfile` arguments exist and they are set as
-    appropriate.
+    Verify that the `--tls-cert-file` and `--tls-private-key-file` arguments exist and they
+    are set as appropriate.
   remediation: |
-    Follow the Kubernetes documentation and set up the TLS connection between
-    the
-    apiserver and etcd. Then, edit the API server pod specification file
-    `/etc/kubernetes/manifests/kube-apiserver.yaml` on the master node and set the etcd
-    certificate and key file parameters.
+    Follow the Kubernetes documentation and set up the TLS connection on the
+    apiserver.
+    Then, edit the API server pod specification file `/etc/kubernetes/manifests/kube-apiserver.yaml` 
+    on the master node and set the TLS certificate and private key file
+    parameters.
     ```
-    --etcd-certfile=<path/to/client-certificate-file>
-    --etcd-keyfile=<path/to/client-key-file>
+    --tls-cert-file=<path/to/tls-certificate-file>
+    --tls-private-key-file=<path/to/tls-key-file>
     ```
-  impact: |
-    TLS and client certificate authentication must be configured for etcd.
-  default_value: |
-    By default, `--etcd-certfile` and `--etcd-keyfile` arguments are not set
+  impact: >
+    TLS and client certificate authentication must be configured for your
+    Kubernetes cluster deployment.
+  default_value: >
+    By default, `--tls-cert-file` and `--tls-private-key-file` arguments are not
+    set.
   references: |
     1. [https://kubernetes.io/docs/admin/kube-apiserver/](https://kubernetes.io/docs/admin/kube-apiserver/)
-    2. [https://coreos.com/etcd/docs/latest/op-guide/security.html](https://coreos.com/etcd/docs/latest/op-guide/security.html)
+    2. [http://rootsquash.com/2016/05/10/securing-the-kubernetes-api/](http://rootsquash.com/2016/05/10/securing-the-kubernetes-api/)
+    3. [https://github.com/kelseyhightower/docker-kubernetes-tls-guide](https://github.com/kelseyhightower/docker-kubernetes-tls-guide)
   section: API Server
   version: "1.0"
   tags:

--- a/compliance/cis_k8s/rules/cis_1_2_29/data.yaml
+++ b/compliance/cis_k8s/rules/cis_1_2_29/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 4dbe7add-e373-5280-84e4-6fdf80409b8e
+  id: 81433715-b03e-515b-8244-d26490fed01e
   name: Ensure that the --tls-cert-file and --tls-private-key-file arguments are
     set as appropriate (Automated)
   profile_applicability: |

--- a/compliance/cis_k8s/rules/cis_1_2_29/data.yaml
+++ b/compliance/cis_k8s/rules/cis_1_2_29/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 81433715-b03e-515b-8244-d26490fed01e
+  id: 2184baf2-193c-5e0c-9076-8747e9b403d5
   name: Ensure that the --tls-cert-file and --tls-private-key-file arguments are
     set as appropriate (Automated)
   profile_applicability: |

--- a/compliance/cis_k8s/rules/cis_1_2_3/data.yaml
+++ b/compliance/cis_k8s/rules/cis_1_2_3/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 02a43051-0bad-5e1d-a846-b4024175634a
+  id: 615a4c44-e55c-57b1-9525-54e200e1a705
   name: Ensure that the --kubelet-https argument is set to true (Automated)
   profile_applicability: |
     * Level 1 - Master Node

--- a/compliance/cis_k8s/rules/cis_1_2_3/data.yaml
+++ b/compliance/cis_k8s/rules/cis_1_2_3/data.yaml
@@ -1,36 +1,31 @@
 metadata:
-  id: 6c595b13-8d46-5c74-9d49-d6c023303be5
-  name: Ensure that the --token-auth-file parameter is not set (Automated)
+  id: d6fc4ba2-5cdf-5ef2-be01-451ec7ded8bc
+  name: Ensure that the --kubelet-https argument is set to true (Automated)
   profile_applicability: |
     * Level 1 - Master Node
   description: |
-    Do not use token based authentication.
+    Use https for kubelet connections.
   rationale: >
-    The token-based authentication utilizes static tokens to authenticate
-    requests to the apiserver. The tokens are stored in clear-text in a file on
-    the apiserver, and cannot be revoked or rotated without restarting the
-    apiserver. Hence, do not use static token-based authentication.
+    Connections from apiserver to kubelets could potentially carry sensitive
+    data such as secrets and keys. It is thus important to use in-transit
+    encryption for any communication between the apiserver and kubelets.
   audit: |
     Run the following command on the master node:
     ```
     ps -ef | grep kube-apiserver
     ```
-    Verify that the `--token-auth-file` argument does not exist.
+    Verify that the `--kubelet-https` argument either does not exist or is set to `true`.
   remediation: |
-    Follow the documentation and configure alternate mechanisms for
-    authentication. Then,
-    edit the API server pod specification file `/etc/kubernetes/manifests/kube-apiserver.yaml` 
-    on the master node and remove the `--token-auth-file=<filename>`
-    parameter.
-  impact: >
-    You will have to configure and use alternate authentication mechanisms such
-    as
-    certificates. Static token based authentication could not be used.
+    Edit the API server pod specification file
+    `/etc/kubernetes/manifests/kube-apiserver.yaml` 
+    on the master node and remove the `--kubelet-https` parameter.
+  impact: |
+    You require TLS to be configured on apiserver as well as kubelets.
   default_value: |
-    By default, `--token-auth-file` argument is not set.
+    By default, kubelet connections are over https.
   references: |
-    1. [https://kubernetes.io/docs/admin/authentication/#static-token-file](https://kubernetes.io/docs/admin/authentication/#static-token-file)
-    2. [https://kubernetes.io/docs/admin/kube-apiserver/](https://kubernetes.io/docs/admin/kube-apiserver/)
+    1. [https://kubernetes.io/docs/admin/kube-apiserver/](https://kubernetes.io/docs/admin/kube-apiserver/)
+    2. [https://kubernetes.io/docs/admin/kubelet-authentication-authorization/](https://kubernetes.io/docs/admin/kubelet-authentication-authorization/)
   section: API Server
   version: "1.0"
   tags:

--- a/compliance/cis_k8s/rules/cis_1_2_3/data.yaml
+++ b/compliance/cis_k8s/rules/cis_1_2_3/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: d6fc4ba2-5cdf-5ef2-be01-451ec7ded8bc
+  id: 02a43051-0bad-5e1d-a846-b4024175634a
   name: Ensure that the --kubelet-https argument is set to true (Automated)
   profile_applicability: |
     * Level 1 - Master Node

--- a/compliance/cis_k8s/rules/cis_1_2_30/data.yaml
+++ b/compliance/cis_k8s/rules/cis_1_2_30/data.yaml
@@ -1,7 +1,6 @@
 metadata:
-  id: 4dbe7add-e373-5280-84e4-6fdf80409b8e
-  name: Ensure that the --tls-cert-file and --tls-private-key-file arguments are
-    set as appropriate (Automated)
+  id: dc418fc4-c306-5470-9d0e-f6ea5466a3d2
+  name: Ensure that the --client-ca-file argument is set as appropriate (Automated)
   profile_applicability: |
     * Level 1 - Master Node
   description: |
@@ -9,29 +8,29 @@ metadata:
   rationale: >
     API server communication contains sensitive parameters that should remain
     encrypted in transit. Configure the API server to serve only HTTPS traffic.
+    If `--client-ca-file` argument is set, any request presenting a client
+    certificate signed by one of the authorities in the `client-ca-file` is
+    authenticated with an identity corresponding to the CommonName of the client
+    certificate.
   audit: |
     Run the following command on the master node:
     ```
     ps -ef | grep kube-apiserver
     ```
-    Verify that the `--tls-cert-file` and `--tls-private-key-file` arguments exist and they
-    are set as appropriate.
+    Verify that the `--client-ca-file` argument exists and it is set as appropriate.
   remediation: |
     Follow the Kubernetes documentation and set up the TLS connection on the
     apiserver.
     Then, edit the API server pod specification file `/etc/kubernetes/manifests/kube-apiserver.yaml` 
-    on the master node and set the TLS certificate and private key file
-    parameters.
+    on the master node and set the client certificate authority file.
     ```
-    --tls-cert-file=<path/to/tls-certificate-file>
-    --tls-private-key-file=<path/to/tls-key-file>
+    --client-ca-file=<path/to/client-ca-file>
     ```
   impact: >
     TLS and client certificate authentication must be configured for your
     Kubernetes cluster deployment.
-  default_value: >
-    By default, `--tls-cert-file` and `--tls-private-key-file` arguments are not
-    set.
+  default_value: |
+    By default, `--client-ca-file` argument is not set.
   references: |
     1. [https://kubernetes.io/docs/admin/kube-apiserver/](https://kubernetes.io/docs/admin/kube-apiserver/)
     2. [http://rootsquash.com/2016/05/10/securing-the-kubernetes-api/](http://rootsquash.com/2016/05/10/securing-the-kubernetes-api/)

--- a/compliance/cis_k8s/rules/cis_1_2_30/data.yaml
+++ b/compliance/cis_k8s/rules/cis_1_2_30/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: dc418fc4-c306-5470-9d0e-f6ea5466a3d2
+  id: 5c30c4ad-44ef-5479-9e1c-6d5e3986aefd
   name: Ensure that the --client-ca-file argument is set as appropriate (Automated)
   profile_applicability: |
     * Level 1 - Master Node

--- a/compliance/cis_k8s/rules/cis_1_2_30/data.yaml
+++ b/compliance/cis_k8s/rules/cis_1_2_30/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 5c30c4ad-44ef-5479-9e1c-6d5e3986aefd
+  id: 793081ed-18f0-5c3f-a785-0eca54085fb9
   name: Ensure that the --client-ca-file argument is set as appropriate (Automated)
   profile_applicability: |
     * Level 1 - Master Node

--- a/compliance/cis_k8s/rules/cis_1_2_31/data.yaml
+++ b/compliance/cis_k8s/rules/cis_1_2_31/data.yaml
@@ -40,7 +40,7 @@ metadata:
   tags:
     - CIS
     - Kubernetes
-    - CIS 1.2.31
+    - CIS 1.2.30
     - API Server
   benchmark:
     name: CIS Kubernetes V1.20

--- a/compliance/cis_k8s/rules/cis_1_2_31/data.yaml
+++ b/compliance/cis_k8s/rules/cis_1_2_31/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: d617ca06-ec94-54f5-89e2-97bbfc1bfdc7
+  id: aed7a736-5180-5f79-a56b-e7b9f2e670d8
   name: Ensure that the --etcd-cafile argument is set as appropriate (Automated)
   profile_applicability: |
     • Level 1 - Master Node

--- a/compliance/cis_k8s/rules/cis_1_2_31/data.yaml
+++ b/compliance/cis_k8s/rules/cis_1_2_31/data.yaml
@@ -1,46 +1,44 @@
 metadata:
-  id: dc418fc4-c306-5470-9d0e-f6ea5466a3d2
-  name: Ensure that the --client-ca-file argument is set as appropriate (Automated)
+  id: d617ca06-ec94-54f5-89e2-97bbfc1bfdc7
+  name: Ensure that the --etcd-cafile argument is set as appropriate (Automated)
   profile_applicability: |
-    * Level 1 - Master Node
-  description: |
-    Setup TLS connection on the API server.
+    • Level 1 - Master Node
+  description: >
+    etcd should be configured to make use of TLS encryption for client
+    connections.
   rationale: >
-    API server communication contains sensitive parameters that should remain
-    encrypted in transit. Configure the API server to serve only HTTPS traffic.
-    If `--client-ca-file` argument is set, any request presenting a client
-    certificate signed by one of the authorities in the `client-ca-file` is
-    authenticated with an identity corresponding to the CommonName of the client
-    certificate.
+    etcd is a highly-available key value store used by Kubernetes deployments
+    for persistent
+    storage of all of its REST API objects. These objects are sensitive in nature and should be
+    protected by client authentication. This requires the API server to identify itself to the etcd
+    server using a SSL Certificate Authority file.
   audit: |
     Run the following command on the master node:
     ```
     ps -ef | grep kube-apiserver
     ```
-    Verify that the `--client-ca-file` argument exists and it is set as appropriate.
+    Verify that the `--etcd-cafile` argument exists and it is set as appropriate.
   remediation: |
-    Follow the Kubernetes documentation and set up the TLS connection on the
-    apiserver.
-    Then, edit the API server pod specification file `/etc/kubernetes/manifests/kube-apiserver.yaml` 
-    on the master node and set the client certificate authority file.
+    Follow the Kubernetes documentation and set up the TLS connection between
+    the apiserver and etcd. Then, edit the API server pod specification file
+    `/etc/kubernetes/manifests/kube-apiserver.yaml` on the master node and set the etcd
+    certificate authority file parameter.
     ```
-    --client-ca-file=<path/to/client-ca-file>
+    --etcd-cafile=<path/to/ca-file>
     ```
-  impact: >
-    TLS and client certificate authentication must be configured for your
-    Kubernetes cluster deployment.
+  impact: |
+    TLS and client certificate authentication must be configured for etcd.
   default_value: |
-    By default, `--client-ca-file` argument is not set.
+    By default, `--etcd-cafile` is not set.
   references: |
     1. [https://kubernetes.io/docs/admin/kube-apiserver/](https://kubernetes.io/docs/admin/kube-apiserver/)
-    2. [http://rootsquash.com/2016/05/10/securing-the-kubernetes-api/](http://rootsquash.com/2016/05/10/securing-the-kubernetes-api/)
-    3. [https://github.com/kelseyhightower/docker-kubernetes-tls-guide](https://github.com/kelseyhightower/docker-kubernetes-tls-guide)
+    2. [https://coreos.com/etcd/docs/latest/op-guide/security.html](https://coreos.com/etcd/docs/latest/op-guide/security.html)
   section: API Server
   version: "1.0"
   tags:
     - CIS
     - Kubernetes
-    - CIS 1.2.30
+    - CIS 1.2.31
     - API Server
   benchmark:
     name: CIS Kubernetes V1.20

--- a/compliance/cis_k8s/rules/cis_1_2_31/data.yaml
+++ b/compliance/cis_k8s/rules/cis_1_2_31/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: aed7a736-5180-5f79-a56b-e7b9f2e670d8
+  id: 5b436829-b78a-5758-964e-7cf1b5db1008
   name: Ensure that the --etcd-cafile argument is set as appropriate (Automated)
   profile_applicability: |
     • Level 1 - Master Node

--- a/compliance/cis_k8s/rules/cis_1_2_4/data.yaml
+++ b/compliance/cis_k8s/rules/cis_1_2_4/data.yaml
@@ -1,31 +1,41 @@
 metadata:
-  id: d6fc4ba2-5cdf-5ef2-be01-451ec7ded8bc
-  name: Ensure that the --kubelet-https argument is set to true (Automated)
+  id: c4c453d8-7efd-5869-90aa-7f5d588be594
+  name: Ensure that the --kubelet-client-certificate and
+    --kubelet-client-keyarguments are set as appropriate (Automated)
   profile_applicability: |
     * Level 1 - Master Node
   description: |
-    Use https for kubelet connections.
+    Enable certificate based kubelet authentication.
   rationale: >
-    Connections from apiserver to kubelets could potentially carry sensitive
-    data such as secrets and keys. It is thus important to use in-transit
-    encryption for any communication between the apiserver and kubelets.
+    The apiserver, by default, does not authenticate itself to the kubelet's
+    HTTPS endpoints. The requests from the apiserver are treated anonymously.
+    You should set up certificate- based kubelet authentication to ensure that
+    the apiserver authenticates itself to kubelets when submitting requests.
   audit: |
     Run the following command on the master node:
     ```
     ps -ef | grep kube-apiserver
     ```
-    Verify that the `--kubelet-https` argument either does not exist or is set to `true`.
+    Verify that the `--kubelet-client-certificate` and `--kubelet-client-key` arguments
+    exist and they are set as appropriate.
   remediation: |
-    Edit the API server pod specification file
-    `/etc/kubernetes/manifests/kube-apiserver.yaml` 
-    on the master node and remove the `--kubelet-https` parameter.
+    Follow the Kubernetes documentation and set up the TLS connection between
+    the
+    apiserver and kubelets. Then, edit API server pod specification file
+    `/etc/kubernetes/manifests/kube-apiserver.yaml` on the master node and set the
+    kubelet client certificate and key parameters as below.
+    ```
+    --kubelet-client-certificate=<path/to/client-certificate-file>
+    --kubelet-client-key=<path/to/client-key-file>
+    ```
   impact: |
     You require TLS to be configured on apiserver as well as kubelets.
   default_value: |
-    By default, kubelet connections are over https.
+    By default, certificate-based kubelet authentication is not set.
   references: |
     1. [https://kubernetes.io/docs/admin/kube-apiserver/](https://kubernetes.io/docs/admin/kube-apiserver/)
     2. [https://kubernetes.io/docs/admin/kubelet-authentication-authorization/](https://kubernetes.io/docs/admin/kubelet-authentication-authorization/)
+    3. [https://kubernetes.io/docs/concepts/cluster-administration/master-node-communication/#apiserver---kubelet](https://kubernetes.io/docs/concepts/cluster-administration/master-node-communication/#apiserver---kubelet)
   section: API Server
   version: "1.0"
   tags:

--- a/compliance/cis_k8s/rules/cis_1_2_4/data.yaml
+++ b/compliance/cis_k8s/rules/cis_1_2_4/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: c4c453d8-7efd-5869-90aa-7f5d588be594
+  id: 795a93b4-ff80-528e-a420-befa978c5f95
   name: Ensure that the --kubelet-client-certificate and
     --kubelet-client-keyarguments are set as appropriate (Automated)
   profile_applicability: |

--- a/compliance/cis_k8s/rules/cis_1_2_4/data.yaml
+++ b/compliance/cis_k8s/rules/cis_1_2_4/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 795a93b4-ff80-528e-a420-befa978c5f95
+  id: e0b17dee-7c45-51b0-9000-ab4c821cbfcc
   name: Ensure that the --kubelet-client-certificate and
     --kubelet-client-keyarguments are set as appropriate (Automated)
   profile_applicability: |

--- a/compliance/cis_k8s/rules/cis_1_2_5/data.yaml
+++ b/compliance/cis_k8s/rules/cis_1_2_5/data.yaml
@@ -1,37 +1,40 @@
 metadata:
-  id: c4c453d8-7efd-5869-90aa-7f5d588be594
-  name: Ensure that the --kubelet-client-certificate and
-    --kubelet-client-keyarguments are set as appropriate (Automated)
+  id: 6ad764be-71a5-54cf-92fc-30c4f995fdd6
+  name: Ensure that the --kubelet-certificate-authority argument is set as
+    appropriate (Automated)
   profile_applicability: |
     * Level 1 - Master Node
   description: |
-    Enable certificate based kubelet authentication.
+    Verify kubelet's certificate before establishing connection.
   rationale: >
-    The apiserver, by default, does not authenticate itself to the kubelet's
-    HTTPS endpoints. The requests from the apiserver are treated anonymously.
-    You should set up certificate- based kubelet authentication to ensure that
-    the apiserver authenticates itself to kubelets when submitting requests.
+    The connections from the apiserver to the kubelet are used for fetching logs
+    for pods, attaching (through kubectl) to running pods, and using the
+    kubelet's port-forwarding functionality. These connections terminate at the
+    kubelet's HTTPS endpoint. By default, the apiserver does not verify the
+    kubelet's serving certificate, which makes the connection subject to
+    man-in-the-middle attacks, and unsafe to run over untrusted and/or public
+    networks.
   audit: |
     Run the following command on the master node:
     ```
     ps -ef | grep kube-apiserver
     ```
-    Verify that the `--kubelet-client-certificate` and `--kubelet-client-key` arguments
-    exist and they are set as appropriate.
+    Verify that the `--kubelet-certificate-authority` argument exists and is set as
+    appropriate.
   remediation: |
-    Follow the Kubernetes documentation and set up the TLS connection between
-    the
-    apiserver and kubelets. Then, edit API server pod specification file
-    `/etc/kubernetes/manifests/kube-apiserver.yaml` on the master node and set the
-    kubelet client certificate and key parameters as below.
+    Follow the Kubernetes documentation and setup the TLS connection between the
+    apiserver
+    and kubelets. Then, edit the API server pod specification file
+    `/etc/kubernetes/manifests/kube-apiserver.yaml` on the master node and set the 
+    `--kubelet-certificate-authority` parameter to the path to the cert file for the certificate
+    authority.
     ```
-    --kubelet-client-certificate=<path/to/client-certificate-file>
-    --kubelet-client-key=<path/to/client-key-file>
+    --kubelet-certificate-authority=<ca-string>
     ```
   impact: |
     You require TLS to be configured on apiserver as well as kubelets.
   default_value: |
-    By default, certificate-based kubelet authentication is not set.
+    By default, `--kubelet-certificate-authority` argument is not set.
   references: |
     1. [https://kubernetes.io/docs/admin/kube-apiserver/](https://kubernetes.io/docs/admin/kube-apiserver/)
     2. [https://kubernetes.io/docs/admin/kubelet-authentication-authorization/](https://kubernetes.io/docs/admin/kubelet-authentication-authorization/)

--- a/compliance/cis_k8s/rules/cis_1_2_5/data.yaml
+++ b/compliance/cis_k8s/rules/cis_1_2_5/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 6ad764be-71a5-54cf-92fc-30c4f995fdd6
+  id: fdec58e4-f1a3-51a9-a1c6-04521afc0977
   name: Ensure that the --kubelet-certificate-authority argument is set as
     appropriate (Automated)
   profile_applicability: |

--- a/compliance/cis_k8s/rules/cis_1_2_5/data.yaml
+++ b/compliance/cis_k8s/rules/cis_1_2_5/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: fdec58e4-f1a3-51a9-a1c6-04521afc0977
+  id: 8fce5a41-142d-5077-ad4e-fc2815b40b2e
   name: Ensure that the --kubelet-certificate-authority argument is set as
     appropriate (Automated)
   profile_applicability: |

--- a/compliance/cis_k8s/rules/cis_1_2_6/data.yaml
+++ b/compliance/cis_k8s/rules/cis_1_2_6/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: ef206c48-d83d-5f01-9fea-019b67724f8f
+  id: 74b5a92c-186d-5ab0-8926-6aa8e0c6f972
   name: Ensure that the --authorization-mode argument is not set to AlwaysAllow
     (Automated)
   profile_applicability: |

--- a/compliance/cis_k8s/rules/cis_1_2_6/data.yaml
+++ b/compliance/cis_k8s/rules/cis_1_2_6/data.yaml
@@ -1,44 +1,35 @@
 metadata:
-  id: 6ad764be-71a5-54cf-92fc-30c4f995fdd6
-  name: Ensure that the --kubelet-certificate-authority argument is set as
-    appropriate (Automated)
+  id: ef206c48-d83d-5f01-9fea-019b67724f8f
+  name: Ensure that the --authorization-mode argument is not set to AlwaysAllow
+    (Automated)
   profile_applicability: |
     * Level 1 - Master Node
   description: |
-    Verify kubelet's certificate before establishing connection.
+    Do not always authorize all requests.
   rationale: >
-    The connections from the apiserver to the kubelet are used for fetching logs
-    for pods, attaching (through kubectl) to running pods, and using the
-    kubelet's port-forwarding functionality. These connections terminate at the
-    kubelet's HTTPS endpoint. By default, the apiserver does not verify the
-    kubelet's serving certificate, which makes the connection subject to
-    man-in-the-middle attacks, and unsafe to run over untrusted and/or public
-    networks.
+    The API Server, can be configured to allow all requests. This mode should
+    not be used on any production cluster.
   audit: |
     Run the following command on the master node:
     ```
     ps -ef | grep kube-apiserver
     ```
-    Verify that the `--kubelet-certificate-authority` argument exists and is set as
-    appropriate.
+    Verify that the `--authorization-mode` argument exists and is not set to `AlwaysAllow`.
   remediation: |
-    Follow the Kubernetes documentation and setup the TLS connection between the
-    apiserver
-    and kubelets. Then, edit the API server pod specification file
-    `/etc/kubernetes/manifests/kube-apiserver.yaml` on the master node and set the 
-    `--kubelet-certificate-authority` parameter to the path to the cert file for the certificate
-    authority.
+    Edit the API server pod specification file
+    `/etc/kubernetes/manifests/kube-apiserver.yaml` 
+    on the master node and set the `--authorization-mode` parameter to
+    values other than `AlwaysAllow`. One such example could be as below.
     ```
-    --kubelet-certificate-authority=<ca-string>
+    --authorization-mode=RBAC
     ```
   impact: |
-    You require TLS to be configured on apiserver as well as kubelets.
+    Only authorized requests will be served.
   default_value: |
-    By default, `--kubelet-certificate-authority` argument is not set.
+    By default, `AlwaysAllow` is not enabled.
   references: |
     1. [https://kubernetes.io/docs/admin/kube-apiserver/](https://kubernetes.io/docs/admin/kube-apiserver/)
-    2. [https://kubernetes.io/docs/admin/kubelet-authentication-authorization/](https://kubernetes.io/docs/admin/kubelet-authentication-authorization/)
-    3. [https://kubernetes.io/docs/concepts/cluster-administration/master-node-communication/#apiserver---kubelet](https://kubernetes.io/docs/concepts/cluster-administration/master-node-communication/#apiserver---kubelet)
+    2. [https://kubernetes.io/docs/admin/authorization/](https://kubernetes.io/docs/admin/authorization/)
   section: API Server
   version: "1.0"
   tags:

--- a/compliance/cis_k8s/rules/cis_1_2_6/data.yaml
+++ b/compliance/cis_k8s/rules/cis_1_2_6/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 74b5a92c-186d-5ab0-8926-6aa8e0c6f972
+  id: 8590255b-1409-512d-832b-a9d88804bf03
   name: Ensure that the --authorization-mode argument is not set to AlwaysAllow
     (Automated)
   profile_applicability: |

--- a/compliance/cis_k8s/rules/cis_1_2_7/data.yaml
+++ b/compliance/cis_k8s/rules/cis_1_2_7/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: cf8b515a-8a14-58c7-acee-57d61d3bb7b0
+  id: 0f7b80fa-4af5-508e-b64a-08d3e7e64615
   name: Ensure that the --authorization-mode argument includes Node (Automated)
   profile_applicability: |
     * Level 1 - Master Node

--- a/compliance/cis_k8s/rules/cis_1_2_7/data.yaml
+++ b/compliance/cis_k8s/rules/cis_1_2_7/data.yaml
@@ -1,35 +1,37 @@
 metadata:
-  id: ef206c48-d83d-5f01-9fea-019b67724f8f
-  name: Ensure that the --authorization-mode argument is not set to AlwaysAllow
-    (Automated)
+  id: cf8b515a-8a14-58c7-acee-57d61d3bb7b0
+  name: Ensure that the --authorization-mode argument includes Node (Automated)
   profile_applicability: |
     * Level 1 - Master Node
   description: |
-    Do not always authorize all requests.
+    Restrict kubelet nodes to reading only objects associated with them.
   rationale: >
-    The API Server, can be configured to allow all requests. This mode should
-    not be used on any production cluster.
+    The `Node` authorization mode only allows kubelets to read `Secret`,
+    `ConfigMap`, `PersistentVolume`, and `PersistentVolumeClaim` objects
+    associated with their nodes.
   audit: |
     Run the following command on the master node:
     ```
     ps -ef | grep kube-apiserver
     ```
-    Verify that the `--authorization-mode` argument exists and is not set to `AlwaysAllow`.
+    Verify that the `--authorization-mode` argument exists and is set to a value to include `Node`.
   remediation: |
     Edit the API server pod specification file
     `/etc/kubernetes/manifests/kube-apiserver.yaml` 
-    on the master node and set the `--authorization-mode` parameter to
-    values other than `AlwaysAllow`. One such example could be as below.
+    on the master node and set the `--authorization-mode` parameter to a
+    value that includes `Node`.
     ```
-    --authorization-mode=RBAC
+    --authorization-mode=Node,RBAC
     ```
   impact: |
-    Only authorized requests will be served.
+    None
   default_value: |
-    By default, `AlwaysAllow` is not enabled.
+    By default, `Node` authorization is not enabled.
   references: |
     1. [https://kubernetes.io/docs/admin/kube-apiserver/](https://kubernetes.io/docs/admin/kube-apiserver/)
-    2. [https://kubernetes.io/docs/admin/authorization/](https://kubernetes.io/docs/admin/authorization/)
+    2. [https://kubernetes.io/docs/admin/authorization/node/](https://kubernetes.io/docs/admin/authorization/node/)
+    3. [https://github.com/kubernetes/kubernetes/pull/46076](https://github.com/kubernetes/kubernetes/pull/46076)
+    4. [https://acotten.com/post/kube17-security](https://acotten.com/post/kube17-security)
   section: API Server
   version: "1.0"
   tags:

--- a/compliance/cis_k8s/rules/cis_1_2_7/data.yaml
+++ b/compliance/cis_k8s/rules/cis_1_2_7/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 0f7b80fa-4af5-508e-b64a-08d3e7e64615
+  id: 45028365-2b48-5237-9ece-9804dcf536e8
   name: Ensure that the --authorization-mode argument includes Node (Automated)
   profile_applicability: |
     * Level 1 - Master Node

--- a/compliance/cis_k8s/rules/cis_1_2_8/data.yaml
+++ b/compliance/cis_k8s/rules/cis_1_2_8/data.yaml
@@ -1,46 +1,41 @@
 metadata:
-  id: dc418fc4-c306-5470-9d0e-f6ea5466a3d2
-  name: Ensure that the --client-ca-file argument is set as appropriate (Automated)
+  id: 3c31068a-4858-5d44-ab2c-53068cf8d300
+  name: Ensure that the --authorization-mode argument includes RBAC (Automated)
   profile_applicability: |
-    * Level 1 - Master Node
+    • Level 1 - Master Node
   description: |
-    Setup TLS connection on the API server.
+    Turn on Role Based Access Control.
   rationale: >
-    API server communication contains sensitive parameters that should remain
-    encrypted in transit. Configure the API server to serve only HTTPS traffic.
-    If `--client-ca-file` argument is set, any request presenting a client
-    certificate signed by one of the authorities in the `client-ca-file` is
-    authenticated with an identity corresponding to the CommonName of the client
-    certificate.
+    Role Based Access Control (RBAC) allows fine-grained control over the
+    operations that
+    different entities can perform on different objects in the cluster. It is recommended to use
+    the RBAC authorization mode.
   audit: |
     Run the following command on the master node:
     ```
     ps -ef | grep kube-apiserver
     ```
-    Verify that the `--client-ca-file` argument exists and it is set as appropriate.
+    Verify that the `--authorization-mode` argument exists and is set to a value to include `RBAC`.
   remediation: |
-    Follow the Kubernetes documentation and set up the TLS connection on the
-    apiserver.
-    Then, edit the API server pod specification file `/etc/kubernetes/manifests/kube-apiserver.yaml` 
-    on the master node and set the client certificate authority file.
+    Edit the API server pod specification file `/etc/kubernetes/manifests/kube-apiserver.yaml
+    on the master node and set the `--authorization-mode` parameter to a
+    value that includes `RBAC`, for example:
     ```
-    --client-ca-file=<path/to/client-ca-file>
+    --authorization-mode=Node,RBAC
     ```
   impact: >
-    TLS and client certificate authentication must be configured for your
-    Kubernetes cluster deployment.
+    When RBAC is enabled you will need to ensure that appropriate RBAC settings
+    (including Roles, RoleBindings and ClusterRoleBindings) are configured to allow appropriate access.
   default_value: |
-    By default, `--client-ca-file` argument is not set.
+    By default, `RBAC` authorization is not enabled.
   references: |
-    1. [https://kubernetes.io/docs/admin/kube-apiserver/](https://kubernetes.io/docs/admin/kube-apiserver/)
-    2. [http://rootsquash.com/2016/05/10/securing-the-kubernetes-api/](http://rootsquash.com/2016/05/10/securing-the-kubernetes-api/)
-    3. [https://github.com/kelseyhightower/docker-kubernetes-tls-guide](https://github.com/kelseyhightower/docker-kubernetes-tls-guide)
+    1. [https://kubernetes.io/docs/reference/access-authn-authz/rbac/](https://kubernetes.io/docs/reference/access-authn-authz/rbac/)
   section: API Server
   version: "1.0"
   tags:
     - CIS
     - Kubernetes
-    - CIS 1.2.30
+    - CIS 1.2.8
     - API Server
   benchmark:
     name: CIS Kubernetes V1.20

--- a/compliance/cis_k8s/rules/cis_1_2_8/data.yaml
+++ b/compliance/cis_k8s/rules/cis_1_2_8/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 917e5ea2-65d1-529f-8e13-e29cd025ef8f
+  id: d0711b87-897e-53b0-9cbf-64da523046ad
   name: Ensure that the --authorization-mode argument includes RBAC (Automated)
   profile_applicability: |
     • Level 1 - Master Node

--- a/compliance/cis_k8s/rules/cis_1_2_8/data.yaml
+++ b/compliance/cis_k8s/rules/cis_1_2_8/data.yaml
@@ -1,43 +1,46 @@
 metadata:
-  id: cf8b515a-8a14-58c7-acee-57d61d3bb7b0
-  name: Ensure that the --authorization-mode argument includes Node (Automated)
+  id: dc418fc4-c306-5470-9d0e-f6ea5466a3d2
+  name: Ensure that the --client-ca-file argument is set as appropriate (Automated)
   profile_applicability: |
     * Level 1 - Master Node
   description: |
-    Restrict kubelet nodes to reading only objects associated with them.
+    Setup TLS connection on the API server.
   rationale: >
-    The `Node` authorization mode only allows kubelets to read `Secret`,
-    `ConfigMap`, `PersistentVolume`, and `PersistentVolumeClaim` objects
-    associated with their nodes.
+    API server communication contains sensitive parameters that should remain
+    encrypted in transit. Configure the API server to serve only HTTPS traffic.
+    If `--client-ca-file` argument is set, any request presenting a client
+    certificate signed by one of the authorities in the `client-ca-file` is
+    authenticated with an identity corresponding to the CommonName of the client
+    certificate.
   audit: |
     Run the following command on the master node:
     ```
     ps -ef | grep kube-apiserver
     ```
-    Verify that the `--authorization-mode` argument exists and is set to a value to include `Node`.
+    Verify that the `--client-ca-file` argument exists and it is set as appropriate.
   remediation: |
-    Edit the API server pod specification file
-    `/etc/kubernetes/manifests/kube-apiserver.yaml` 
-    on the master node and set the `--authorization-mode` parameter to a
-    value that includes `Node`.
+    Follow the Kubernetes documentation and set up the TLS connection on the
+    apiserver.
+    Then, edit the API server pod specification file `/etc/kubernetes/manifests/kube-apiserver.yaml` 
+    on the master node and set the client certificate authority file.
     ```
-    --authorization-mode=Node,RBAC
+    --client-ca-file=<path/to/client-ca-file>
     ```
-  impact: |
-    None
+  impact: >
+    TLS and client certificate authentication must be configured for your
+    Kubernetes cluster deployment.
   default_value: |
-    By default, `Node` authorization is not enabled.
+    By default, `--client-ca-file` argument is not set.
   references: |
     1. [https://kubernetes.io/docs/admin/kube-apiserver/](https://kubernetes.io/docs/admin/kube-apiserver/)
-    2. [https://kubernetes.io/docs/admin/authorization/node/](https://kubernetes.io/docs/admin/authorization/node/)
-    3. [https://github.com/kubernetes/kubernetes/pull/46076](https://github.com/kubernetes/kubernetes/pull/46076)
-    4. [https://acotten.com/post/kube17-security](https://acotten.com/post/kube17-security)
+    2. [http://rootsquash.com/2016/05/10/securing-the-kubernetes-api/](http://rootsquash.com/2016/05/10/securing-the-kubernetes-api/)
+    3. [https://github.com/kelseyhightower/docker-kubernetes-tls-guide](https://github.com/kelseyhightower/docker-kubernetes-tls-guide)
   section: API Server
   version: "1.0"
   tags:
     - CIS
     - Kubernetes
-    - CIS 1.2.8
+    - CIS 1.2.30
     - API Server
   benchmark:
     name: CIS Kubernetes V1.20

--- a/compliance/cis_k8s/rules/cis_1_2_8/data.yaml
+++ b/compliance/cis_k8s/rules/cis_1_2_8/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 3c31068a-4858-5d44-ab2c-53068cf8d300
+  id: 917e5ea2-65d1-529f-8e13-e29cd025ef8f
   name: Ensure that the --authorization-mode argument includes RBAC (Automated)
   profile_applicability: |
     • Level 1 - Master Node

--- a/compliance/cis_k8s/rules/cis_1_3_2/data.yaml
+++ b/compliance/cis_k8s/rules/cis_1_3_2/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 668fcf10-ee9a-5c33-9ac2-33b9b32b7b44
+  id: 924d2f43-b169-5c30-8580-18510daac8a2
   name: Ensure that the --profiling argument is set to false (Automated)
   profile_applicability: |
     * Level 1 - Master Node

--- a/compliance/cis_k8s/rules/cis_1_3_2/data.yaml
+++ b/compliance/cis_k8s/rules/cis_1_3_2/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: c0717726-3f52-57e8-8754-487bcb8e51c0
+  id: 668fcf10-ee9a-5c33-9ac2-33b9b32b7b44
   name: Ensure that the --profiling argument is set to false (Automated)
   profile_applicability: |
     * Level 1 - Master Node

--- a/compliance/cis_k8s/rules/cis_1_3_3/data.yaml
+++ b/compliance/cis_k8s/rules/cis_1_3_3/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 94a81d72-319b-5142-bb68-815fb1cf0ecc
+  id: 6c5d4276-fa95-5cbf-b430-2d391e8c562b
   name:
     Ensure that the --use-service-account-credentials argument is set to true
     (Automated)

--- a/compliance/cis_k8s/rules/cis_1_3_3/data.yaml
+++ b/compliance/cis_k8s/rules/cis_1_3_3/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: eac06678-1697-5028-925a-7fa9f678b19a
+  id: 94a81d72-319b-5142-bb68-815fb1cf0ecc
   name:
     Ensure that the --use-service-account-credentials argument is set to true
     (Automated)

--- a/compliance/cis_k8s/rules/cis_1_3_4/data.yaml
+++ b/compliance/cis_k8s/rules/cis_1_3_4/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 2a8dae44-f089-5807-b160-39634b112efd
+  id: b6e29513-63fc-5a5f-9443-e4761b16f484
   name: Ensure that the --service-account-private-key-file argument is set as
     appropriate (Automated)
   profile_applicability: |

--- a/compliance/cis_k8s/rules/cis_1_3_4/data.yaml
+++ b/compliance/cis_k8s/rules/cis_1_3_4/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 0667965a-8c0f-5cce-9ba7-9e6e24064802
+  id: 2a8dae44-f089-5807-b160-39634b112efd
   name: Ensure that the --service-account-private-key-file argument is set as
     appropriate (Automated)
   profile_applicability: |

--- a/compliance/cis_k8s/rules/cis_1_3_5/data.yaml
+++ b/compliance/cis_k8s/rules/cis_1_3_5/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 7c613860-b592-5dec-aeb7-9ce88958dabd
+  id: 9a9c1ce3-0ea2-5054-8eee-b30607bebe09
   name: Ensure that the --root-ca-file argument is set as appropriate (Automated)
   profile_applicability: |
     * Level 1 - Master Node

--- a/compliance/cis_k8s/rules/cis_1_3_5/data.yaml
+++ b/compliance/cis_k8s/rules/cis_1_3_5/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 9a9c1ce3-0ea2-5054-8eee-b30607bebe09
+  id: adaa6ec8-2099-5161-b776-647155687af0
   name: Ensure that the --root-ca-file argument is set as appropriate (Automated)
   profile_applicability: |
     * Level 1 - Master Node

--- a/compliance/cis_k8s/rules/cis_1_3_6/data.yaml
+++ b/compliance/cis_k8s/rules/cis_1_3_6/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 0a33af0f-101d-5ecd-a772-3ea0dbc3e9c9
+  id: fa3b6472-9369-52a4-8f47-269505bedc59
   name: Ensure that the RotateKubeletServerCertificate argument is set to true
     (Automated)
   profile_applicability: |

--- a/compliance/cis_k8s/rules/cis_1_3_6/data.yaml
+++ b/compliance/cis_k8s/rules/cis_1_3_6/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: fa3b6472-9369-52a4-8f47-269505bedc59
+  id: 0ca70034-78a0-5478-98f4-e4a16dc7780e
   name: Ensure that the RotateKubeletServerCertificate argument is set to true
     (Automated)
   profile_applicability: |

--- a/compliance/cis_k8s/rules/cis_1_3_7/data.yaml
+++ b/compliance/cis_k8s/rules/cis_1_3_7/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 806841fe-40f7-556c-9589-acc4c62ea075
+  id: 96387edc-dd3e-5bb1-9d05-dcb6f4187a7a
   name: Ensure that the --bind-address argument is set to 127.0.0.1 (Automated)
   profile_applicability: |
     * Level 1 - Master Node

--- a/compliance/cis_k8s/rules/cis_1_3_7/data.yaml
+++ b/compliance/cis_k8s/rules/cis_1_3_7/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 96387edc-dd3e-5bb1-9d05-dcb6f4187a7a
+  id: 630b0709-ea2a-5cea-8cb3-14fa160be415
   name: Ensure that the --bind-address argument is set to 127.0.0.1 (Automated)
   profile_applicability: |
     * Level 1 - Master Node

--- a/compliance/cis_k8s/rules/cis_1_4_1/data.yaml
+++ b/compliance/cis_k8s/rules/cis_1_4_1/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 8d3862e2-b599-5036-8c09-6dbdbb8c6f39
+  id: 1d191afc-fdff-508f-8b9f-4f9ae0375271
   name: Ensure that the --profiling argument is set to false (Automated)
   profile_applicability: |
     * Level 1 - Master Node

--- a/compliance/cis_k8s/rules/cis_1_4_1/data.yaml
+++ b/compliance/cis_k8s/rules/cis_1_4_1/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 1d191afc-fdff-508f-8b9f-4f9ae0375271
+  id: 16f3d090-fe9c-5011-8be7-428c53009a26
   name: Ensure that the --profiling argument is set to false (Automated)
   profile_applicability: |
     * Level 1 - Master Node

--- a/compliance/cis_k8s/rules/cis_1_4_2/data.yaml
+++ b/compliance/cis_k8s/rules/cis_1_4_2/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: a17289ba-16fd-533a-be1c-2f79dffc90b2
+  id: f23635f5-231c-555b-8736-15d7648580fc
   name: Ensure that the --bind-address argument is set to 127.0.0.1 (Automated)
   profile_applicability: |
     * Level 1 - Master Node

--- a/compliance/cis_k8s/rules/cis_1_4_2/data.yaml
+++ b/compliance/cis_k8s/rules/cis_1_4_2/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: f23635f5-231c-555b-8736-15d7648580fc
+  id: 9b25ec98-5118-5a2b-9f00-06daa6c7c4b3
   name: Ensure that the --bind-address argument is set to 127.0.0.1 (Automated)
   profile_applicability: |
     * Level 1 - Master Node

--- a/compliance/cis_k8s/rules/cis_2_1/data.yaml
+++ b/compliance/cis_k8s/rules/cis_2_1/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 4a05fc22-79a3-575c-b3f4-2224b44340fd
+  id: e8447fcf-6b1e-5d40-a0ee-dfe83e3424bf
   name: Ensure that the --cert-file and --key-file arguments are set as
     appropriate (Automated)
   profile_applicability: |

--- a/compliance/cis_k8s/rules/cis_2_1/data.yaml
+++ b/compliance/cis_k8s/rules/cis_2_1/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 42ae3fda-5908-5411-8ee9-f8f3ae670352
+  id: 4a05fc22-79a3-575c-b3f4-2224b44340fd
   name: Ensure that the --cert-file and --key-file arguments are set as
     appropriate (Automated)
   profile_applicability: |

--- a/compliance/cis_k8s/rules/cis_2_2/data.yaml
+++ b/compliance/cis_k8s/rules/cis_2_2/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 3ef4dbec-6fb7-57a2-be6c-16117690d862
+  id: a9eab1dd-a3f4-54e6-af40-7e5d61542ec6
   name: Ensure that the --client-cert-auth argument is set to true (Automated)
   profile_applicability: |
     * Level 1 - Master Node

--- a/compliance/cis_k8s/rules/cis_2_2/data.yaml
+++ b/compliance/cis_k8s/rules/cis_2_2/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: fe303e19-4f10-5613-88e2-563a40282ea6
+  id: 3ef4dbec-6fb7-57a2-be6c-16117690d862
   name: Ensure that the --client-cert-auth argument is set to true (Automated)
   profile_applicability: |
     * Level 1 - Master Node

--- a/compliance/cis_k8s/rules/cis_2_3/data.yaml
+++ b/compliance/cis_k8s/rules/cis_2_3/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 6e5e9c9c-1155-56d8-87a6-208d9a610f35
+  id: f19b8857-721c-5c1d-8db5-e1ffd6942e47
   name: Ensure that the --auto-tls argument is not set to true (Automated)
   profile_applicability: |
     * Level 1 - Master Node

--- a/compliance/cis_k8s/rules/cis_2_3/data.yaml
+++ b/compliance/cis_k8s/rules/cis_2_3/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: f19b8857-721c-5c1d-8db5-e1ffd6942e47
+  id: 7aaeeea4-1aa8-54e3-9e8d-2d59e97abebf
   name: Ensure that the --auto-tls argument is not set to true (Automated)
   profile_applicability: |
     * Level 1 - Master Node

--- a/compliance/cis_k8s/rules/cis_2_4/data.yaml
+++ b/compliance/cis_k8s/rules/cis_2_4/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 8725e827-f8ba-557c-8f53-fe2246662ae3
+  id: ca0d8e5c-8d60-54d8-bb5a-9b2e50231c62
   name:
     Ensure that the --peer-cert-file and --peer-key-file arguments are set as
     appropriate (Automated)

--- a/compliance/cis_k8s/rules/cis_2_4/data.yaml
+++ b/compliance/cis_k8s/rules/cis_2_4/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: ca0d8e5c-8d60-54d8-bb5a-9b2e50231c62
+  id: f594f927-576a-5a07-9e1f-a65b8bfadfda
   name:
     Ensure that the --peer-cert-file and --peer-key-file arguments are set as
     appropriate (Automated)

--- a/compliance/cis_k8s/rules/cis_2_5/data.yaml
+++ b/compliance/cis_k8s/rules/cis_2_5/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: ce7229b5-4d39-5859-89ba-cd5e64a5814b
+  id: 3f09b0dd-4620-575e-bdd9-de9352ffd7b4
   name: Ensure that the --peer-client-cert-auth argument is set to true (Automated)
   profile_applicability: |
     * Level 1 - Master Node

--- a/compliance/cis_k8s/rules/cis_2_5/data.yaml
+++ b/compliance/cis_k8s/rules/cis_2_5/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 3f09b0dd-4620-575e-bdd9-de9352ffd7b4
+  id: 01889b3d-1c3b-5fe6-9a0f-d512016e05e8
   name: Ensure that the --peer-client-cert-auth argument is set to true (Automated)
   profile_applicability: |
     * Level 1 - Master Node

--- a/compliance/cis_k8s/rules/cis_2_6/data.yaml
+++ b/compliance/cis_k8s/rules/cis_2_6/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 768e492d-212e-5714-b4ec-f36349b34d8c
+  id: c82651ca-d099-5884-a8e7-36dbc13d2211
   name: Ensure that the --peer-auto-tls argument is not set to true (Automated)
   profile_applicability: |
     * Level 1 - Master Node

--- a/compliance/cis_k8s/rules/cis_2_6/data.yaml
+++ b/compliance/cis_k8s/rules/cis_2_6/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: c82651ca-d099-5884-a8e7-36dbc13d2211
+  id: cef9ccbc-fa05-5fd5-b55b-c8d3ff21ab9b
   name: Ensure that the --peer-auto-tls argument is not set to true (Automated)
   profile_applicability: |
     * Level 1 - Master Node

--- a/compliance/cis_k8s/rules/cis_4_1_1/data.yaml
+++ b/compliance/cis_k8s/rules/cis_4_1_1/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: c9383baa-89f0-56e3-a3c8-23e41575558e
+  id: 4247baed-c82d-5134-adeb-c1ed6968ed36
   name: Ensure that the kubelet service file permissions are set to 644 or more
     restrictive (Automated)
   profile_applicability: |

--- a/compliance/cis_k8s/rules/cis_4_1_1/data.yaml
+++ b/compliance/cis_k8s/rules/cis_4_1_1/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 640bd199-98c8-5932-9bdc-8b17434bdc77
+  id: c9383baa-89f0-56e3-a3c8-23e41575558e
   name: Ensure that the kubelet service file permissions are set to 644 or more
     restrictive (Automated)
   profile_applicability: |

--- a/compliance/cis_k8s/rules/cis_4_1_10/data.yaml
+++ b/compliance/cis_k8s/rules/cis_4_1_10/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: b6df0d77-cfb2-5eab-9978-96e2bdd4cd4b
+  id: 602aba24-f893-5506-b98a-2d15ac61a35b
   name: Ensure that the kubelet --config configuration file ownership is set to
     root:root (Automated)
   profile_applicability: |

--- a/compliance/cis_k8s/rules/cis_4_1_10/data.yaml
+++ b/compliance/cis_k8s/rules/cis_4_1_10/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: bd564e86-601e-5b48-bf74-6c9c5c23444f
+  id: b6df0d77-cfb2-5eab-9978-96e2bdd4cd4b
   name: Ensure that the kubelet --config configuration file ownership is set to
     root:root (Automated)
   profile_applicability: |

--- a/compliance/cis_k8s/rules/cis_4_1_2/data.yaml
+++ b/compliance/cis_k8s/rules/cis_4_1_2/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 8fd55a1d-3d2d-5127-85c8-1fc23dde20c8
+  id: 809615ab-5628-5f35-8935-96cb7b0be4a2
   name: Ensure that the kubelet service file ownership is set to root:root
     (Automated)
   profile_applicability: |

--- a/compliance/cis_k8s/rules/cis_4_1_2/data.yaml
+++ b/compliance/cis_k8s/rules/cis_4_1_2/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: d5ba56e3-b61f-52ad-a37b-de3a2cb90f79
+  id: 8fd55a1d-3d2d-5127-85c8-1fc23dde20c8
   name: Ensure that the kubelet service file ownership is set to root:root
     (Automated)
   profile_applicability: |

--- a/compliance/cis_k8s/rules/cis_4_1_5/data.yaml
+++ b/compliance/cis_k8s/rules/cis_4_1_5/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 3b3f2e32-7d00-5e31-bf60-30bebc0033b8
+  id: 05665928-f325-516a-b1bd-3394445981af
   name:
     Ensure that the --kubeconfig kubelet.conf file permissions are set to 644
     or more restrictive (Automated)

--- a/compliance/cis_k8s/rules/cis_4_1_5/data.yaml
+++ b/compliance/cis_k8s/rules/cis_4_1_5/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 05665928-f325-516a-b1bd-3394445981af
+  id: b7eab64f-900a-538c-a1ce-3d874864cde0
   name:
     Ensure that the --kubeconfig kubelet.conf file permissions are set to 644
     or more restrictive (Automated)

--- a/compliance/cis_k8s/rules/cis_4_1_9/data.yaml
+++ b/compliance/cis_k8s/rules/cis_4_1_9/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 421ce5e8-d64a-5632-9ae1-1089ecb69651
+  id: 42be8bf1-f37d-5def-b1ba-49332bce0b8b
   name:
     Ensure that the kubelet --config configuration file has permissions set to
     644 or more restrictive (Automated)

--- a/compliance/cis_k8s/rules/cis_4_1_9/data.yaml
+++ b/compliance/cis_k8s/rules/cis_4_1_9/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: cbb6d18c-e059-5eff-ba99-412953364eac
+  id: 421ce5e8-d64a-5632-9ae1-1089ecb69651
   name:
     Ensure that the kubelet --config configuration file has permissions set to
     644 or more restrictive (Automated)

--- a/compliance/cis_k8s/rules/cis_4_2_1/data.yaml
+++ b/compliance/cis_k8s/rules/cis_4_2_1/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: ceea4bd5-69b5-5e3c-9038-0b91f9bf2f08
+  id: 5d2b0fb4-32fc-565f-bf70-93700f144da0
   name: Ensure that the --anonymous-auth argument is set to false (Automated)
   profile_applicability: |
     * Level 1 - Worker Node

--- a/compliance/cis_k8s/rules/cis_4_2_1/data.yaml
+++ b/compliance/cis_k8s/rules/cis_4_2_1/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: dc235873-bac7-5b97-bec5-d1f5baa639da
+  id: ceea4bd5-69b5-5e3c-9038-0b91f9bf2f08
   name: Ensure that the --anonymous-auth argument is set to false (Automated)
   profile_applicability: |
     * Level 1 - Worker Node

--- a/compliance/cis_k8s/rules/cis_4_2_2/data.yaml
+++ b/compliance/cis_k8s/rules/cis_4_2_2/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: c7533dee-e7cf-5082-a72d-dcea3742080d
+  id: d74e3db8-7690-5c13-8c19-61066c2052a8
   name: Ensure that the --authorization-mode argument is not set to AlwaysAllow
     (Automated)
   profile_applicability: |

--- a/compliance/cis_k8s/rules/cis_4_2_2/data.yaml
+++ b/compliance/cis_k8s/rules/cis_4_2_2/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: d74e3db8-7690-5c13-8c19-61066c2052a8
+  id: 66ce739b-235a-5715-be8b-402f403ad6ae
   name: Ensure that the --authorization-mode argument is not set to AlwaysAllow
     (Automated)
   profile_applicability: |

--- a/compliance/cis_k8s/rules/cis_4_2_3/data.yaml
+++ b/compliance/cis_k8s/rules/cis_4_2_3/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 75d9dcd6-0e64-58b0-a57c-c5b0c59490bd
+  id: 07044969-6a77-5f46-a266-6b2f41a95a1b
   name: Ensure that the --client-ca-file argument is set as appropriate (Automated)
   profile_applicability: |
     * Level 1 - Worker Node

--- a/compliance/cis_k8s/rules/cis_4_2_3/data.yaml
+++ b/compliance/cis_k8s/rules/cis_4_2_3/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 07044969-6a77-5f46-a266-6b2f41a95a1b
+  id: 5ecbb746-d5e2-5541-92e5-a597c82fc86c
   name: Ensure that the --client-ca-file argument is set as appropriate (Automated)
   profile_applicability: |
     * Level 1 - Worker Node

--- a/compliance/cis_k8s/rules/cis_4_2_6/data.yaml
+++ b/compliance/cis_k8s/rules/cis_4_2_6/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: f2fdd4be-80bd-5b01-9103-700c265f0493
+  id: 28c54f3d-6a91-5155-8b59-535254651a1c
   name: Ensure that the --protect-kernel-defaults argument is set to true (Automated)
   profile_applicability: |
     * Level 1 - Worker Node

--- a/compliance/cis_k8s/rules/cis_4_2_6/data.yaml
+++ b/compliance/cis_k8s/rules/cis_4_2_6/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 28c54f3d-6a91-5155-8b59-535254651a1c
+  id: 3e13b894-3ebe-554f-9808-c1a5b041d524
   name: Ensure that the --protect-kernel-defaults argument is set to true (Automated)
   profile_applicability: |
     * Level 1 - Worker Node

--- a/compliance/cis_k8s/rules/cis_4_2_7/data.yaml
+++ b/compliance/cis_k8s/rules/cis_4_2_7/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: c87217bb-9cdc-5654-a095-3e59d1a0aac0
+  id: 3a597763-43d1-5cd9-824e-ed1e65fd3988
   name: Ensure that the --make-iptables-util-chains argument is set to true
     (Automated)
   profile_applicability: |

--- a/compliance/cis_k8s/rules/cis_4_2_7/data.yaml
+++ b/compliance/cis_k8s/rules/cis_4_2_7/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 64762605-406e-5801-8953-77f3447eff31
+  id: c87217bb-9cdc-5654-a095-3e59d1a0aac0
   name: Ensure that the --make-iptables-util-chains argument is set to true
     (Automated)
   profile_applicability: |

--- a/compliance/cis_k8s/rules/cis_5_1_3/data.yaml
+++ b/compliance/cis_k8s/rules/cis_5_1_3/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 405eb973-8e8f-5880-b6d5-9602508ef958
+  id: 23459689-f7ad-5011-bb00-68bce4ded4af
   name: Minimize wildcard use in Roles and ClusterRoles (Manual)
   profile_applicability: |
     * Level 1 - Worker Node

--- a/compliance/cis_k8s/rules/cis_5_1_3/data.yaml
+++ b/compliance/cis_k8s/rules/cis_5_1_3/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 9b285231-91ec-586d-9141-5e855e445464
+  id: 405eb973-8e8f-5880-b6d5-9602508ef958
   name: Minimize wildcard use in Roles and ClusterRoles (Manual)
   profile_applicability: |
     * Level 1 - Worker Node

--- a/compliance/cis_k8s/rules/cis_5_1_5/data.yaml
+++ b/compliance/cis_k8s/rules/cis_5_1_5/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: f7f2f00b-a5f6-5157-addd-8cfe5e9f5e97
+  id: 823f5e65-6aa3-5248-a099-f7da1d54ab97
   name: Ensure that default service accounts are not actively used. (Manual)
   profile_applicability: |
     * Level 1 - Master Node

--- a/compliance/cis_k8s/rules/cis_5_1_5/data.yaml
+++ b/compliance/cis_k8s/rules/cis_5_1_5/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 18ba69c4-1da3-508a-96f7-72465a4213e5
+  id: f7f2f00b-a5f6-5157-addd-8cfe5e9f5e97
   name: Ensure that default service accounts are not actively used. (Manual)
   profile_applicability: |
     * Level 1 - Master Node

--- a/compliance/cis_k8s/rules/cis_5_1_6/data.yaml
+++ b/compliance/cis_k8s/rules/cis_5_1_6/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 6073b93e-b952-5b92-95c4-a32a219e1d48
+  id: 621c2ef4-683e-510f-9fba-8632fa186025
   name: Ensure that Service Account Tokens are only mounted where necessary (Manual)
   profile_applicability: |
     * Level 1 - Master Node

--- a/compliance/cis_k8s/rules/cis_5_1_6/data.yaml
+++ b/compliance/cis_k8s/rules/cis_5_1_6/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: e08b172c-148d-5a9b-bad6-142d0e589ef5
+  id: 6073b93e-b952-5b92-95c4-a32a219e1d48
   name: Ensure that Service Account Tokens are only mounted where necessary (Manual)
   profile_applicability: |
     * Level 1 - Master Node

--- a/compliance/cis_k8s/rules/cis_5_2_1/data.yaml
+++ b/compliance/cis_k8s/rules/cis_5_2_1/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: e3291708-971b-5f0e-aa25-5653fb5cb907
+  id: bd24dd77-aa87-5348-920a-88fff7752479
   name: Minimize the admission of privileged containers (Automated)
   profile_applicability: |
     * Level 1 - Master Node

--- a/compliance/cis_k8s/rules/cis_5_2_1/data.yaml
+++ b/compliance/cis_k8s/rules/cis_5_2_1/data.yaml
@@ -1,6 +1,6 @@
 metadata:
   id: e3291708-971b-5f0e-aa25-5653fb5cb907
-  name: Minimize the admission of privileged containers (Manual)
+  name: Minimize the admission of privileged containers (Automated)
   profile_applicability: |
     * Level 1 - Master Node
   description: >

--- a/compliance/cis_k8s/rules/cis_5_2_1/data.yaml
+++ b/compliance/cis_k8s/rules/cis_5_2_1/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: bd24dd77-aa87-5348-920a-88fff7752479
+  id: 0d2c3f44-85d6-53ad-947a-99b6ad1f16fe
   name: Minimize the admission of privileged containers (Automated)
   profile_applicability: |
     * Level 1 - Master Node

--- a/compliance/cis_k8s/rules/cis_5_2_2/data.yaml
+++ b/compliance/cis_k8s/rules/cis_5_2_2/data.yaml
@@ -2,7 +2,7 @@ metadata:
   id: aba0102d-dab4-54a1-8f48-3137e9896540
   name:
     Minimize the admission of containers wishing to share the host process ID
-    namespace (Manual)
+    namespace (Automated)
   profile_applicability: |
     * Level 1 - Master Node
   description: >

--- a/compliance/cis_k8s/rules/cis_5_2_2/data.yaml
+++ b/compliance/cis_k8s/rules/cis_5_2_2/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: aba0102d-dab4-54a1-8f48-3137e9896540
+  id: 9246ee22-9a01-50ce-b4c3-edc8e2f8a815
   name:
     Minimize the admission of containers wishing to share the host process ID
     namespace (Automated)

--- a/compliance/cis_k8s/rules/cis_5_2_2/data.yaml
+++ b/compliance/cis_k8s/rules/cis_5_2_2/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 9246ee22-9a01-50ce-b4c3-edc8e2f8a815
+  id: 59459b57-926c-5709-a482-7bfdc21e1db4
   name:
     Minimize the admission of containers wishing to share the host process ID
     namespace (Automated)

--- a/compliance/cis_k8s/rules/cis_5_2_3/data.yaml
+++ b/compliance/cis_k8s/rules/cis_5_2_3/data.yaml
@@ -1,7 +1,7 @@
 metadata:
   id: 4d21b544-ac5c-5ef1-bec8-2f6b77abdc50
   name: Minimize the admission of containers wishing to share the hostIPC
-    namespace (Manual)
+    namespace (Automated)
   profile_applicability: |
     * Level 1 - Master Node
   description: >

--- a/compliance/cis_k8s/rules/cis_5_2_3/data.yaml
+++ b/compliance/cis_k8s/rules/cis_5_2_3/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 951aa0e1-8413-5312-9e87-78156997d6cd
+  id: 945f29dc-21e5-5f26-aab4-1c2dbf3daf1a
   name: Minimize the admission of containers wishing to share the hostIPC
     namespace (Automated)
   profile_applicability: |

--- a/compliance/cis_k8s/rules/cis_5_2_3/data.yaml
+++ b/compliance/cis_k8s/rules/cis_5_2_3/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 4d21b544-ac5c-5ef1-bec8-2f6b77abdc50
+  id: 951aa0e1-8413-5312-9e87-78156997d6cd
   name: Minimize the admission of containers wishing to share the hostIPC
     namespace (Automated)
   profile_applicability: |

--- a/compliance/cis_k8s/rules/cis_5_2_4/data.yaml
+++ b/compliance/cis_k8s/rules/cis_5_2_4/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: d856f865-c10c-5b78-a378-1bfbd691fa71
+  id: 4a50a8fb-5abb-5e24-82af-d59fd16397af
   name: Minimize the admission of containers wishing to share the host network
     namespace (Automated)
   profile_applicability: |

--- a/compliance/cis_k8s/rules/cis_5_2_4/data.yaml
+++ b/compliance/cis_k8s/rules/cis_5_2_4/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 4a50a8fb-5abb-5e24-82af-d59fd16397af
+  id: 86b4d62b-c3ad-5b29-84a4-925ae258207e
   name: Minimize the admission of containers wishing to share the host network
     namespace (Automated)
   profile_applicability: |

--- a/compliance/cis_k8s/rules/cis_5_2_4/data.yaml
+++ b/compliance/cis_k8s/rules/cis_5_2_4/data.yaml
@@ -1,7 +1,7 @@
 metadata:
   id: d856f865-c10c-5b78-a378-1bfbd691fa71
   name: Minimize the admission of containers wishing to share the host network
-    namespace (Manual)
+    namespace (Automated)
   profile_applicability: |
     * Level 1 - Master Node
   description: >

--- a/compliance/cis_k8s/rules/cis_5_2_5/data.yaml
+++ b/compliance/cis_k8s/rules/cis_5_2_5/data.yaml
@@ -1,6 +1,6 @@
 metadata:
   id: fd02c2d3-8cc3-517f-a379-b3bb8919e3c8
-  name: Minimize the admission of containers with allowPrivilegeEscalation (Manual)
+  name: Minimize the admission of containers with allowPrivilegeEscalation (Automated)
   profile_applicability: |
     * Level 1 - Master Node
   description: >

--- a/compliance/cis_k8s/rules/cis_5_2_5/data.yaml
+++ b/compliance/cis_k8s/rules/cis_5_2_5/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: fd02c2d3-8cc3-517f-a379-b3bb8919e3c8
+  id: 727c8e00-a6cd-5a51-a147-c6b796b58f6c
   name: Minimize the admission of containers with allowPrivilegeEscalation (Automated)
   profile_applicability: |
     * Level 1 - Master Node

--- a/compliance/cis_k8s/rules/cis_5_2_5/data.yaml
+++ b/compliance/cis_k8s/rules/cis_5_2_5/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 727c8e00-a6cd-5a51-a147-c6b796b58f6c
+  id: c346ffdb-c68b-58e8-b9bf-f8e946cfd1fd
   name: Minimize the admission of containers with allowPrivilegeEscalation (Automated)
   profile_applicability: |
     * Level 1 - Master Node

--- a/compliance/cis_k8s/rules/cis_5_2_6/data.yaml
+++ b/compliance/cis_k8s/rules/cis_5_2_6/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 4bda85d1-1952-5633-a723-ef94f74a0c01
+  id: 17677bce-de0c-558c-8a09-812b914a4a77
   name: Minimize the admission of root containers (Automated)
   profile_applicability: |
     * Level 2 - Master Node

--- a/compliance/cis_k8s/rules/cis_5_2_6/data.yaml
+++ b/compliance/cis_k8s/rules/cis_5_2_6/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 17677bce-de0c-558c-8a09-812b914a4a77
+  id: 7e122766-328d-58f2-94d5-990b1521c366
   name: Minimize the admission of root containers (Automated)
   profile_applicability: |
     * Level 2 - Master Node

--- a/compliance/cis_k8s/rules/cis_5_2_6/data.yaml
+++ b/compliance/cis_k8s/rules/cis_5_2_6/data.yaml
@@ -1,6 +1,6 @@
 metadata:
   id: 4bda85d1-1952-5633-a723-ef94f74a0c01
-  name: Minimize the admission of root containers (Manual)
+  name: Minimize the admission of root containers (Automated)
   profile_applicability: |
     * Level 2 - Master Node
   description: |

--- a/compliance/cis_k8s/rules/cis_5_2_7/data.yaml
+++ b/compliance/cis_k8s/rules/cis_5_2_7/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 47d0819f-3562-52de-a0b8-facb68e2cc87
+  id: e479b6a8-1594-5904-8206-19a8f03de9c0
   name: Minimize the admission of containers with the NET_RAW capability (Automated)
   profile_applicability: |
     * Level 1 - Master Node

--- a/compliance/cis_k8s/rules/cis_5_2_7/data.yaml
+++ b/compliance/cis_k8s/rules/cis_5_2_7/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: a0e19ff9-1a85-57a5-af21-a37e0ce4cefc
+  id: 47d0819f-3562-52de-a0b8-facb68e2cc87
   name: Minimize the admission of containers with the NET_RAW capability (Automated)
   profile_applicability: |
     * Level 1 - Master Node

--- a/compliance/cis_k8s/rules/cis_5_2_7/data.yaml
+++ b/compliance/cis_k8s/rules/cis_5_2_7/data.yaml
@@ -1,6 +1,6 @@
 metadata:
   id: a0e19ff9-1a85-57a5-af21-a37e0ce4cefc
-  name: Minimize the admission of containers with the NET_RAW capability (Manual)
+  name: Minimize the admission of containers with the NET_RAW capability (Automated)
   profile_applicability: |
     * Level 1 - Master Node
   description: >

--- a/compliance/cis_k8s/rules/cis_5_2_8/data.yaml
+++ b/compliance/cis_k8s/rules/cis_5_2_8/data.yaml
@@ -1,6 +1,6 @@
 metadata:
   id: 6e903b52-eeed-5abf-9ead-24b6d309681e
-  name: Minimize the admission of containers with added capabilities (Manual)
+  name: Minimize the admission of containers with added capabilities (Automated)
   profile_applicability: |
     * Level 1 - Master Node
   description: >

--- a/compliance/cis_k8s/rules/cis_5_2_8/data.yaml
+++ b/compliance/cis_k8s/rules/cis_5_2_8/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 212c7bdd-03e9-5473-9ced-244f1e35e08d
+  id: ad6d4076-950a-5349-8951-d7148f886b22
   name: Minimize the admission of containers with added capabilities (Automated)
   profile_applicability: |
     * Level 1 - Master Node

--- a/compliance/cis_k8s/rules/cis_5_2_8/data.yaml
+++ b/compliance/cis_k8s/rules/cis_5_2_8/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 6e903b52-eeed-5abf-9ead-24b6d309681e
+  id: 212c7bdd-03e9-5473-9ced-244f1e35e08d
   name: Minimize the admission of containers with added capabilities (Automated)
   profile_applicability: |
     * Level 1 - Master Node

--- a/compliance/cis_k8s/rules/cis_5_2_9/data.yaml
+++ b/compliance/cis_k8s/rules/cis_5_2_9/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 49ca234d-44d9-57ff-a136-7d0117f234bc
+  id: 21da5544-410e-5958-9e8d-bb2e9ab02fe5
   name: Minimize the admission of containers with capabilities assigned (Manual)
   profile_applicability: |
     * Level 2 - Master Node

--- a/compliance/cis_k8s/rules/cis_5_2_9/data.yaml
+++ b/compliance/cis_k8s/rules/cis_5_2_9/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: a91b8961-37d1-5759-a84f-45e9986df95c
+  id: 49ca234d-44d9-57ff-a136-7d0117f234bc
   name: Minimize the admission of containers with capabilities assigned (Manual)
   profile_applicability: |
     * Level 2 - Master Node


### PR DESCRIPTION
Updated the rules to the relevant benchmark

Updated the calculation of ids to newly format:
uuidv5 namespace value is `9478c8d6-6d2d-55d1-ae9b-90a067aabe98` (constant for all benchmarks and rules)
uuidv5 string value is `*BenchmarkName*-*BenchmarkVersion* *RuleNumber* *RuleName*`

As an example for "CIS Benchmark for Kubernetes V1.20" version "1.0.0" and rule "1.2.18" the id will be calculated like this:
`uuidv5("CIS Benchmark for Kubernetes V1.20-1.0.0 1.2.18 Ensure that the --insecure-port argument is set to 0 (Automated)", "9478c8d6-6d2d-55d1-ae9b-90a067aabe98")`

Taken from https://www.cisecurity.org/cis-benchmarks/
![Screen Shot 2022-04-19 at 11 42 11](https://user-images.githubusercontent.com/12246907/164094969-5bd27ce5-c2bf-4018-b301-e4f22742f786.png)
