### PR TITLE
Kube resource type rules to audits refactor

### DIFF
--- a/bundle/compliance/cis_eks/rules/cis_4_2_1/rule.rego
+++ b/bundle/compliance/cis_eks/rules/cis_4_2_1/rule.rego
@@ -1,29 +1,7 @@
 package compliance.cis_eks.rules.cis_4_2_1
 
-import data.compliance.lib.common
-import data.compliance.lib.data_adapter
-
-# Minimize the admission of privileged containers (Automated)
-
-# evaluate
-default rule_evaluation = true
-
-# Verify that there is at least one PSP which does not return true.
-rule_evaluation = false {
-	container := data_adapter.containers[_]
-	common.contains_key_with_value(container.securityContext, "privileged", true)
-}
+import data.compliance.policy.kube_api.minimize_admission as audit
 
 finding = result {
-	# filter
-	data_adapter.is_kube_api
-
-	# set result
-	result := {
-		"evaluation": common.calculate_result(rule_evaluation),
-		"evidence": {
-			"uid": data_adapter.pod.metadata.uid,
-			"containers": {json.filter(c, ["name", "securityContext/privileged"]) | c := data_adapter.containers[_]},
-		},
-	}
+	result := audit.finding("privileged")
 }

--- a/bundle/compliance/cis_eks/rules/cis_4_2_2/rule.rego
+++ b/bundle/compliance/cis_eks/rules/cis_4_2_2/rule.rego
@@ -1,23 +1,7 @@
 package compliance.cis_eks.rules.cis_4_2_2
 
-import data.compliance.lib.assert
-import data.compliance.lib.common
-import data.compliance.lib.data_adapter
+import data.compliance.policy.kube_api.minimize_sharing as audit
 
-# Minimize the admission of containers wishing to share the host process ID namespace (Automated)
 finding = result {
-	# filter
-	data_adapter.is_kube_api
-
-	# evaluate
-	rule_evaluation := assert.is_false(common.contains_key_with_value(data_adapter.pod.spec, "hostPID", true))
-
-	# set result
-	result := {
-		"evaluation": common.calculate_result(rule_evaluation),
-		"evidence": json.filter(data_adapter.pod, [
-			"metadata/uid",
-			"spec/hostPID",
-		]),
-	}
+	result := audit.finding("hostPID")
 }

--- a/bundle/compliance/cis_eks/rules/cis_4_2_3/rule.rego
+++ b/bundle/compliance/cis_eks/rules/cis_4_2_3/rule.rego
@@ -1,23 +1,7 @@
 package compliance.cis_eks.rules.cis_4_2_3
 
-import data.compliance.lib.assert
-import data.compliance.lib.common
-import data.compliance.lib.data_adapter
+import data.compliance.policy.kube_api.minimize_sharing as audit
 
-# Minimize the admission of containers wishing to share the host IPC namespace (Automated)
 finding = result {
-	# filter
-	data_adapter.is_kube_api
-
-	# evaluate
-	rule_evaluation := assert.is_false(common.contains_key_with_value(data_adapter.pod.spec, "hostIPC", true))
-
-	# set result
-	result := {
-		"evaluation": common.calculate_result(rule_evaluation),
-		"evidence": json.filter(data_adapter.pod, [
-			"metadata/uid",
-			"spec/hostIPC",
-		]),
-	}
+	result := audit.finding("hostIPC")
 }

--- a/bundle/compliance/cis_eks/rules/cis_4_2_4/rule.rego
+++ b/bundle/compliance/cis_eks/rules/cis_4_2_4/rule.rego
@@ -1,23 +1,7 @@
 package compliance.cis_eks.rules.cis_4_2_4
 
-import data.compliance.lib.assert
-import data.compliance.lib.common
-import data.compliance.lib.data_adapter
+import data.compliance.policy.kube_api.minimize_sharing as audit
 
-# Minimize the admission of containers wishing to share the host network namespace (Automated)
 finding = result {
-	# filter
-	data_adapter.is_kube_api
-
-	# evaluate
-	rule_evaluation := assert.is_false(common.contains_key_with_value(data_adapter.pod.spec, "hostNetwork", true))
-
-	# set result
-	result := {
-		"evaluation": common.calculate_result(rule_evaluation),
-		"evidence": json.filter(data_adapter.pod, [
-			"metadata/uid",
-			"spec/hostNetwork",
-		]),
-	}
+	result := audit.finding("hostNetwork")
 }

--- a/bundle/compliance/cis_eks/rules/cis_4_2_5/rule.rego
+++ b/bundle/compliance/cis_eks/rules/cis_4_2_5/rule.rego
@@ -1,29 +1,7 @@
 package compliance.cis_eks.rules.cis_4_2_5
 
