### PR TITLE
Update data_adapter kube-api filtering 

### DIFF
--- a/compliance/cis_k8s/rules/cis_5_1_5/rule.rego
+++ b/compliance/cis_k8s/rules/cis_5_1_5/rule.rego
@@ -29,6 +29,7 @@ rule_violation {
 
 finding = result {
 	# filter
+	data_adapter.is_kube_api
 	data_adapter.is_service_account_or_pod
 
 	# evaluate

--- a/compliance/cis_k8s/rules/cis_5_1_6/rule.rego
+++ b/compliance/cis_k8s/rules/cis_5_1_6/rule.rego
@@ -22,6 +22,7 @@ rule_violation {
 
 finding = result {
 	# filter
+	data_adapter.is_kube_api
 	data_adapter.is_service_account_or_pod
 
 	# evaluate

--- a/compliance/kubernetes_common/test_data.rego
+++ b/compliance/kubernetes_common/test_data.rego
@@ -10,7 +10,7 @@ not_evaluated_input = {
 
 # kube-api input data that should not get evaluated
 not_evaluated_kube_api_input = {
-	"type": "kube-api",
+	"type": "k8s_object",
 	"resource": {"kind": "some_kind"},
 }
 
@@ -40,7 +40,7 @@ process_input_with_external_data(process_name, arguments, external_data) = {
 }
 
 kube_api_input(resource) = {
-	"type": "kube-api",
+	"type": "k8s_object",
 	"resource": resource,
 }
 
@@ -51,7 +51,7 @@ kube_api_role_rule(api_group, resource, verb) = {
 }
 
 kube_api_role_input(kind, rules) = {
-	"type": "kube-api",
+	"type": "k8s_object",
 	"resource": {
 		"kind": kind,
 		"metadata": {"name": "role-name"},
@@ -60,7 +60,7 @@ kube_api_role_input(kind, rules) = {
 }
 
 kube_api_pod_input(pod_name, service_account, automount_setting) = {
-	"type": "kube-api",
+	"type": "k8s_object",
 	"resource": {
 		"kind": "Pod",
 		"metadata": {"name": pod_name},
@@ -73,7 +73,7 @@ kube_api_pod_input(pod_name, service_account, automount_setting) = {
 }
 
 kube_api_service_account_input(name, automount_setting) = {
-	"type": "kube-api",
+	"type": "k8s_object",
 	"resource": {
 		"kind": "ServiceAccount",
 		"metadata": {"name": name},

--- a/compliance/lib/data_adapter/data_adapter.rego
+++ b/compliance/lib/data_adapter/data_adapter.rego
@@ -87,7 +87,7 @@ is_kubelet {
 }
 
 is_kube_api {
-	input.type == "kube-api"
+	input.type == "k8s_object"
 }
 
 is_cluster_roles {


### PR DESCRIPTION
Kube objects type was updated in Cloudbeat to `k8s_object` but the data adapter was not, this led to some kube rules not filtering correctly and in turn not running at all
____
- Closing: https://github.com/elastic/security-team/issues/4169