### PR TITLE
File permissions checks fix for exact permissions

### DIFF
--- a/bundle/compliance/cis_eks/rules/cis_3_1_1/rule.rego
+++ b/bundle/compliance/cis_eks/rules/cis_3_1_1/rule.rego
@@ -4,5 +4,5 @@ import data.compliance.policy.file.ensure_permissions as audit
 
 finding = result {
 	audit.filename_filter("kubeconfig")
-	result := audit.finding(6, 4, 4)
+	result := audit.finding(audit.file_permission_match(6, 4, 4))
 }

--- a/bundle/compliance/cis_eks/rules/cis_3_1_3/rule.rego
+++ b/bundle/compliance/cis_eks/rules/cis_3_1_3/rule.rego
@@ -4,5 +4,5 @@ import data.compliance.policy.file.ensure_permissions as audit
 
 finding = result {
 	audit.filename_filter("kubelet-config.json")
-	result := audit.finding(6, 4, 4)
+	result := audit.finding(audit.file_permission_match(6, 4, 4))
 }

--- a/bundle/compliance/cis_k8s/rules/cis_1_1_1/rule.rego
+++ b/bundle/compliance/cis_k8s/rules/cis_1_1_1/rule.rego
@@ -4,5 +4,5 @@ import data.compliance.policy.file.ensure_permissions as audit
 
 finding = result {
 	audit.filename_filter("kube-apiserver.yaml")
-	result := audit.finding(6, 4, 4)
+	result := audit.finding(audit.file_permission_match(6, 4, 4))
 }

--- a/bundle/compliance/cis_k8s/rules/cis_1_1_11/rule.rego
+++ b/bundle/compliance/cis_k8s/rules/cis_1_1_11/rule.rego
@@ -4,5 +4,5 @@ import data.compliance.policy.file.ensure_permissions as audit
 
 finding = result {
 	audit.path_filter("/var/lib/etcd/")
-	result := audit.finding(7, 0, 0)
+	result := audit.finding(audit.file_permission_match(7, 0, 0))
 }

--- a/bundle/compliance/cis_k8s/rules/cis_1_1_13/rule.rego
+++ b/bundle/compliance/cis_k8s/rules/cis_1_1_13/rule.rego
@@ -4,5 +4,5 @@ import data.compliance.policy.file.ensure_permissions as audit
 
 finding = result {
 	audit.filename_filter("admin.conf")
-	result := audit.finding(6, 0, 0)
+	result := audit.finding(audit.file_permission_match(6, 0, 0))
 }

--- a/bundle/compliance/cis_k8s/rules/cis_1_1_15/rule.rego
+++ b/bundle/compliance/cis_k8s/rules/cis_1_1_15/rule.rego
@@ -4,5 +4,5 @@ import data.compliance.policy.file.ensure_permissions as audit
 
 finding = result {
 	audit.filename_filter("scheduler.conf")
-	result := audit.finding(6, 4, 4)
+	result := audit.finding(audit.file_permission_match(6, 4, 4))
 }

--- a/bundle/compliance/cis_k8s/rules/cis_1_1_17/rule.rego
+++ b/bundle/compliance/cis_k8s/rules/cis_1_1_17/rule.rego
@@ -4,5 +4,5 @@ import data.compliance.policy.file.ensure_permissions as audit
 
 finding = result {
 	audit.filename_filter("controller-manager.conf")
-	result := audit.finding(6, 4, 4)
+	result := audit.finding(audit.file_permission_match(6, 4, 4))
 }

--- a/bundle/compliance/cis_k8s/rules/cis_1_1_20/rule.rego
+++ b/bundle/compliance/cis_k8s/rules/cis_1_1_20/rule.rego
@@ -5,5 +5,5 @@ import data.compliance.policy.file.ensure_permissions as audit
 finding = result {
 	audit.path_filter("/etc/kubernetes/pki")
 	audit.filename_suffix_filter(".crt")
-	result := audit.finding(6, 4, 4)
+	result := audit.finding(audit.file_permission_match(6, 4, 4))
 }