-import data.compliance.lib.common
-import data.compliance.lib.data_adapter
-
-# Minimize the admission of containers with allowPrivilegeEscalation (Automated)
-
-# evaluate
-default rule_evaluation = true
-
-# Verify that there is at least one PSP which does not return true.
-rule_evaluation = false {
-	container := data_adapter.containers[_]
-	common.contains_key_with_value(container.securityContext, "allowPrivilegeEscalation", true)
-}
+import data.compliance.policy.kube_api.minimize_admission as audit
 
 finding = result {
-	# filter
-	data_adapter.is_kube_api
-
-	# set result
-	result := {
-		"evaluation": common.calculate_result(rule_evaluation),
-		"evidence": {
-			"uid": data_adapter.pod.metadata.uid,
-			"containers": {json.filter(c, ["name", "securityContext/allowPrivilegeEscalation"]) | c := data_adapter.containers[_]},
-		},
-	}
+	result := audit.finding("allowPrivilegeEscalation")
 }

--- a/bundle/compliance/cis_eks/rules/cis_4_2_6/rule.rego
+++ b/bundle/compliance/cis_eks/rules/cis_4_2_6/rule.rego
@@ -1,39 +1,7 @@
 package compliance.cis_eks.rules.cis_4_2_6
 
-import data.compliance.lib.common
-import data.compliance.lib.data_adapter
-
-# Minimize the admission of root containers (Automated)
-
-# evaluate
-default rule_evaluation = true
-
-# Verify that there is at least one PSP which returns MustRunAsNonRoot or MustRunAs with the range of UIDs not including 0.
-rule_evaluation = false {
-	not common.contains_key_with_value(data_adapter.pod.spec.runAsUser, "rule", "MustRunAsNonRoot")
-	common.contains_key_with_value(data_adapter.pod.spec.runAsUser, "rule", "MustRunAs")
-	range := data_adapter.pod.spec.runAsUser.ranges[_]
-	range.min <= 0
-}
-
-rule_evaluation = false {
-	container := data_adapter.containers[_]
-	common.contains_key_with_value(container.securityContext, "runAsUser", 0)
-}
+import data.compliance.policy.kube_api.minimize_admission_root as audit
 
 finding = result {
-	# filter
-	data_adapter.is_kube_api
-
-	# set result
-	pod := json.filter(data_adapter.pod, [
-		"metadata/uid",
-		"spec/runAsUser",
-	])
-
-	containers := {"containers": json.filter(c, ["name", "securityContext/runAsUser"]) | c := data_adapter.containers[_]}
-	result := {
-		"evaluation": common.calculate_result(rule_evaluation),
-		"evidence": object.union(pod, containers),
-	}
+	result := audit.finding
 }

--- a/bundle/compliance/cis_eks/rules/cis_4_2_7/rule.rego
+++ b/bundle/compliance/cis_eks/rules/cis_4_2_7/rule.rego
@@ -1,35 +1,7 @@
 package compliance.cis_eks.rules.cis_4_2_7
 
-import data.compliance.lib.common
-import data.compliance.lib.data_adapter
-
-# Minimize the admission of containers with the NET_RAW capability (Automated)
-
-# evaluate
-default rule_evaluation = false
-
-# Verify that there is at least one PSP which returns NET_RAW or ALL.
-rule_evaluation {
-	# Verify that there is at least one PSP which returns NET_RAW.
-	data_adapter.pod.spec.requiredDropCapabilities[_] == "NET_RAW"
-}
-
-# or 
-rule_evaluation {
-	# Verify that there is at least one PSP which returns ALL.
-	data_adapter.pod.spec.requiredDropCapabilities[_] == "ALL"
-}
+import data.compliance.policy.kube_api.minimize_certain_capability as audit
 
 finding = result {
-	# filter
-	data_adapter.is_kube_api
-
-	# set result
-	result := {
-		"evaluation": common.calculate_result(rule_evaluation),
-		"evidence": json.filter(data_adapter.pod, [
-			"metadata/uid",
-			"spec/requiredDropCapabilities",
-		]),
-	}
+	result := audit.finding
 }

--- a/bundle/compliance/cis_eks/rules/cis_4_2_8/rule.rego
+++ b/bundle/compliance/cis_eks/rules/cis_4_2_8/rule.rego
@@ -1,25 +1,7 @@
 package compliance.cis_eks.rules.cis_4_2_8
 
-import data.compliance.lib.assert
-import data.compliance.lib.common
-import data.compliance.lib.data_adapter
-
-# Minimize the admission of containers with added capabilities (Automated)
+import data.compliance.policy.kube_api.minimize_added_capabilities as audit
 
 finding = result {
-	# filter
-	data_adapter.is_kube_api
-
-	# evaluate
-	allowedCapabilities := object.get(data_adapter.pod.spec, "allowedCapabilities", [])
-	rule_evaluation := assert.array_is_empty(allowedCapabilities)
-
-	# set result
-	result := {
-		"evaluation": common.calculate_result(rule_evaluation),
-		"evidence": json.filter(data_adapter.pod, [
-			"metadata/uid",
-			"spec/allowedCapabilities",
-		]),
-	}
+	result := audit.finding
 }

--- a/bundle/compliance/cis_eks/rules/cis_4_2_9/rule.rego
+++ b/bundle/compliance/cis_eks/rules/cis_4_2_9/rule.rego
@@ -1,27 +1,7 @@
 package compliance.cis_eks.rules.cis_4_2_9
 
