### PR TITLE
CSP-48-cis-4.2.7-fix default value

### DIFF
--- a/compliance/cis_eks/rules/cis_3_2_7/rule.rego
+++ b/compliance/cis_eks/rules/cis_3_2_7/rule.rego
@@ -4,20 +4,20 @@ import data.compliance.cis_eks
 import data.compliance.lib.common
 import data.compliance.lib.data_adapter
 
-default rule_evaluation = false
+default rule_evaluation = true
 
 process_args := cis_eks.data_adapter.process_args
 
 # Ensure that the --make-iptables-util-chains argument is set to true (Automated)
-rule_evaluation {
-	common.contains_key_with_value(process_args, "--make-iptables-util-chains", "true")
+rule_evaluation = false {
+	common.contains_key_with_value(process_args, "--make-iptables-util-chains", "false")
 }
 
 # In case both flags and configuration file are specified, the executable argument takes precedence.
 # Checks that the entry for makeIPTablesUtilChains is set to true.
-rule_evaluation {
+rule_evaluation = false {
 	not process_args["--make-iptables-util-chains"]
-	data_adapter.process_config.config.makeIPTablesUtilChains
+	data_adapter.process_config.config.makeIPTablesUtilChains == false
 }
 
 finding = result {

--- a/compliance/cis_eks/rules/cis_3_2_7/test.rego
+++ b/compliance/cis_eks/rules/cis_3_2_7/test.rego
@@ -4,13 +4,13 @@ import data.kubernetes_common.test_data
 import data.lib.test
 
 test_violation {
-	test.assert_fail(finding) with input as rule_input("")
 	test.assert_fail(finding) with input as rule_input("--make-iptables-util-chains false")
 	test.assert_fail(finding) with input as rule_input_with_external("", create_process_config(false))
 	test.assert_fail(finding) with input as rule_input_with_external("--make-iptables-util-chains false", create_process_config(true))
 }
 
 test_pass {
+	test.assert_pass(finding) with input as rule_input("")
 	test.assert_pass(finding) with input as rule_input("--make-iptables-util-chains true")
 	test.assert_pass(finding) with input as rule_input_with_external("--make-iptables-util-chains true", create_process_config(false))
 	test.assert_pass(finding) with input as rule_input_with_external("--make-iptables-util-chains true", create_process_config(true))

--- a/compliance/cis_k8s/rules/cis_1_2_23/rule.rego
+++ b/compliance/cis_k8s/rules/cis_1_2_23/rule.rego
@@ -11,7 +11,7 @@ process_args := cis_k8s.data_adapter.process_args
 
 default rule_evaluation = true
 
-rule_evaluation = false{
+rule_evaluation = false {
 	value := process_args["--request-timeout"]
 	common.duration_lte(value, "60s")
 }

--- a/compliance/cis_k8s/rules/cis_4_2_7/rule.rego
+++ b/compliance/cis_k8s/rules/cis_4_2_7/rule.rego
@@ -6,19 +6,19 @@ import data.compliance.lib.data_adapter
 
 # Ensure that the --make-iptables-util-chains argument is set to true (Automated)
 
-default rule_evaluation = false
+default rule_evaluation = true
 
 process_args := cis_k8s.data_adapter.process_args
 
-rule_evaluation {
-	common.contains_key_with_value(process_args, "--make-iptables-util-chains", "true")
+rule_evaluation = false {
+	common.contains_key_with_value(process_args, "--make-iptables-util-chains", "false")
 }
 
 # In case both flags and configuration file are specified, the executable argument takes precedence.
 # Checks that the entry for makeIPTablesUtilChains is set to true.
-rule_evaluation {
+rule_evaluation = false {
 	not process_args["--make-iptables-util-chains"]
-	data_adapter.process_config.config.makeIPTablesUtilChains
+	data_adapter.process_config.config.makeIPTablesUtilChains == false
 }
 
 finding = result {

--- a/compliance/cis_k8s/rules/cis_4_2_7/test.rego
+++ b/compliance/cis_k8s/rules/cis_4_2_7/test.rego
@@ -4,13 +4,13 @@ import data.kubernetes_common.test_data
 import data.lib.test
 
 test_violation {
-	test.assert_fail(finding) with input as rule_input("")
 	test.assert_fail(finding) with input as rule_input("--make-iptables-util-chains=false")
 	test.assert_fail(finding) with input as rule_input_with_external("", create_process_config(false))
 	test.assert_fail(finding) with input as rule_input_with_external("--make-iptables-util-chains=false", create_process_config(true))
 }
 
 test_pass {
+	test.assert_pass(finding) with input as rule_input("")
 	test.assert_pass(finding) with input as rule_input("--make-iptables-util-chains=true")
 	test.assert_pass(finding) with input as rule_input_with_external("--make-iptables-util-chains=true", create_process_config(false))
 	test.assert_pass(finding) with input as rule_input_with_external("--make-iptables-util-chains=true", create_process_config(true))


### PR DESCRIPTION
* fixed : https://github.com/elastic/csp-security-policies/issues/90

Whenever there is no `--make-iptables-util-chains` process flag the rule should pass