--- a/bundle/compliance/cis_k8s/rules/cis_1_1_21/rule.rego
+++ b/bundle/compliance/cis_k8s/rules/cis_1_1_21/rule.rego
@@ -5,5 +5,5 @@ import data.compliance.policy.file.ensure_permissions as audit
 finding = result {
 	audit.path_filter("/etc/kubernetes/pki")
 	audit.filename_suffix_filter(".key")
-	result := audit.finding(6, 4, 4)
+	result := audit.finding(audit.file_permission_match_exact(6, 0, 0))
 }

--- a/bundle/compliance/cis_k8s/rules/cis_1_1_3/rule.rego
+++ b/bundle/compliance/cis_k8s/rules/cis_1_1_3/rule.rego
@@ -4,5 +4,5 @@ import data.compliance.policy.file.ensure_permissions as audit
 
 finding = result {
 	audit.filename_filter("kube-controller-manager.yaml")
-	result := audit.finding(6, 4, 4)
+	result := audit.finding(audit.file_permission_match(6, 4, 4))
 }

--- a/bundle/compliance/cis_k8s/rules/cis_1_1_5/rule.rego
+++ b/bundle/compliance/cis_k8s/rules/cis_1_1_5/rule.rego
@@ -4,5 +4,5 @@ import data.compliance.policy.file.ensure_permissions as audit
 
 finding = result {
 	audit.filename_filter("kube-scheduler.yaml")
-	result := audit.finding(6, 4, 4)
+	result := audit.finding(audit.file_permission_match(6, 4, 4))
 }

--- a/bundle/compliance/cis_k8s/rules/cis_1_1_7/rule.rego
+++ b/bundle/compliance/cis_k8s/rules/cis_1_1_7/rule.rego
@@ -4,5 +4,5 @@ import data.compliance.policy.file.ensure_permissions as audit
 
 finding = result {
 	audit.filename_filter("etcd.yaml")
-	result := audit.finding(6, 4, 4)
+	result := audit.finding(audit.file_permission_match(6, 4, 4))
 }

--- a/bundle/compliance/cis_k8s/rules/cis_4_1_1/rule.rego
+++ b/bundle/compliance/cis_k8s/rules/cis_4_1_1/rule.rego
@@ -4,5 +4,5 @@ import data.compliance.policy.file.ensure_permissions as audit
 
 finding = result {
 	audit.filename_filter("10-kubeadm.conf")
-	result := audit.finding(6, 4, 4)
+	result := audit.finding(audit.file_permission_match(6, 4, 4))
 }

--- a/bundle/compliance/cis_k8s/rules/cis_4_1_5/rule.rego
+++ b/bundle/compliance/cis_k8s/rules/cis_4_1_5/rule.rego
@@ -4,5 +4,5 @@ import data.compliance.policy.file.ensure_permissions as audit
 
 finding = result {
 	audit.filename_filter("kubelet.conf")
-	result := audit.finding(6, 4, 4)
+	result := audit.finding(audit.file_permission_match(6, 4, 4))
 }

--- a/bundle/compliance/cis_k8s/rules/cis_4_1_9/rule.rego
+++ b/bundle/compliance/cis_k8s/rules/cis_4_1_9/rule.rego
@@ -4,5 +4,5 @@ import data.compliance.policy.file.ensure_permissions as audit
 
 finding = result {
 	audit.filename_filter("config.yaml")
-	result := audit.finding(6, 4, 4)
+	result := audit.finding(audit.file_permission_match(6, 4, 4))
 }

--- a/bundle/compliance/policy/file/common.rego
+++ b/bundle/compliance/policy/file/common.rego
@@ -18,6 +18,15 @@ file_permission_match(filemode, user, group, other) {
 	true
 }
 