-import data.compliance.lib.assert
-import data.compliance.lib.common
-import data.compliance.lib.data_adapter
-
-# Minimize the admission of containers with capabilities assigned (Manual)
-# evaluate
-default rule_evaluation = true
-
-rule_evaluation = false {
-	container := data_adapter.containers[_]
-	capabilities := object.get(container.securityContext, "capabilities", [])
-	not assert.array_is_empty(capabilities)
-}
+import data.compliance.policy.kube_api.minimize_assigned_capabilities as audit
 
 finding = result {
-	# filter
-	data_adapter.is_kube_api
-	data_adapter.containers
-
-	# set result
-	result := {
-		"evaluation": common.calculate_result(rule_evaluation),
-		"containers": {json.filter(c, ["name", "securityContext/capabilities"]) | c := data_adapter.containers[_]},
-	}
+	result := audit.finding
 }

--- a/bundle/compliance/cis_k8s/rules/cis_5_1_3/rule.rego
+++ b/bundle/compliance/cis_k8s/rules/cis_5_1_3/rule.rego
@@ -1,41 +1,7 @@
 package compliance.cis_k8s.rules.cis_5_1_3
 
-import data.compliance.lib.assert
-import data.compliance.lib.common
-import data.compliance.lib.data_adapter
-import future.keywords.in
-
-# Minimize wildcard use in Roles and ClusterRoles (Manual)
-default rule_violation = false
-
-# evaluate
-rule_violation {
-	cluster_roles_rule := data_adapter.cluster_roles.rules[i]
-	is_using_wildcards(cluster_roles_rule)
-}
+import data.compliance.policy.kube_api.minimize_wildcard as audit
 
 finding = result {
-	# filter
-	data_adapter.is_cluster_roles
-
-	# evaluate
-	rule_evaluation := assert.is_false(rule_violation)
-
-	# set result
-	result := {
-		"evaluation": common.calculate_result(rule_evaluation),
-		"evidence": {"cluster_roles": data_adapter.cluster_roles},
-	}
-}
-
-is_using_wildcards(rule) {
-	"*" in rule.apiGroups # assert no wild-cards in api_group
-}
-
-is_using_wildcards(rule) {
-	"*" in rule.resources # assert no wild-cards in resources
-}
-
-is_using_wildcards(rule) {
-	"*" in rule.verbs # assert no wild-cards in verbs
+	result := audit.finding
 }

--- a/bundle/compliance/cis_k8s/rules/cis_5_1_5/rule.rego
+++ b/bundle/compliance/cis_k8s/rules/cis_5_1_5/rule.rego
@@ -1,46 +1,7 @@
 package compliance.cis_k8s.rules.cis_5_1_5
 
-import data.compliance.lib.assert
-import data.compliance.lib.common
-import data.compliance.lib.data_adapter
-import future.keywords.in
-
-# Ensure that default service accounts are not actively used (Manual)
-default rule_violation = false
-
-# no roles or cluster roles bound to default service account apart from the defaults.
-rule_violation {
-	pod := data_adapter.pod
-	pod.spec.serviceAccount == "default"
-}
-
-# no roles or cluster roles bound to default service account apart from the defaults.
-rule_violation {
-	pod := data_adapter.pod
-	pod.spec.serviceAccountName == "default"
-}
-
-# ensure that the automountServiceAccountToken: false
-rule_violation {
-	service_account := data_adapter.service_account
-	service_account.metadata.name == "default"
-	service_account.automountServiceAccountToken == true
-}
+import data.compliance.policy.kube_api.ensure_service_accounts as audit
 
 finding = result {
-	# filter
-	data_adapter.is_kube_api
-	data_adapter.is_service_account_or_pod
-
-	# evaluate
-	rule_evaluation = assert.is_false(rule_violation)
-
-	# set result
-	result := {
-		"evaluation": common.calculate_result(rule_evaluation),
-		"evidence": {
-			"serviceAccounts": [pod.spec.serviceAccount | data_adapter.pods[pod]],
-			"serviceAccount": [service_account | data_adapter.service_accounts[service_account]],
-		},
-	}
+	result := audit.finding(audit.service_account_default)
 }

--- a/bundle/compliance/cis_k8s/rules/cis_5_1_6/rule.rego
+++ b/bundle/compliance/cis_k8s/rules/cis_5_1_6/rule.rego
@@ -1,39 +1,7 @@
 package compliance.cis_k8s.rules.cis_5_1_6
 
-import data.compliance.lib.assert
-import data.compliance.lib.common
-import data.compliance.lib.data_adapter
-import future.keywords.in
-
-# Ensure that default service accounts are not actively used (Manual)
-default rule_violation = false
-
-# Review pod and service account objects in the cluster and ensure that automountServiceAccountToken is
-# set to false
-rule_violation {
-	pod := data_adapter.pod
-	pod.spec.automountServiceAccountToken == true
-}
-
-rule_violation {
-	service_account := data_adapter.service_account
-	service_account.automountServiceAccountToken == true
-}
+import data.compliance.policy.kube_api.ensure_service_accounts as audit
 
 finding = result {
-	# filter
-	data_adapter.is_kube_api
-	data_adapter.is_service_account_or_pod
-
-	# evaluate
-	rule_evaluation = assert.is_false(rule_violation)
-
-	# set result
-	result := {
-		"evaluation": common.calculate_result(rule_evaluation),
-		"evidence": {
-			"serviceAccounts": [pod.spec.serviceAccount | data_adapter.pods[pod]],
-			"serviceAccount": [service_account | data_adapter.service_accounts[service_account]],
-		},
-	}
+	result := audit.finding(audit.service_account_automount)
 }

