### PR TITLE
Duplicate benchmark loop fix

### DIFF
--- a/compliance/main.rego
+++ b/compliance/main.rego
@@ -15,15 +15,19 @@ findings = f {
 	# iterate over activated benchmarks
 	benchmarks := [key | data.activated_rules[key]]
 
+	rego := compliance
+
 	# aggregate findings from activated benchmarks
-	f := [finding | compliance[benchmarks[_]].findings[finding]]
+	f := [finding | rego[benchmarks[_]].findings[finding]]
 }
 
 findings = f {
 	not data.activated_rules
 
+	rego := compliance
+
 	# aggregate findings from all benchmarks
-	f := [finding | compliance[benchmarks].findings[finding]]
+	f := [finding | rego[benchmarks].findings[finding]]
 }
 
 metadata = common.metadata

--- a/compliance/main.rego
+++ b/compliance/main.rego
@@ -15,19 +15,15 @@ findings = f {
 	# iterate over activated benchmarks
 	benchmarks := [key | data.activated_rules[key]]
 
-	rego := compliance
-
 	# aggregate findings from activated benchmarks
-	f := [finding | rego[benchmarks[_]].findings[finding]]
+	f := {finding | compliance[benchmarks[_]].findings[finding]}
 }
 
 findings = f {
 	not data.activated_rules
 
-	rego := compliance
-
 	# aggregate findings from all benchmarks
-	f := [finding | rego[benchmarks].findings[finding]]
+	f := {finding | compliance[benchmarks].findings[finding]}
 }
 
 metadata = common.metadata


### PR DESCRIPTION
Compliance had multiple non-unique values (cis_k8s twice), thus evaluated twice and this is the reason why we've had more findings than expected.

Still investigating the reason why adding YAML files under rule directories creates a duplicate in the compliance import value for the benchmarks.

Another way to resolve this issue is by assuring uniqueness via Set.
```
rego := {x | x = compliance[benchmarks]}
```

Fixes - https://github.com/elastic/cloudbeat/issues/219
Opened - https://github.com/open-policy-agent/opa/issues/4787