+file_permission_match_exact(filemode, user, group, other) {
+	permissions = parse_permission(filemode)
+
+	# filemode format {user}{group}{other} e.g. 644
+	check_permissions_exact(permissions, [user, group, other])
+} else = false {
+	true
+}
+
 # in some os filemodes starts with 0 to indicate that the value is Octal (base 8)
 # remove prefix if needed, and return a list of file premission [user, group, other]
 parse_permission(filemode) = permissions {
@@ -33,6 +42,12 @@ parse_permission(filemode) = permissions {
 
 check_permissions(permissions, max_permissions) {
 	assert.all_true([r | r = bits.and(permissions[p], bits.negate(max_permissions[p])) == 0])
+} else = false {
+	true
+}
+
+check_permissions_exact(permissions, target_permissions) {
+	assert.all_true([r | r = permissions[p] == target_permissions[p]])
 } else = false {
 	true
 }

--- a/bundle/compliance/policy/file/common_test.rego
+++ b/bundle/compliance/policy/file/common_test.rego
@@ -34,6 +34,15 @@ test_file_ownership_match_user_gid_mismatch {
 	assert.is_false(file_ownership_match(user, group, requierd_user, requierd_group))
 }
 
+test_file_permission_match_exact {
+	users := [0, 1, 2, 3, 4, 5, 6, 7]
+	groups := [0, 1, 2, 3, 4, 5, 6, 7]
+	others := [0, 1, 2, 3, 4, 5, 6, 7]
+
+	results := {file_permission_match_exact(sprintf("%d%d%d", filemode), filemode[0], filemode[1], filemode[2]) | filemode := [users[u], groups[g], others[o]]}
+	assert.all_true(results)
+}
+
 test_file_permission_match {
 	users := [0, 1, 2, 3, 4, 5, 6, 7]
 	groups := [0, 1, 2, 3, 4, 5, 6, 7]

--- a/bundle/compliance/policy/file/ensure_permissions.rego
+++ b/bundle/compliance/policy/file/ensure_permissions.rego
@@ -4,15 +4,12 @@ import data.compliance.lib.common as lib_common
 import data.compliance.policy.file.common as file_common
 import data.compliance.policy.file.data_adapter
 
-finding(user, group, other) := result {
-	mode := data_adapter.filemode
-	rule_evaluation := file_common.file_permission_match(mode, user, group, other)
-
+finding(rule_evaluation) := result {
 	# set result
 	result := lib_common.generate_result(
-		lib_common.calculate_result(rule_evaluation),
-		{"filemode": mode},
-		{"filemode": ((user * 100) + (group * 10)) + other},
+		lib_common.calculate_result(rule_evaluation.evaluation),
+		{"filemode": rule_evaluation.mode},
+		{"filemode": ((rule_evaluation.user * 100) + (rule_evaluation.group * 10)) + rule_evaluation.other},
 	)
 }
 
@@ -21,3 +18,25 @@ path_filter(name) := file_common.file_in_path(name, data_adapter.file_path)
 filename_filter(name) := data_adapter.filename == name
 
 filename_suffix_filter(suffix) := endswith(data_adapter.filename, suffix)
+
+file_permission_match(user, group, other) := result {
+	mode := data_adapter.filemode
+	result := {
+		"evaluation": file_common.file_permission_match(mode, user, group, other),
+		"mode": mode,
+		"user": user,
+		"group": group,
+		"other": other,
+	}
+}
+
+file_permission_match_exact(user, group, other) := result {
+	mode := data_adapter.filemode
+	result := {
+		"evaluation": file_common.file_permission_match_exact(mode, user, group, other),
+		"mode": mode,
+		"user": user,
+		"group": group,
+		"other": other,
+	}
+}


### PR DESCRIPTION
We've had a problem when we wanted to verify exact permissions because we've always checked permissions that are equal or more restrictive.

Fixes:
- #132 