--- a/bundle/compliance/cis_k8s/rules/cis_5_2_10/rule.rego
+++ b/bundle/compliance/cis_k8s/rules/cis_5_2_10/rule.rego
@@ -1,27 +1,7 @@
 package compliance.cis_k8s.rules.cis_5_2_10
 
-import data.compliance.lib.assert
-import data.compliance.lib.common
-import data.compliance.lib.data_adapter
-
-# Minimize the admission of containers with capabilities assigned (Manual)
-# evaluate
-default rule_evaluation = true
-
-rule_evaluation = false {
-	container := data_adapter.containers[_]
-	capabilities := object.get(container.securityContext, "capabilities", [])
-	not assert.array_is_empty(capabilities)
-}
+import data.compliance.policy.kube_api.minimize_assigned_capabilities as audit
 
 finding = result {
-	# filter
-	data_adapter.is_kube_api
-	data_adapter.containers
-
-	# set result
-	result := {
-		"evaluation": common.calculate_result(rule_evaluation),
-		"containers": {json.filter(c, ["name", "securityContext/capabilities"]) | c := data_adapter.containers[_]},
-	}
+	result := audit.finding
 }

--- a/bundle/compliance/cis_k8s/rules/cis_5_2_2/rule.rego
+++ b/bundle/compliance/cis_k8s/rules/cis_5_2_2/rule.rego
@@ -1,29 +1,7 @@
 package compliance.cis_k8s.rules.cis_5_2_2
 
-import data.compliance.lib.common
-import data.compliance.lib.data_adapter
-
-# Minimize the admission of privileged containers (Automated)
-
-# evaluate
-default rule_evaluation = true
-
-# Verify that there is at least one PSP which does not return true.
-rule_evaluation = false {
-	container := data_adapter.containers[_]
-	common.contains_key_with_value(container.securityContext, "privileged", true)
-}
+import data.compliance.policy.kube_api.minimize_admission as audit
 
 finding = result {
-	# filter
-	data_adapter.is_kube_api
-
-	# set result
-	result := {
-		"evaluation": common.calculate_result(rule_evaluation),
-		"evidence": {
-			"uid": data_adapter.pod.metadata.uid,
-			"containers": {json.filter(c, ["name", "securityContext/privileged"]) | c := data_adapter.containers[_]},
-		},
-	}
+	result := audit.finding("privileged")
 }

--- a/bundle/compliance/cis_k8s/rules/cis_5_2_3/rule.rego
+++ b/bundle/compliance/cis_k8s/rules/cis_5_2_3/rule.rego
@@ -1,23 +1,7 @@
 package compliance.cis_k8s.rules.cis_5_2_3
 
-import data.compliance.lib.assert
-import data.compliance.lib.common
-import data.compliance.lib.data_adapter
+import data.compliance.policy.kube_api.minimize_sharing as audit
 
-# Minimize the admission of containers wishing to share the host process ID namespace (Automated)
 finding = result {
-	# filter
-	data_adapter.is_kube_api
-
-	# evaluate
-	rule_evaluation := assert.is_false(common.contains_key_with_value(data_adapter.pod.spec, "hostPID", true))
-
-	# set result
-	result := {
-		"evaluation": common.calculate_result(rule_evaluation),
-		"evidence": json.filter(data_adapter.pod, [
-			"metadata/uid",
-			"spec/hostPID",
-		]),
-	}
+	result := audit.finding("hostPID")
 }

--- a/bundle/compliance/cis_k8s/rules/cis_5_2_4/rule.rego
+++ b/bundle/compliance/cis_k8s/rules/cis_5_2_4/rule.rego
@@ -1,23 +1,7 @@
 package compliance.cis_k8s.rules.cis_5_2_4
 
-import data.compliance.lib.assert
-import data.compliance.lib.common
-import data.compliance.lib.data_adapter
+import data.compliance.policy.kube_api.minimize_sharing as audit
 
-# Minimize the admission of containers wishing to share the host IPC namespace (Automated)
 finding = result {
-	# filter
-	data_adapter.is_kube_api
-
-	# evaluate
-	rule_evaluation := assert.is_false(common.contains_key_with_value(data_adapter.pod.spec, "hostIPC", true))
-
-	# set result
-	result := {
-		"evaluation": common.calculate_result(rule_evaluation),
-		"evidence": json.filter(data_adapter.pod, [
-			"metadata/uid",
-			"spec/hostIPC",
-		]),
-	}
+	result := audit.finding("hostIPC")
 }

--- a/bundle/compliance/cis_k8s/rules/cis_5_2_5/rule.rego
+++ b/bundle/compliance/cis_k8s/rules/cis_5_2_5/rule.rego
@@ -1,23 +1,7 @@
 package compliance.cis_k8s.rules.cis_5_2_5
 
-import data.compliance.lib.assert
-import data.compliance.lib.common
-import data.compliance.lib.data_adapter
+import data.compliance.policy.kube_api.minimize_sharing as audit
 
-# Minimize the admission of containers wishing to share the host network namespace (Automated)
 finding = result {
-	# filter
-	data_adapter.is_kube_api
-
-	# evaluate
-	rule_evaluation := assert.is_false(common.contains_key_with_value(data_adapter.pod.spec, "hostNetwork", true))
-
-	# set result
-	result := {
-		"evaluation": common.calculate_result(rule_evaluation),
-		"evidence": json.filter(data_adapter.pod, [
-			"metadata/uid",
-			"spec/hostNetwork",
-		]),
-	}
+	result := audit.finding("hostNetwork")
 }

--- a/bundle/compliance/cis_k8s/rules/cis_5_2_6/rule.rego
+++ b/bundle/compliance/cis_k8s/rules/cis_5_2_6/rule.rego
@@ -1,29 +1,7 @@
 package compliance.cis_k8s.rules.cis_5_2_6
 
-import data.compliance.lib.common
-import data.compliance.lib.data_adapter
-
-# Minimize the admission of containers with allowPrivilegeEscalation (Automated)
-
-# evaluate
-default rule_evaluation = true
-
-# Verify that there is at least one PSP which does not return true.
-rule_evaluation = false {
-	container := data_adapter.containers[_]
-	common.contains_key_with_value(container.securityContext, "allowPrivilegeEscalation", true)
-}
+import data.compliance.policy.kube_api.minimize_admission as audit
 
 finding = result {
-	# filter
-	data_adapter.is_kube_api
-
-	# set result
-	result := {
-		"evaluation": common.calculate_result(rule_evaluation),
-		"evidence": {
-			"uid": data_adapter.pod.metadata.uid,
-			"containers": {json.filter(c, ["name", "securityContext/allowPrivilegeEscalation"]) | c := data_adapter.containers[_]},
-		},
-	}
+	result := audit.finding("allowPrivilegeEscalation")
 }

--- a/bundle/compliance/cis_k8s/rules/cis_5_2_7/rule.rego
+++ b/bundle/compliance/cis_k8s/rules/cis_5_2_7/rule.rego
@@ -1,39 +1,7 @@
 package compliance.cis_k8s.rules.cis_5_2_7
 
-import data.compliance.lib.common
-import data.compliance.lib.data_adapter
-
-# Minimize the admission of root containers (Automated)
-
-# evaluate
-default rule_evaluation = true
-
-# Verify that there is at least one PSP which returns MustRunAsNonRoot or MustRunAs with the range of users not including 0.
-rule_evaluation = false {
-	not common.contains_key_with_value(data_adapter.pod.spec.runAsUser, "rule", "MustRunAsNonRoot")
-	common.contains_key_with_value(data_adapter.pod.spec.runAsUser, "rule", "MustRunAs")
-	range := data_adapter.pod.spec.runAsUser.ranges[_]
-	range.min <= 0
-}
-
-rule_evaluation = false {
-	container := data_adapter.containers[_]
-	common.contains_key_with_value(container.securityContext, "runAsUser", 0)
-}
+import data.compliance.policy.kube_api.minimize_admission_root as audit
 
 finding = result {
-	# filter
-	data_adapter.is_kube_api
-
-	# set result
-	pod := json.filter(data_adapter.pod, [
-		"metadata/uid",
-		"spec/runAsUser",
-	])
-
-	containers := {"containers": json.filter(c, ["name", "securityContext/runAsUser"]) | c := data_adapter.containers[_]}
-	result := {
-		"evaluation": common.calculate_result(rule_evaluation),
-		"evidence": object.union(pod, containers),
-	}
+	result := audit.finding
 }

--- a/bundle/compliance/cis_k8s/rules/cis_5_2_8/rule.rego
+++ b/bundle/compliance/cis_k8s/rules/cis_5_2_8/rule.rego
@@ -1,35 +1,7 @@
 package compliance.cis_k8s.rules.cis_5_2_8
 
-import data.compliance.lib.common
-import data.compliance.lib.data_adapter
-
-# Minimize the admission of containers with the NET_RAW capability (Automated)
-
-# evaluate
-default rule_evaluation = false
-
-# Verify that there is at least one PSP which returns NET_RAW or ALL.
-rule_evaluation {
-	# Verify that there is at least one PSP which returns NET_RAW.
-	data_adapter.pod.spec.requiredDropCapabilities[_] == "NET_RAW"
-}
-
-# or 
-rule_evaluation {
-	# Verify that there is at least one PSP which returns ALL.
-	data_adapter.pod.spec.requiredDropCapabilities[_] == "ALL"
-}
+import data.compliance.policy.kube_api.minimize_certain_capability as audit
 
 finding = result {
-	# filter
-	data_adapter.is_kube_api
-
-	# set result
-	result := {
-		"evaluation": common.calculate_result(rule_evaluation),
-		"evidence": json.filter(data_adapter.pod, [
-			"metadata/uid",
-			"spec/requiredDropCapabilities",
-		]),
-	}
+	result := audit.finding
 }

--- a/bundle/compliance/cis_k8s/rules/cis_5_2_9/rule.rego
+++ b/bundle/compliance/cis_k8s/rules/cis_5_2_9/rule.rego
@@ -1,25 +1,7 @@
 package compliance.cis_k8s.rules.cis_5_2_9
 
-import data.compliance.lib.assert
-import data.compliance.lib.common
-import data.compliance.lib.data_adapter
-
-# Minimize the admission of containers with added capabilities (Automated)
+import data.compliance.policy.kube_api.minimize_added_capabilities as audit
 
 finding = result {
-	# filter
-	data_adapter.is_kube_api
-
-	# evaluate
-	allowedCapabilities := object.get(data_adapter.pod.spec, "allowedCapabilities", [])
-	rule_evaluation := assert.array_is_empty(allowedCapabilities)
-
-	# set result
-	result := {
-		"evaluation": common.calculate_result(rule_evaluation),
-		"evidence": json.filter(data_adapter.pod, [
-			"metadata/uid",
-			"spec/allowedCapabilities",
-		]),
-	}
+	result := audit.finding
 }

--- a/bundle/compliance/lib/common/common.rego
+++ b/bundle/compliance/lib/common/common.rego
@@ -110,10 +110,17 @@ ranges_gte(ranges, value) {
 	not ranges_smaller_than(ranges, value)
 }
 
-generate_result(evaluation, expected, evidence) = result {
+generate_result(evaluation, evidence, expected) = result {
 	result := {
 		"evaluation": evaluation,
+		"evidence": evidence,
 		"expected": expected,
+	}
+}
+
+generate_result_without_expected(evaluation, evidence) = result {
+	result := {
+		"evaluation": evaluation,
 		"evidence": evidence,
 	}
 }

--- a/bundle/compliance/lib/data_adapter/data_adapter.rego
+++ b/bundle/compliance/lib/data_adapter/data_adapter.rego
@@ -1,7 +1,5 @@
 package compliance.lib.data_adapter
 
-import future.keywords.in
-
 is_process {
 	input.type == "process"
 }
@@ -57,41 +55,13 @@ is_kubelet {
 	process_name == "kubelet"
 }
 
+# TODO: Remove after refactoring of EKS 5.4.3 to use data_adapter instead of input directly
 is_kube_api {
 	input.type == "k8s_object"
 }
 
-is_cluster_roles {
-	is_kube_api
-	input.resource.kind in {"Role", "ClusterRole"}
-}
-
-cluster_roles := roles {
-	is_cluster_roles
-	roles = input.resource
-}
-
-service_account := account {
-	input.resource.kind == "ServiceAccount"
-	account = input.resource
-}
-
+# TODO: Remove after refactoring of EKS 5.4.3 to use data_adapter instead of input directly
 is_kube_node {
 	is_kube_api
 	input.resource.kind == "Node"
-}
-
-pod = p {
-	input.resource.kind == "Pod"
-	p := input.resource
-}
-
-is_service_account_or_pod = pod
-
-is_service_account_or_pod = service_account
-
-containers = c {
-	input.resource.kind == "Pod"
-	container_types := {"containers", "initContainers"}
-	c := pod.spec[container_types[t]]
 }

--- a/bundle/compliance/policy/file/data_adapter.rego
+++ b/bundle/compliance/policy/file/data_adapter.rego
@@ -1,7 +1,5 @@
 package compliance.policy.file.data_adapter
 
-import future.keywords.in
-
 is_filesystem {
 	input.type == "file"
 }

--- a/bundle/compliance/policy/file/ensure_ownership.rego
+++ b/bundle/compliance/policy/file/ensure_ownership.rego
@@ -12,8 +12,8 @@ finding(owner_user, owner_group) = result {
 	# set result
 	result := lib_common.generate_result(
 		lib_common.calculate_result(rule_evaluation),
-		{"owner": owner_user, "group": owner_group},
 		{"owner": user, "group": group},
+		{"owner": owner_user, "group": owner_group},
 	)
 }
 

--- a/bundle/compliance/policy/file/ensure_permissions.rego
+++ b/bundle/compliance/policy/file/ensure_permissions.rego
@@ -11,8 +11,8 @@ finding(user, group, other) := result {
 	# set result
 	result := lib_common.generate_result(
 		lib_common.calculate_result(rule_evaluation),
-		{"filemode": ((user * 100) + (group * 10)) + other},
 		{"filemode": mode},
+		{"filemode": ((user * 100) + (group * 10)) + other},
 	)
 }
 

--- a/bundle/compliance/policy/kube_api/data_adapter.rego
+++ b/bundle/compliance/policy/kube_api/data_adapter.rego
@@ -1,0 +1,42 @@
+package compliance.policy.kube_api.data_adapter
+
+import future.keywords.in
+
+is_kube_api {
+	input.type == "k8s_object"
+}
+
+is_cluster_roles {
+	is_kube_api
+	input.resource.kind in {"Role", "ClusterRole"}
+}
+
+cluster_roles := roles {
+	is_cluster_roles
+	roles = input.resource
+}
+
+service_account := account {
+	input.resource.kind == "ServiceAccount"
+	account = input.resource
+}
+
+is_kube_node {
+	is_kube_api
+	input.resource.kind == "Node"
+}
+
+pod = p {
+	input.resource.kind == "Pod"
+	p := input.resource
+}
+
+is_service_account_or_pod = pod
+
+is_service_account_or_pod = service_account
+
+containers = c {
+	input.resource.kind == "Pod"
+	container_types := {"containers", "initContainers"}
+	c := pod.spec[container_types[t]]
+}

--- a/bundle/compliance/policy/kube_api/ensure_service_accounts.rego
+++ b/bundle/compliance/policy/kube_api/ensure_service_accounts.rego
@@ -1,0 +1,56 @@
+package compliance.policy.kube_api.ensure_service_accounts
+
+import data.compliance.lib.assert
+import data.compliance.lib.common as lib_common
+import data.compliance.policy.kube_api.data_adapter
+
+finding(rule_violation) := result {
+	data_adapter.is_kube_api
+	data_adapter.is_service_account_or_pod
+
+	rule_evaluation = assert.is_false(rule_violation)
+
+	# set result
+	result := lib_common.generate_result_without_expected(
+		lib_common.calculate_result(rule_evaluation),
+		{
+			"serviceAccounts": [pod.spec.serviceAccount | data_adapter.pods[pod]],
+			"serviceAccount": [service_account | data_adapter.service_accounts[service_account]],
+		},
+	)
+}
+
+default service_account_automount = false
+
+# Review pod and service account objects in the cluster and ensure that automountServiceAccountToken is
+# set to false
+service_account_automount {
+	pod := data_adapter.pod
+	pod.spec.automountServiceAccountToken == true
+}
+
+service_account_automount {
+	service_account := data_adapter.service_account
+	service_account.automountServiceAccountToken == true
+}
+
+default service_account_default = false
+
+# no roles or cluster roles bound to default service account apart from the defaults.
+service_account_default {
+	pod := data_adapter.pod
+	pod.spec.serviceAccount == "default"
+}
+
+# no roles or cluster roles bound to default service account apart from the defaults.
+service_account_default {
+	pod := data_adapter.pod
+	pod.spec.serviceAccountName == "default"
+}
+
+# ensure that the automountServiceAccountToken: false
+service_account_default {
+	service_account := data_adapter.service_account
+	service_account.metadata.name == "default"
+	service_account.automountServiceAccountToken == true
+}

--- a/bundle/compliance/policy/kube_api/minimize_added_capabilities.rego
+++ b/bundle/compliance/policy/kube_api/minimize_added_capabilities.rego
@@ -1,0 +1,21 @@
+package compliance.policy.kube_api.minimize_added_capabilities
+
+import data.compliance.lib.assert
+import data.compliance.lib.common as lib_common
+import data.compliance.policy.kube_api.data_adapter
+
+finding := result {
+	data_adapter.is_kube_api
+
+	allowedCapabilities := object.get(data_adapter.pod.spec, "allowedCapabilities", [])
+	rule_evaluation := assert.array_is_empty(allowedCapabilities)
+
+	# set result
+	result := lib_common.generate_result_without_expected(
+		lib_common.calculate_result(rule_evaluation),
+		{"filemode": json.filter(data_adapter.pod, [
+			"metadata/uid",
+			"spec/allowedCapabilities",
+		])},
+	)
+}

--- a/bundle/compliance/policy/kube_api/minimize_admission.rego
+++ b/bundle/compliance/policy/kube_api/minimize_admission.rego
@@ -1,0 +1,24 @@
+package compliance.policy.kube_api.minimize_admission
+
+import data.compliance.lib.common as lib_common
+import data.compliance.policy.kube_api.data_adapter
+
+finding(entity) = result {
+	data_adapter.is_kube_api
+
+	# set result
+	result := lib_common.generate_result_without_expected(
+		lib_common.calculate_result(rule_evaluation(entity)),
+		{
+			"uid": data_adapter.pod.metadata.uid,
+			"containers": {json.filter(c, ["name", concat("", ["securityContext/", entity])]) | c := data_adapter.containers[_]},
+		},
+	)
+}
+
+rule_evaluation(entity) = false {
+	container := data_adapter.containers[_]
+	lib_common.contains_key_with_value(container.securityContext, entity, true)
+} else = true {
+	true
+}

--- a/bundle/compliance/policy/kube_api/minimize_admission_root.rego
+++ b/bundle/compliance/policy/kube_api/minimize_admission_root.rego
@@ -1,0 +1,36 @@
+package compliance.policy.kube_api.minimize_admission_root
+
+import data.compliance.lib.common as lib_common
+import data.compliance.policy.kube_api.data_adapter
+
+default rule_evaluation = true
+
+# Verify that there is at least one PSP which returns MustRunAsNonRoot or MustRunAs with the range of UIDs not including 0.
+rule_evaluation = false {
+	not lib_common.contains_key_with_value(data_adapter.pod.spec.runAsUser, "rule", "MustRunAsNonRoot")
+	lib_common.contains_key_with_value(data_adapter.pod.spec.runAsUser, "rule", "MustRunAs")
+	range := data_adapter.pod.spec.runAsUser.ranges[_]
+	range.min <= 0
+}
+
+rule_evaluation = false {
+	container := data_adapter.containers[_]
+	lib_common.contains_key_with_value(container.securityContext, "runAsUser", 0)
+}
+
+finding = result {
+	data_adapter.is_kube_api
+
+	pod := json.filter(data_adapter.pod, [
+		"metadata/uid",
+		"spec/runAsUser",
+	])
+
+	containers := {"containers": json.filter(c, ["name", "securityContext/runAsUser"]) | c := data_adapter.containers[_]}
+
+	# set result
+	result := lib_common.generate_result_without_expected(
+		lib_common.calculate_result(rule_evaluation),
+		object.union(pod, containers),
+	)
+}

--- a/bundle/compliance/policy/kube_api/minimize_assigned_capabilities.rego
+++ b/bundle/compliance/policy/kube_api/minimize_assigned_capabilities.rego
@@ -1,0 +1,24 @@
+package compliance.policy.kube_api.minimize_assigned_capabilities
+
+import data.compliance.lib.assert
+import data.compliance.lib.common as lib_common
+import data.compliance.policy.kube_api.data_adapter
+
+default rule_evaluation = true
+
+rule_evaluation = false {
+	container := data_adapter.containers[_]
+	capabilities := object.get(container.securityContext, "capabilities", [])
+	not assert.array_is_empty(capabilities)
+}
+
+finding := result {
+	data_adapter.is_kube_api
+	data_adapter.containers
+
+	# set result
+	result := lib_common.generate_result_without_expected(
+		lib_common.calculate_result(rule_evaluation),
+		{"containers": {json.filter(c, ["name", "securityContext/capabilities"]) | c := data_adapter.containers[_]}},
+	)
+}

--- a/bundle/compliance/policy/kube_api/minimize_certain_capability.rego
+++ b/bundle/compliance/policy/kube_api/minimize_certain_capability.rego
@@ -1,0 +1,31 @@
+package compliance.policy.kube_api.minimize_certain_capability
+
+import data.compliance.lib.common as lib_common
+import data.compliance.policy.kube_api.data_adapter
+
+default rule_evaluation = false
+
+# Verify that there is at least one PSP which returns NET_RAW or ALL.
+rule_evaluation {
+	# Verify that there is at least one PSP which returns NET_RAW.
+	data_adapter.pod.spec.requiredDropCapabilities[_] == "NET_RAW"
+}
+
+# or 
+rule_evaluation {
+	# Verify that there is at least one PSP which returns ALL.
+	data_adapter.pod.spec.requiredDropCapabilities[_] == "ALL"
+}
+
+finding := result {
+	data_adapter.is_kube_api
+
+	# set result
+	result := lib_common.generate_result_without_expected(
+		lib_common.calculate_result(rule_evaluation),
+		json.filter(data_adapter.pod, [
+			"metadata/uid",
+			"spec/requiredDropCapabilities",
+		]),
+	)
+}

--- a/bundle/compliance/policy/kube_api/minimize_sharing.rego
+++ b/bundle/compliance/policy/kube_api/minimize_sharing.rego
@@ -1,0 +1,20 @@
+package compliance.policy.kube_api.minimize_sharing
+
+import data.compliance.lib.assert
+import data.compliance.lib.common as lib_common
+import data.compliance.policy.kube_api.data_adapter
+
+finding(entity) := result {
+	data_adapter.is_kube_api
+
+	rule_evaluation := assert.is_false(lib_common.contains_key_with_value(data_adapter.pod.spec, entity, true))
+
+	# set result
+	result := lib_common.generate_result_without_expected(
+		lib_common.calculate_result(rule_evaluation),
+		json.filter(data_adapter.pod, [
+			"metadata/uid",
+			concat("", ["spec/", entity]),
+		]),
+	)
+}

--- a/bundle/compliance/policy/kube_api/minimize_wildcard.rego
+++ b/bundle/compliance/policy/kube_api/minimize_wildcard.rego
@@ -1,0 +1,37 @@
+package compliance.policy.kube_api.minimize_wildcard
+
+import data.compliance.lib.assert
+import data.compliance.lib.common as lib_common
+import data.compliance.policy.kube_api.data_adapter
+import future.keywords.in
+
+default rule_violation = false
+
+rule_violation {
+	cluster_roles_rule := data_adapter.cluster_roles.rules[i]
+	is_using_wildcards(cluster_roles_rule)
+}
+
+finding = result {
+	data_adapter.is_cluster_roles
+
+	rule_evaluation := assert.is_false(rule_violation)
+
+	# set result
+	result := lib_common.generate_result_without_expected(
+		lib_common.calculate_result(rule_evaluation),
+		{"cluster_roles": data_adapter.cluster_roles},
+	)
+}
+
+is_using_wildcards(rule) {
+	"*" in rule.apiGroups # assert no wild-cards in api_group
+}
+
+is_using_wildcards(rule) {
+	"*" in rule.resources # assert no wild-cards in resources
+}
+
+is_using_wildcards(rule) {
+	"*" in rule.verbs # assert no wild-cards in verbs
+}


### PR DESCRIPTION
Refactoring rules that are associated with kube-api resource type to work with audit functions, while supporting backward compatibility