### PR TITLE
Improve process evaluation performance

### DIFF
--- a/bundle/compliance/cis_eks/data_adapter.rego
+++ b/bundle/compliance/cis_eks/data_adapter.rego
@@ -1,3 +1,5 @@
 package compliance.cis_eks.data_adapter
 
-process_args_seperator = " "
+import data.compliance.policy.process.data_adapter as process_data_adapter
+
+process_args := process_data_adapter.process_args(" ")

--- a/bundle/compliance/cis_eks/rules/cis_3_2_1/test.rego
+++ b/bundle/compliance/cis_eks/rules/cis_3_2_1/test.rego
@@ -4,31 +4,23 @@ import data.compliance.cis_eks.data_adapter
 import data.kubernetes_common.test_data
 import data.lib.test
 
-violations {
-	test.assert_fail(finding) with input as rule_input("")
-	test.assert_fail(finding) with input as rule_input("--anonymous-auth true")
-	test.assert_fail(finding) with input as rule_input_with_external("--anonymous-auth true", create_process_config(true))
-	test.assert_fail(finding) with input as rule_input_with_external("--anonymous-auth true", create_process_config(false))
-	test.assert_fail(finding) with input as rule_input_with_external("", create_process_config(true))
-}
-
-test_violations {
-	violations with data.benchmark_data_adapter as data_adapter
-}
-
-passes {
-	test.assert_pass(finding) with input as rule_input("--anonymous-auth false")
-	test.assert_pass(finding) with input as rule_input_with_external("--anonymous-auth false", create_process_config(true))
-	test.assert_pass(finding) with input as rule_input_with_external("--anonymous-auth false", create_process_config(false))
-	test.assert_pass(finding) with input as rule_input_with_external("", create_process_config(false))
+test_violation {
+	eval_fail with input as rule_input("")
+	eval_fail with input as rule_input("--anonymous-auth true")
+	eval_fail with input as rule_input_with_external("--anonymous-auth true", create_process_config(true))
+	eval_fail with input as rule_input_with_external("--anonymous-auth true", create_process_config(false))
+	eval_fail with input as rule_input_with_external("", create_process_config(true))
 }
 
 test_pass {
-	passes with data.benchmark_data_adapter as data_adapter
+	eval_pass with input as rule_input("--anonymous-auth false")
+	eval_pass with input as rule_input_with_external("--anonymous-auth false", create_process_config(true))
+	eval_pass with input as rule_input_with_external("--anonymous-auth false", create_process_config(false))
+	eval_pass with input as rule_input_with_external("", create_process_config(false))
 }
 
 test_not_evaluated {
-	not finding with input as test_data.process_input("some_process", []) with data.benchmark_data_adapter as data_adapter
+	not_eval with input as test_data.process_input("some_process", [])
 }
 
 rule_input(argument) = test_data.process_input_with_external_data("kubelet", [argument], {})
@@ -43,3 +35,15 @@ create_process_config(anonymous_enabled) = {"config": {"authentication": {
 		"enabled": true,
 	},
 }}}
+
+eval_fail {
+	test.assert_fail(finding) with data.benchmark_data_adapter as data_adapter
+}
+
+eval_pass {
+	test.assert_pass(finding) with data.benchmark_data_adapter as data_adapter
+}
+
+not_eval {
+	not finding with data.benchmark_data_adapter as data_adapter
+}

--- a/bundle/compliance/cis_eks/rules/cis_3_2_10/test.rego
+++ b/bundle/compliance/cis_eks/rules/cis_3_2_10/test.rego
@@ -4,30 +4,22 @@ import data.compliance.cis_eks.data_adapter
 import data.kubernetes_common.test_data
 import data.lib.test
 
-violations {
-	test.assert_fail(finding) with input as rule_input("--rotate-certificates false")
-	test.assert_fail(finding) with input as rule_input_with_external("", create_process_config(false))
-	test.assert_fail(finding) with input as rule_input_with_external("--rotate-certificates false", create_process_config(true))
-}
-
-test_violations {
-	violations with data.benchmark_data_adapter as data_adapter
-}
-
-passes {
-	test.assert_pass(finding) with input as rule_input("")
-	test.assert_pass(finding) with input as rule_input("--rotate-certificates true")
-	test.assert_pass(finding) with input as rule_input_with_external("--rotate-certificates true", create_process_config(false))
-	test.assert_pass(finding) with input as rule_input_with_external("--rotate-certificates true", create_process_config(true))
-	test.assert_pass(finding) with input as rule_input_with_external("", create_process_config(true))
+test_violation {
+	eval_fail with input as rule_input("--rotate-certificates false")
+	eval_fail with input as rule_input_with_external("", create_process_config(false))
+	eval_fail with input as rule_input_with_external("--rotate-certificates false", create_process_config(true))
 }
 
 test_pass {
-	passes with data.benchmark_data_adapter as data_adapter
+	eval_pass with input as rule_input("")
+	eval_pass with input as rule_input("--rotate-certificates true")
+	eval_pass with input as rule_input_with_external("--rotate-certificates true", create_process_config(false))
+	eval_pass with input as rule_input_with_external("--rotate-certificates true", create_process_config(true))
+	eval_pass with input as rule_input_with_external("", create_process_config(true))
 }
 
 test_not_evaluated {
-	not finding with input as test_data.process_input("some_process", []) with data.benchmark_data_adapter as data_adapter
+	not_eval with input as test_data.process_input("some_process", [])
 }
 
 rule_input(argument) = test_data.process_input("kubelet", [argument])
@@ -35,3 +27,15 @@ rule_input(argument) = test_data.process_input("kubelet", [argument])
 rule_input_with_external(argument, external_data) = test_data.process_input_with_external_data("kubelet", [argument], external_data)
 
 create_process_config(rotateCertificates) = {"config": {"rotateCertificates": rotateCertificates}}
+
+eval_fail {
+	test.assert_fail(finding) with data.benchmark_data_adapter as data_adapter
+}
+
+eval_pass {
+	test.assert_pass(finding) with data.benchmark_data_adapter as data_adapter
+}
+
+not_eval {
+	not finding with data.benchmark_data_adapter as data_adapter
+}

--- a/bundle/compliance/cis_eks/rules/cis_3_2_11/test.rego
+++ b/bundle/compliance/cis_eks/rules/cis_3_2_11/test.rego
@@ -4,37 +4,29 @@ import data.compliance.cis_eks.data_adapter
 import data.kubernetes_common.test_data
 import data.lib.test
 
-violations {
-	test.assert_fail(finding) with input as rule_input("")
-	test.assert_fail(finding) with input as rule_input("--feature-gates RotateKubeletServerCertificate=false")
-	test.assert_fail(finding) with input as rule_input_with_external("", create_process_config(false, false))
-	test.assert_fail(finding) with input as rule_input_with_external("--feature-gates RotateKubeletServerCertificate false", create_process_config(false, false))
-	test.assert_fail(finding) with input as rule_input_with_external("--feature-gates RotateKubeletServerCertificate false", create_process_config(true, false))
-	test.assert_fail(finding) with input as rule_input_with_external("--feature-gates RotateKubeletServerCertificate false", create_process_config(true, false))
-}
-
-test_violations {
-	violations with data.benchmark_data_adapter as data_adapter
-}
-
-passes {
-	test.assert_pass(finding) with input as rule_input("--feature-gates RotateKubeletServerCertificate=true")
-	test.assert_pass(finding) with input as rule_input("--rotate-server-certificates true")
-	test.assert_pass(finding) with input as rule_input_with_external("--feature-gates=RotateKubeletServerCertificate=true", create_process_config(true, false))
-	test.assert_pass(finding) with input as rule_input_with_external("--feature-gates RotateKubeletServerCertificate=true", create_process_config(false, false))
-	test.assert_pass(finding) with input as rule_input_with_external("--feature-gates RotateKubeletServerCertificate=true", create_process_config(false, true))
-	test.assert_pass(finding) with input as rule_input_with_external("--feature-gates Rotate=true", create_process_config(true, false))
-	test.assert_pass(finding) with input as rule_input_with_external("", create_process_config(true, false))
-	test.assert_pass(finding) with input as rule_input_with_external("", create_process_config(false, true))
-	test.assert_pass(finding) with input as rule_input_with_external("", create_process_config(true, true))
+test_violation {
+	eval_fail with input as rule_input("")
+	eval_fail with input as rule_input("--feature-gates RotateKubeletServerCertificate=false")
+	eval_fail with input as rule_input_with_external("", create_process_config(false, false))
+	eval_fail with input as rule_input_with_external("--feature-gates RotateKubeletServerCertificate false", create_process_config(false, false))
+	eval_fail with input as rule_input_with_external("--feature-gates RotateKubeletServerCertificate false", create_process_config(true, false))
+	eval_fail with input as rule_input_with_external("--feature-gates RotateKubeletServerCertificate false", create_process_config(true, false))
 }
 
 test_pass {
-	passes with data.benchmark_data_adapter as data_adapter
+	eval_pass with input as rule_input("--feature-gates RotateKubeletServerCertificate=true")
+	eval_pass with input as rule_input("--rotate-server-certificates true")
+	eval_pass with input as rule_input_with_external("--feature-gates=RotateKubeletServerCertificate=true", create_process_config(true, false))
+	eval_pass with input as rule_input_with_external("--feature-gates RotateKubeletServerCertificate=true", create_process_config(false, false))
+	eval_pass with input as rule_input_with_external("--feature-gates RotateKubeletServerCertificate=true", create_process_config(false, true))
+	eval_pass with input as rule_input_with_external("--feature-gates Rotate=true", create_process_config(true, false))
+	eval_pass with input as rule_input_with_external("", create_process_config(true, false))
+	eval_pass with input as rule_input_with_external("", create_process_config(false, true))
+	eval_pass with input as rule_input_with_external("", create_process_config(true, true))
 }
 
 test_not_evaluated {
-	not finding with input as test_data.process_input("some_process", []) with data.benchmark_data_adapter as data_adapter
+	not_eval with input as test_data.process_input("some_process", [])
 }
 
 rule_input(argument) = test_data.process_input("kubelet", [argument])
@@ -42,3 +34,15 @@ rule_input(argument) = test_data.process_input("kubelet", [argument])
 rule_input_with_external(argument, external_data) = test_data.process_input_with_external_data("kubelet", [argument], external_data)
 
 create_process_config(rotateCertificates, serverTLSBootstrap) = {"config": {"serverTLSBootstrap": serverTLSBootstrap, "featureGates": {"RotateKubeletServerCertificate": rotateCertificates}}}
+
+eval_fail {
+	test.assert_fail(finding) with data.benchmark_data_adapter as data_adapter
+}
+
+eval_pass {
+	test.assert_pass(finding) with data.benchmark_data_adapter as data_adapter
+}
+
+not_eval {
+	not finding with data.benchmark_data_adapter as data_adapter
+}

--- a/bundle/compliance/cis_eks/rules/cis_3_2_2/test.rego
+++ b/bundle/compliance/cis_eks/rules/cis_3_2_2/test.rego
@@ -4,29 +4,21 @@ import data.compliance.cis_eks.data_adapter
 import data.kubernetes_common.test_data
 import data.lib.test
 
-violations {
-	test.assert_fail(finding) with input as rule_input("")
-	test.assert_fail(finding) with input as rule_input("--authorization-mode AlwaysAllow")
-	test.assert_fail(finding) with input as rule_input_with_external("--authorization-mode AlwaysAllow", create_process_config("AlwaysAllow"))
-	test.assert_fail(finding) with input as rule_input_with_external("", create_process_config("AlwaysAllow"))
-}
-
-test_violations {
-	violations with data.benchmark_data_adapter as data_adapter
-}
-
-passes {
-	test.assert_pass(finding) with input as rule_input("--authorization-mode Webhook")
-	test.assert_pass(finding) with input as rule_input_with_external("--authorization-mode Webhook", create_process_config("AlwaysAllow"))
-	test.assert_pass(finding) with input as rule_input_with_external("", create_process_config("Webhook"))
+test_violation {
+	eval_fail with input as rule_input("")
+	eval_fail with input as rule_input("--authorization-mode AlwaysAllow")
+	eval_fail with input as rule_input_with_external("--authorization-mode AlwaysAllow", create_process_config("AlwaysAllow"))
+	eval_fail with input as rule_input_with_external("", create_process_config("AlwaysAllow"))
 }
 
 test_pass {
-	passes with data.benchmark_data_adapter as data_adapter
+	eval_pass with input as rule_input("--authorization-mode Webhook")
+	eval_pass with input as rule_input_with_external("--authorization-mode Webhook", create_process_config("AlwaysAllow"))
+	eval_pass with input as rule_input_with_external("", create_process_config("Webhook"))
 }
 
 test_not_evaluated {
-	not finding with input as test_data.process_input("some_process", []) with data.benchmark_data_adapter as data_adapter
+	not_eval with input as test_data.process_input("some_process", [])
 }
 
 rule_input(argument) = test_data.process_input("kubelet", [argument])
@@ -40,3 +32,15 @@ create_process_config(authz_mode) = {"config": {"authorization": {
 		"cacheUnauthorizedTTL": "0s",
 	},
 }}}
+
+eval_fail {
+	test.assert_fail(finding) with data.benchmark_data_adapter as data_adapter
+}
+
+eval_pass {
+	test.assert_pass(finding) with data.benchmark_data_adapter as data_adapter
+}
+
+not_eval {
+	not finding with data.benchmark_data_adapter as data_adapter
+}

--- a/bundle/compliance/cis_eks/rules/cis_3_2_3/test.rego
+++ b/bundle/compliance/cis_eks/rules/cis_3_2_3/test.rego
@@ -4,26 +4,18 @@ import data.compliance.cis_eks.data_adapter
 import data.kubernetes_common.test_data
 import data.lib.test
 
-violations {
-	test.assert_fail(finding) with input as rule_input("")
-}
-
 test_violation {
-	violations with data.benchmark_data_adapter as data_adapter
-}
-
-passes {
-	test.assert_pass(finding) with input as rule_input("--client-ca-file <path/to/client-ca-file>")
-	test.assert_pass(finding) with input as rule_input_with_external("--client-ca-file <path/to/client-ca-file>", create_process_config("<path/to/client-ca-file>"))
-	test.assert_pass(finding) with input as rule_input_with_external("", create_process_config("<path/to/client-ca-file>"))
+	eval_fail with input as rule_input("")
 }
 
 test_pass {
-	passes with data.benchmark_data_adapter as data_adapter
+	eval_pass with input as rule_input("--client-ca-file <path/to/client-ca-file>")
+	eval_pass with input as rule_input_with_external("--client-ca-file <path/to/client-ca-file>", create_process_config("<path/to/client-ca-file>"))
+	eval_pass with input as rule_input_with_external("", create_process_config("<path/to/client-ca-file>"))
 }
 
 test_not_evaluated {
-	not finding with input as test_data.process_input("some_process", []) with data.benchmark_data_adapter as data_adapter
+	not_eval with input as test_data.process_input("some_process", [])
 }
 
 rule_input(argument) = test_data.process_input("kubelet", [argument])
@@ -38,3 +30,15 @@ create_process_config(client_CA_path) = {"config": {"authentication": {
 		"enabled": true,
 	},
 }}}
+
+eval_fail {
+	test.assert_fail(finding) with data.benchmark_data_adapter as data_adapter
+}
+
+eval_pass {
+	test.assert_pass(finding) with data.benchmark_data_adapter as data_adapter
+}
+
+not_eval {
+	not finding with data.benchmark_data_adapter as data_adapter
+}

--- a/bundle/compliance/cis_eks/rules/cis_3_2_4/test.rego
+++ b/bundle/compliance/cis_eks/rules/cis_3_2_4/test.rego
@@ -4,30 +4,22 @@ import data.compliance.cis_eks.data_adapter
 import data.kubernetes_common.test_data
 import data.lib.test
 
-violations {
-	test.assert_fail(finding) with input as rule_input("")
-	test.assert_fail(finding) with input as rule_input("--read-only-port 10")
-	test.assert_fail(finding) with input as rule_input_with_external("--read-only-port 10", create_process_config(0))
-	test.assert_fail(finding) with input as rule_input_with_external("", create_process_config(10))
-}
-
 test_violation {
-	violations with data.benchmark_data_adapter as data_adapter
-}
-
-passes {
-	test.assert_pass(finding) with input as rule_input("--read-only-port 0")
-	test.assert_pass(finding) with input as rule_input_with_external("--read-only-port 0", create_process_config(10))
-	test.assert_pass(finding) with input as rule_input_with_external("--read-only-port 0", create_process_config(0))
-	test.assert_pass(finding) with input as rule_input_with_external("", create_process_config(0))
+	eval_fail with input as rule_input("")
+	eval_fail with input as rule_input("--read-only-port 10")
+	eval_fail with input as rule_input_with_external("--read-only-port 10", create_process_config(0))
+	eval_fail with input as rule_input_with_external("", create_process_config(10))
 }
 
 test_pass {
-	passes with data.benchmark_data_adapter as data_adapter
+	eval_pass with input as rule_input("--read-only-port 0")
+	eval_pass with input as rule_input_with_external("--read-only-port 0", create_process_config(10))
+	eval_pass with input as rule_input_with_external("--read-only-port 0", create_process_config(0))
+	eval_pass with input as rule_input_with_external("", create_process_config(0))
 }
 
 test_not_evaluated {
-	not finding with input as test_data.process_input("some_process", []) with data.benchmark_data_adapter as data_adapter
+	not_eval with input as test_data.process_input("some_process", [])
 }
 
 rule_input(argument) = test_data.process_input_with_external_data("kubelet", [argument], {})
@@ -35,3 +27,15 @@ rule_input(argument) = test_data.process_input_with_external_data("kubelet", [ar
 rule_input_with_external(argument, external_data) = test_data.process_input_with_external_data("kubelet", [argument], external_data)
 
 create_process_config(port) = {"config": {"readOnlyPort": port}}
+
+eval_fail {
+	test.assert_fail(finding) with data.benchmark_data_adapter as data_adapter
+}
+
+eval_pass {
+	test.assert_pass(finding) with data.benchmark_data_adapter as data_adapter
+}
+
+not_eval {
+	not finding with data.benchmark_data_adapter as data_adapter
+}

--- a/bundle/compliance/cis_eks/rules/cis_3_2_5/test.rego
+++ b/bundle/compliance/cis_eks/rules/cis_3_2_5/test.rego
@@ -4,31 +4,23 @@ import data.compliance.cis_eks.data_adapter
 import data.kubernetes_common.test_data
 import data.lib.test
 
-violations {
-	test.assert_fail(finding) with input as rule_input("--streaming-connection-idle-timeout 0")
-	test.assert_fail(finding) with input as rule_input_with_external("--streaming-connection-idle-timeout 0", create_process_config(0))
-	test.assert_fail(finding) with input as rule_input_with_external("--streaming-connection-idle-timeout 0", create_process_config(10))
-	test.assert_fail(finding) with input as rule_input_with_external("", create_process_config(0))
-}
-
 test_violation {
-	violations with data.benchmark_data_adapter as data_adapter
-}
-
-passes {
-	test.assert_pass(finding) with input as rule_input("")
-	test.assert_pass(finding) with input as rule_input("--streaming-connection-idle-timeout 10")
-	test.assert_pass(finding) with input as rule_input_with_external("--streaming-connection-idle-timeout 10", create_process_config(0))
-	test.assert_pass(finding) with input as rule_input_with_external("--streaming-connection-idle-timeout 10", create_process_config(10))
-	test.assert_pass(finding) with input as rule_input_with_external("", create_process_config(10))
+	eval_fail with input as rule_input("--streaming-connection-idle-timeout 0")
+	eval_fail with input as rule_input_with_external("--streaming-connection-idle-timeout 0", create_process_config(0))
+	eval_fail with input as rule_input_with_external("--streaming-connection-idle-timeout 0", create_process_config(10))
+	eval_fail with input as rule_input_with_external("", create_process_config(0))
 }
 
 test_pass {
-	passes with data.benchmark_data_adapter as data_adapter
+	eval_pass with input as rule_input("")
+	eval_pass with input as rule_input("--streaming-connection-idle-timeout 10")
+	eval_pass with input as rule_input_with_external("--streaming-connection-idle-timeout 10", create_process_config(0))
+	eval_pass with input as rule_input_with_external("--streaming-connection-idle-timeout 10", create_process_config(10))
+	eval_pass with input as rule_input_with_external("", create_process_config(10))
 }
 
 test_not_evaluated {
-	not finding with input as test_data.process_input("some_process", []) with data.benchmark_data_adapter as data_adapter
+	not_eval with input as test_data.process_input("some_process", [])
 }
 
 rule_input(argument) = test_data.process_input_with_external_data("kubelet", [argument], {})
@@ -36,3 +28,15 @@ rule_input(argument) = test_data.process_input_with_external_data("kubelet", [ar
 rule_input_with_external(argument, external_data) = test_data.process_input_with_external_data("kubelet", [argument], external_data)
 
 create_process_config(connection_timeout) = {"config": {"streamingConnectionIdleTimeout": connection_timeout}}
+
+eval_fail {
+	test.assert_fail(finding) with data.benchmark_data_adapter as data_adapter
+}
+
+eval_pass {
+	test.assert_pass(finding) with data.benchmark_data_adapter as data_adapter
+}
+
+not_eval {
+	not finding with data.benchmark_data_adapter as data_adapter
+}

--- a/bundle/compliance/cis_eks/rules/cis_3_2_6/test.rego
+++ b/bundle/compliance/cis_eks/rules/cis_3_2_6/test.rego
@@ -4,29 +4,21 @@ import data.compliance.cis_eks.data_adapter
 import data.kubernetes_common.test_data
 import data.lib.test
 
-violations {
-	test.assert_fail(finding) with input as rule_input("")
-	test.assert_fail(finding) with input as rule_input("--protect-kernel-defaults false")
-	test.assert_fail(finding) with input as rule_input_with_external("--protect-kernel-defaults false", create_process_config(true))
-}
-
 test_violation {
-	violations with data.benchmark_data_adapter as data_adapter
-}
-
-passes {
-	test.assert_pass(finding) with input as rule_input("--protect-kernel-defaults true")
-	test.assert_pass(finding) with input as rule_input_with_external("--protect-kernel-defaults true", create_process_config(false))
-	test.assert_pass(finding) with input as rule_input_with_external("--protect-kernel-defaults true", create_process_config(false))
-	test.assert_pass(finding) with input as rule_input_with_external("", create_process_config(true))
+	eval_fail with input as rule_input("")
+	eval_fail with input as rule_input("--protect-kernel-defaults false")
+	eval_fail with input as rule_input_with_external("--protect-kernel-defaults false", create_process_config(true))
 }
 
 test_pass {
-	passes with data.benchmark_data_adapter as data_adapter
+	eval_pass with input as rule_input("--protect-kernel-defaults true")
+	eval_pass with input as rule_input_with_external("--protect-kernel-defaults true", create_process_config(false))
+	eval_pass with input as rule_input_with_external("--protect-kernel-defaults true", create_process_config(false))
+	eval_pass with input as rule_input_with_external("", create_process_config(true))
 }
 
 test_not_evaluated {
-	not finding with input as test_data.process_input("some_process", []) with data.benchmark_data_adapter as data_adapter
+	not_eval with input as test_data.process_input("some_process", [])
 }
 
 rule_input(argument) = test_data.process_input("kubelet", [argument])
@@ -34,3 +26,15 @@ rule_input(argument) = test_data.process_input("kubelet", [argument])
 rule_input_with_external(argument, external_data) = test_data.process_input_with_external_data("kubelet", [argument], external_data)
 
 create_process_config(kernel_protection_enabled) = {"config": {"protectKernelDefaults": kernel_protection_enabled}}
+
+eval_fail {
+	test.assert_fail(finding) with data.benchmark_data_adapter as data_adapter
+}
+
+eval_pass {
+	test.assert_pass(finding) with data.benchmark_data_adapter as data_adapter
+}
+
+not_eval {
+	not finding with data.benchmark_data_adapter as data_adapter
+}

--- a/bundle/compliance/cis_eks/rules/cis_3_2_7/test.rego
+++ b/bundle/compliance/cis_eks/rules/cis_3_2_7/test.rego
@@ -4,30 +4,22 @@ import data.compliance.cis_eks.data_adapter
 import data.kubernetes_common.test_data
 import data.lib.test
 
-violations {
-	test.assert_fail(finding) with input as rule_input("--make-iptables-util-chains false")
-	test.assert_fail(finding) with input as rule_input_with_external("", create_process_config(false))
-	test.assert_fail(finding) with input as rule_input_with_external("--make-iptables-util-chains false", create_process_config(true))
-}
-
 test_violation {
-	violations with data.benchmark_data_adapter as data_adapter
-}
-
-passes {
-	test.assert_pass(finding) with input as rule_input("")
-	test.assert_pass(finding) with input as rule_input("--make-iptables-util-chains true")
-	test.assert_pass(finding) with input as rule_input_with_external("--make-iptables-util-chains true", create_process_config(false))
-	test.assert_pass(finding) with input as rule_input_with_external("--make-iptables-util-chains true", create_process_config(true))
-	test.assert_pass(finding) with input as rule_input_with_external("", create_process_config(true))
+	eval_fail with input as rule_input("--make-iptables-util-chains false")
+	eval_fail with input as rule_input_with_external("", create_process_config(false))
+	eval_fail with input as rule_input_with_external("--make-iptables-util-chains false", create_process_config(true))
 }
 
 test_pass {
-	passes with data.benchmark_data_adapter as data_adapter
+	eval_pass with input as rule_input("")
+	eval_pass with input as rule_input("--make-iptables-util-chains true")
+	eval_pass with input as rule_input_with_external("--make-iptables-util-chains true", create_process_config(false))
+	eval_pass with input as rule_input_with_external("--make-iptables-util-chains true", create_process_config(true))
+	eval_pass with input as rule_input_with_external("", create_process_config(true))
 }
 
 test_not_evaluated {
-	not finding with input as test_data.process_input("some_process", []) with data.benchmark_data_adapter as data_adapter
+	not_eval with input as test_data.process_input("some_process", [])
 }
 
 rule_input(argument) = test_data.process_input("kubelet", [argument])
@@ -35,3 +27,15 @@ rule_input(argument) = test_data.process_input("kubelet", [argument])
 rule_input_with_external(argument, external_data) = test_data.process_input_with_external_data("kubelet", [argument], external_data)
 
 create_process_config(makeIPTablesUtilChains) = {"config": {"makeIPTablesUtilChains": makeIPTablesUtilChains}}
+
+eval_fail {
+	test.assert_fail(finding) with data.benchmark_data_adapter as data_adapter
+}
+
+eval_pass {
+	test.assert_pass(finding) with data.benchmark_data_adapter as data_adapter
+}
+
+not_eval {
+	not finding with data.benchmark_data_adapter as data_adapter
+}

--- a/bundle/compliance/cis_eks/rules/cis_3_2_8/test.rego
+++ b/bundle/compliance/cis_eks/rules/cis_3_2_8/test.rego
@@ -4,27 +4,31 @@ import data.compliance.cis_eks.data_adapter
 import data.kubernetes_common.test_data
 import data.lib.test
 
-violations {
-	test.assert_fail(finding) with input as rule_input("--hostname-override overide")
-}
-
 test_violation {
-	violations with data.benchmark_data_adapter as data_adapter
-}
-
-passes {
-	test.assert_pass(finding) with input as rule_input("--some-key value")
-	test.assert_pass(finding) with input as rule_input("")
+	eval_fail with input as rule_input("--hostname-override overide")
 }
 
 test_pass {
-	passes with data.benchmark_data_adapter as data_adapter
+	eval_pass with input as rule_input("--some-key value")
+	eval_pass with input as rule_input("")
 }
 
 test_not_evaluated {
-	not finding with input as test_data.process_input("some_process", []) with data.benchmark_data_adapter as data_adapter
+	not_eval with input as test_data.process_input("some_process", [])
 }
 
 rule_input(argument) = test_data.process_input_with_external_data("kubelet", [argument], {})
 
 rule_input_with_external(argument, external_data) = test_data.process_input_with_external_data("kubelet", [argument], external_data)
+
+eval_fail {
+	test.assert_fail(finding) with data.benchmark_data_adapter as data_adapter
+}
+
+eval_pass {
+	test.assert_pass(finding) with data.benchmark_data_adapter as data_adapter
+}
+
+not_eval {
+	not finding with data.benchmark_data_adapter as data_adapter
+}

--- a/bundle/compliance/cis_eks/rules/cis_3_2_9/test.rego
+++ b/bundle/compliance/cis_eks/rules/cis_3_2_9/test.rego
@@ -4,31 +4,23 @@ import data.compliance.cis_eks.data_adapter
 import data.kubernetes_common.test_data
 import data.lib.test
 
-violations {
-	test.assert_fail(finding) with input as rule_input("--event-qps 10")
-	test.assert_fail(finding) with input as rule_input_with_external("--event-qps 10", create_process_config(0))
-	test.assert_fail(finding) with input as rule_input_with_external("--event-qps 10", create_process_config(10))
-	test.assert_fail(finding) with input as rule_input_with_external("", create_process_config(10))
-	test.assert_fail(finding) with input as rule_input("")
-}
-
 test_violation {
-	violations with data.benchmark_data_adapter as data_adapter
-}
-
-passes {
-	test.assert_pass(finding) with input as rule_input("--event-qps 0")
-	test.assert_pass(finding) with input as rule_input_with_external("--event-qps 0", create_process_config(0))
-	test.assert_pass(finding) with input as rule_input_with_external("--event-qps 0", create_process_config(10))
-	test.assert_pass(finding) with input as rule_input_with_external("", create_process_config(0))
+	eval_fail with input as rule_input("--event-qps 10")
+	eval_fail with input as rule_input_with_external("--event-qps 10", create_process_config(0))
+	eval_fail with input as rule_input_with_external("--event-qps 10", create_process_config(10))
+	eval_fail with input as rule_input_with_external("", create_process_config(10))
+	eval_fail with input as rule_input("")
 }
 
 test_pass {
-	passes with data.benchmark_data_adapter as data_adapter
+	eval_pass with input as rule_input("--event-qps 0")
+	eval_pass with input as rule_input_with_external("--event-qps 0", create_process_config(0))
+	eval_pass with input as rule_input_with_external("--event-qps 0", create_process_config(10))
+	eval_pass with input as rule_input_with_external("", create_process_config(0))
 }
 
 test_not_evaluated {
-	not finding with input as test_data.process_input("some_process", []) with data.benchmark_data_adapter as data_adapter
+	not_eval with input as test_data.process_input("some_process", [])
 }
 
 rule_input(argument) = test_data.process_input_with_external_data("kubelet", [argument], {})
@@ -36,3 +28,15 @@ rule_input(argument) = test_data.process_input_with_external_data("kubelet", [ar
 rule_input_with_external(argument, external_data) = test_data.process_input_with_external_data("kubelet", [argument], external_data)
 
 create_process_config(eventRecordQPS) = {"config": {"eventRecordQPS": eventRecordQPS}}
+
+eval_fail {
+	test.assert_fail(finding) with data.benchmark_data_adapter as data_adapter
+}
+
+eval_pass {
+	test.assert_pass(finding) with data.benchmark_data_adapter as data_adapter
+}
+
+not_eval {
+	not finding with data.benchmark_data_adapter as data_adapter
+}

--- a/bundle/compliance/cis_k8s/data_adapter.rego
+++ b/bundle/compliance/cis_k8s/data_adapter.rego
@@ -1,3 +1,5 @@
 package compliance.cis_k8s.data_adapter
 
-process_args_seperator = "="
+import data.compliance.policy.process.data_adapter as process_data_adapter
+
+process_args := process_data_adapter.process_args("=")

--- a/bundle/compliance/cis_k8s/rules/cis_1_2_10/test.rego
+++ b/bundle/compliance/cis_k8s/rules/cis_1_2_10/test.rego
@@ -4,27 +4,31 @@ import data.compliance.cis_k8s.data_adapter
 import data.kubernetes_common.test_data
 import data.lib.test
 
-violations {
-	test.assert_fail(finding) with input as rule_input("")
-	test.assert_fail(finding) with input as rule_input("--enable-admission-plugins=AlwaysDeny")
-	test.assert_fail(finding) with input as rule_input("--enable-admission-plugins=NamespaceLifecycle,AlwaysDeny")
-}
-
 test_violation {
-	violations with data.benchmark_data_adapter as data_adapter
-}
-
-passes {
-	test.assert_pass(finding) with input as rule_input("--enable-admission-plugins=EventRateLimit")
-	test.assert_pass(finding) with input as rule_input("--enable-admission-plugins=NamespaceLifecycle,EventRateLimit,NodeRestriction,AlwaysPullImages")
+	eval_fail with input as rule_input("")
+	eval_fail with input as rule_input("--enable-admission-plugins=AlwaysDeny")
+	eval_fail with input as rule_input("--enable-admission-plugins=NamespaceLifecycle,AlwaysDeny")
 }
 
 test_pass {
-	passes with data.benchmark_data_adapter as data_adapter
+	eval_pass with input as rule_input("--enable-admission-plugins=EventRateLimit")
+	eval_pass with input as rule_input("--enable-admission-plugins=NamespaceLifecycle,EventRateLimit,NodeRestriction,AlwaysPullImages")
 }
 
 test_not_evaluated {
-	not finding with input as test_data.process_input("some_process", []) with data.benchmark_data_adapter as data_adapter
+	not_eval with input as test_data.process_input("some_process", [])
 }
 
 rule_input(argument) = test_data.process_input("kube-apiserver", [argument])
+
+eval_fail {
+	test.assert_fail(finding) with data.benchmark_data_adapter as data_adapter
+}
+
+eval_pass {
+	test.assert_pass(finding) with data.benchmark_data_adapter as data_adapter
+}
+
+not_eval {
+	not finding with data.benchmark_data_adapter as data_adapter
+}

--- a/bundle/compliance/cis_k8s/rules/cis_1_2_11/test.rego
+++ b/bundle/compliance/cis_k8s/rules/cis_1_2_11/test.rego
@@ -4,26 +4,30 @@ import data.compliance.cis_k8s.data_adapter
 import data.kubernetes_common.test_data
 import data.lib.test
 
-violations {
-	test.assert_fail(finding) with input as rule_input("--enable-admission-plugins=AlwaysAdmit")
-	test.assert_fail(finding) with input as rule_input("--enable-admission-plugins=PodNodeSelector,AlwaysAdmit")
-}
-
 test_violation {
-	violations with data.benchmark_data_adapter as data_adapter
-}
-
-passes {
-	test.assert_pass(finding) with input as rule_input("--enable-admission-plugins=RBAC")
-	test.assert_pass(finding) with input as rule_input("")
+	eval_fail with input as rule_input("--enable-admission-plugins=AlwaysAdmit")
+	eval_fail with input as rule_input("--enable-admission-plugins=PodNodeSelector,AlwaysAdmit")
 }
 
 test_pass {
-	passes with data.benchmark_data_adapter as data_adapter
+	eval_pass with input as rule_input("--enable-admission-plugins=RBAC")
+	eval_pass with input as rule_input("")
 }
 
 test_not_evaluated {
-	not finding with input as test_data.process_input("some_process", []) with data.benchmark_data_adapter as data_adapter
+	not_eval with input as test_data.process_input("some_process", [])
 }
 
 rule_input(argument) = test_data.process_input("kube-apiserver", [argument])
+
+eval_fail {
+	test.assert_fail(finding) with data.benchmark_data_adapter as data_adapter
+}
+
+eval_pass {
+	test.assert_pass(finding) with data.benchmark_data_adapter as data_adapter
+}
+
+not_eval {
+	not finding with data.benchmark_data_adapter as data_adapter
+}

--- a/bundle/compliance/cis_k8s/rules/cis_1_2_12/test.rego
+++ b/bundle/compliance/cis_k8s/rules/cis_1_2_12/test.rego
@@ -4,27 +4,31 @@ import data.compliance.cis_k8s.data_adapter
 import data.kubernetes_common.test_data
 import data.lib.test
 
-violations {
-	test.assert_fail(finding) with input as rule_input("")
-	test.assert_fail(finding) with input as rule_input("--enable-admission-plugins=AlwaysDeny")
-	test.assert_fail(finding) with input as rule_input("--enable-admission-plugins=NamespaceLifecycle,AlwaysDeny")
-}
-
 test_violation {
-	violations with data.benchmark_data_adapter as data_adapter
-}
-
-passes {
-	test.assert_pass(finding) with input as rule_input("--enable-admission-plugins=AlwaysPullImages")
-	test.assert_pass(finding) with input as rule_input("--enable-admission-plugins=NamespaceLifecycle,AlwaysPullImages")
+	eval_fail with input as rule_input("")
+	eval_fail with input as rule_input("--enable-admission-plugins=AlwaysDeny")
+	eval_fail with input as rule_input("--enable-admission-plugins=NamespaceLifecycle,AlwaysDeny")
 }
 
 test_pass {
-	passes with data.benchmark_data_adapter as data_adapter
+	eval_pass with input as rule_input("--enable-admission-plugins=AlwaysPullImages")
+	eval_pass with input as rule_input("--enable-admission-plugins=NamespaceLifecycle,AlwaysPullImages")
 }
 
 test_not_evaluated {
-	not finding with input as test_data.process_input("some_process", []) with data.benchmark_data_adapter as data_adapter
+	not_eval with input as test_data.process_input("some_process", [])
 }
 
 rule_input(argument) = test_data.process_input("kube-apiserver", [argument])
+
+eval_fail {
+	test.assert_fail(finding) with data.benchmark_data_adapter as data_adapter
+}
+
+eval_pass {
+	test.assert_pass(finding) with data.benchmark_data_adapter as data_adapter
+}
+
+not_eval {
+	not finding with data.benchmark_data_adapter as data_adapter
+}

--- a/bundle/compliance/cis_k8s/rules/cis_1_2_13/test.rego
+++ b/bundle/compliance/cis_k8s/rules/cis_1_2_13/test.rego
@@ -4,28 +4,32 @@ import data.compliance.cis_k8s.data_adapter
 import data.kubernetes_common.test_data
 import data.lib.test
 
-violations {
-	test.assert_fail(finding) with input as rule_input("")
-	test.assert_fail(finding) with input as rule_input("--enable-admission-plugins=AlwaysDeny")
-}
-
 test_violation {
-	violations with data.benchmark_data_adapter as data_adapter
-}
-
-passes {
-	test.assert_pass(finding) with input as rule_input("--enable-admission-plugins=SecurityContextDeny,PodSecurityPolicy")
-	test.assert_pass(finding) with input as rule_input("--enable-admission-plugins=SecurityContextDeny")
-	test.assert_pass(finding) with input as rule_input("--enable-admission-plugins=AlwaysDeny,SecurityContextDeny")
-	test.assert_pass(finding) with input as rule_input("--enable-admission-plugins=PodSecurityPolicy")
+	eval_fail with input as rule_input("")
+	eval_fail with input as rule_input("--enable-admission-plugins=AlwaysDeny")
 }
 
 test_pass {
-	passes with data.benchmark_data_adapter as data_adapter
+	eval_pass with input as rule_input("--enable-admission-plugins=SecurityContextDeny,PodSecurityPolicy")
+	eval_pass with input as rule_input("--enable-admission-plugins=SecurityContextDeny")
+	eval_pass with input as rule_input("--enable-admission-plugins=AlwaysDeny,SecurityContextDeny")
+	eval_pass with input as rule_input("--enable-admission-plugins=PodSecurityPolicy")
 }
 
 test_not_evaluated {
-	not finding with input as test_data.process_input("some_process", []) with data.benchmark_data_adapter as data_adapter
+	not_eval with input as test_data.process_input("some_process", [])
 }
 
 rule_input(argument) = test_data.process_input("kube-apiserver", [argument])
+
+eval_fail {
+	test.assert_fail(finding) with data.benchmark_data_adapter as data_adapter
+}
+
+eval_pass {
+	test.assert_pass(finding) with data.benchmark_data_adapter as data_adapter
+}
+
+not_eval {
+	not finding with data.benchmark_data_adapter as data_adapter
+}

--- a/bundle/compliance/cis_k8s/rules/cis_1_2_14/test.rego
+++ b/bundle/compliance/cis_k8s/rules/cis_1_2_14/test.rego
@@ -4,27 +4,31 @@ import data.compliance.cis_k8s.data_adapter
 import data.kubernetes_common.test_data
 import data.lib.test
 
-violations {
-	test.assert_fail(finding) with input as rule_input("")
-	test.assert_fail(finding) with input as rule_input("--disable-admission-plugins=ServiceAccount")
-	test.assert_fail(finding) with input as rule_input("--disable-admission-plugins=PodNodeSelector,ServiceAccount")
-}
-
 test_violation {
-	violations with data.benchmark_data_adapter as data_adapter
-}
-
-passes {
-	test.assert_pass(finding) with input as rule_input("--disable-admission-plugins=AlwaysDeny")
-	test.assert_pass(finding) with input as rule_input("--disable-admission-plugins=PodNodeSelector,AlwaysDeny")
+	eval_fail with input as rule_input("")
+	eval_fail with input as rule_input("--disable-admission-plugins=ServiceAccount")
+	eval_fail with input as rule_input("--disable-admission-plugins=PodNodeSelector,ServiceAccount")
 }
 
 test_pass {
-	passes with data.benchmark_data_adapter as data_adapter
+	eval_pass with input as rule_input("--disable-admission-plugins=AlwaysDeny")
+	eval_pass with input as rule_input("--disable-admission-plugins=PodNodeSelector,AlwaysDeny")
 }
 
 test_not_evaluated {
-	not finding with input as test_data.process_input("some_process", []) with data.benchmark_data_adapter as data_adapter
+	not_eval with input as test_data.process_input("some_process", [])
 }
 
 rule_input(argument) = test_data.process_input("kube-apiserver", [argument])
+
+eval_fail {
+	test.assert_fail(finding) with data.benchmark_data_adapter as data_adapter
+}
+
+eval_pass {
+	test.assert_pass(finding) with data.benchmark_data_adapter as data_adapter
+}
+
+not_eval {
+	not finding with data.benchmark_data_adapter as data_adapter
+}

--- a/bundle/compliance/cis_k8s/rules/cis_1_2_15/test.rego
+++ b/bundle/compliance/cis_k8s/rules/cis_1_2_15/test.rego
@@ -4,27 +4,31 @@ import data.compliance.cis_k8s.data_adapter
 import data.kubernetes_common.test_data
 import data.lib.test
 
-violations {
-	test.assert_fail(finding) with input as rule_input("")
-	test.assert_fail(finding) with input as rule_input("--disable-admission-plugins=NamespaceLifecycle")
-	test.assert_fail(finding) with input as rule_input("--disable-admission-plugins=PodNodeSelector,NamespaceLifecycle")
-}
-
 test_violation {
-	violations with data.benchmark_data_adapter as data_adapter
-}
-
-passes {
-	test.assert_pass(finding) with input as rule_input("--disable-admission-plugins=AlwaysDeny")
-	test.assert_pass(finding) with input as rule_input("--disable-admission-plugins=PodNodeSelector,AlwaysDeny")
+	eval_fail with input as rule_input("")
+	eval_fail with input as rule_input("--disable-admission-plugins=NamespaceLifecycle")
+	eval_fail with input as rule_input("--disable-admission-plugins=PodNodeSelector,NamespaceLifecycle")
 }
 
 test_pass {
-	passes with data.benchmark_data_adapter as data_adapter
+	eval_pass with input as rule_input("--disable-admission-plugins=AlwaysDeny")
+	eval_pass with input as rule_input("--disable-admission-plugins=PodNodeSelector,AlwaysDeny")
 }
 
 test_not_evaluated {
-	not finding with input as test_data.process_input("some_process", []) with data.benchmark_data_adapter as data_adapter
+	not_eval with input as test_data.process_input("some_process", [])
 }
 
 rule_input(argument) = test_data.process_input("kube-apiserver", [argument])
+
+eval_fail {
+	test.assert_fail(finding) with data.benchmark_data_adapter as data_adapter
+}
+
+eval_pass {
+	test.assert_pass(finding) with data.benchmark_data_adapter as data_adapter
+}
+
+not_eval {
+	not finding with data.benchmark_data_adapter as data_adapter
+}

--- a/bundle/compliance/cis_k8s/rules/cis_1_2_16/test.rego
+++ b/bundle/compliance/cis_k8s/rules/cis_1_2_16/test.rego
@@ -4,27 +4,31 @@ import data.compliance.cis_k8s.data_adapter
 import data.kubernetes_common.test_data
 import data.lib.test
 
-violations {
-	test.assert_fail(finding) with input as rule_input("")
-	test.assert_fail(finding) with input as rule_input("--enable-admission-plugins=AlwaysDeny")
-	test.assert_fail(finding) with input as rule_input("--enable-admission-plugins=NamespaceLifecycle,AlwaysDeny")
-}
-
 test_violation {
-	violations with data.benchmark_data_adapter as data_adapter
-}
-
-passes {
-	test.assert_pass(finding) with input as rule_input("--enable-admission-plugins=NodeRestriction")
-	test.assert_pass(finding) with input as rule_input("--enable-admission-plugins=NamespaceLifecycle,NodeRestriction")
+	eval_fail with input as rule_input("")
+	eval_fail with input as rule_input("--enable-admission-plugins=AlwaysDeny")
+	eval_fail with input as rule_input("--enable-admission-plugins=NamespaceLifecycle,AlwaysDeny")
 }
 
 test_pass {
-	passes with data.benchmark_data_adapter as data_adapter
+	eval_pass with input as rule_input("--enable-admission-plugins=NodeRestriction")
+	eval_pass with input as rule_input("--enable-admission-plugins=NamespaceLifecycle,NodeRestriction")
 }
 
 test_not_evaluated {
-	not finding with input as test_data.process_input("some_process", []) with data.benchmark_data_adapter as data_adapter
+	not_eval with input as test_data.process_input("some_process", [])
 }
 
 rule_input(argument) = test_data.process_input("kube-apiserver", [argument])
+
+eval_fail {
+	test.assert_fail(finding) with data.benchmark_data_adapter as data_adapter
+}
+
+eval_pass {
+	test.assert_pass(finding) with data.benchmark_data_adapter as data_adapter
+}
+
+not_eval {
+	not finding with data.benchmark_data_adapter as data_adapter
+}

--- a/bundle/compliance/cis_k8s/rules/cis_1_2_17/test.rego
+++ b/bundle/compliance/cis_k8s/rules/cis_1_2_17/test.rego
@@ -4,26 +4,30 @@ import data.compliance.cis_k8s.data_adapter
 import data.kubernetes_common.test_data
 import data.lib.test
 
-violations {
-	test.assert_fail(finding) with input as rule_input("--secure-port=0")
-}
-
 test_violation {
-	violations with data.benchmark_data_adapter as data_adapter
-}
-
-passes {
-	test.assert_pass(finding) with input as rule_input("--secure-port=1")
-	test.assert_pass(finding) with input as rule_input("--secure-port=65535")
-	test.assert_pass(finding) with input as rule_input("")
+	eval_fail with input as rule_input("--secure-port=0")
 }
 
 test_pass {
-	passes with data.benchmark_data_adapter as data_adapter
+	eval_pass with input as rule_input("--secure-port=1")
+	eval_pass with input as rule_input("--secure-port=65535")
+	eval_pass with input as rule_input("")
 }
 
 test_not_evaluated {
-	not finding with input as test_data.process_input("some_process", []) with data.benchmark_data_adapter as data_adapter
+	not_eval with input as test_data.process_input("some_process", [])
 }
 
 rule_input(argument) = test_data.process_input("kube-apiserver", [argument])
+
+eval_fail {
+	test.assert_fail(finding) with data.benchmark_data_adapter as data_adapter
+}
+
+eval_pass {
+	test.assert_pass(finding) with data.benchmark_data_adapter as data_adapter
+}
+
+not_eval {
+	not finding with data.benchmark_data_adapter as data_adapter
+}

--- a/bundle/compliance/cis_k8s/rules/cis_1_2_18/test.rego
+++ b/bundle/compliance/cis_k8s/rules/cis_1_2_18/test.rego
@@ -4,25 +4,29 @@ import data.compliance.cis_k8s.data_adapter
 import data.kubernetes_common.test_data
 import data.lib.test
 
-violations {
-	test.assert_fail(finding) with input as rule_input("--profiling=true")
-	test.assert_fail(finding) with input as rule_input("")
-}
-
 test_violation {
-	violations with data.benchmark_data_adapter as data_adapter
-}
-
-passes {
-	test.assert_pass(finding) with input as rule_input("--profiling=false")
+	eval_fail with input as rule_input("--profiling=true")
+	eval_fail with input as rule_input("")
 }
 
 test_pass {
-	passes with data.benchmark_data_adapter as data_adapter
+	eval_pass with input as rule_input("--profiling=false")
 }
 
 test_not_evaluated {
-	not finding with input as test_data.process_input("some_process", []) with data.benchmark_data_adapter as data_adapter
+	not_eval with input as test_data.process_input("some_process", [])
 }
 
 rule_input(argument) = test_data.process_input("kube-apiserver", [argument])
+
+eval_fail {
+	test.assert_fail(finding) with data.benchmark_data_adapter as data_adapter
+}
+
+eval_pass {
+	test.assert_pass(finding) with data.benchmark_data_adapter as data_adapter
+}
+
+not_eval {
+	not finding with data.benchmark_data_adapter as data_adapter
+}

--- a/bundle/compliance/cis_k8s/rules/cis_1_2_19/test.rego
+++ b/bundle/compliance/cis_k8s/rules/cis_1_2_19/test.rego
@@ -4,24 +4,28 @@ import data.compliance.cis_k8s.data_adapter
 import data.kubernetes_common.test_data
 import data.lib.test
 
-violations {
-	test.assert_fail(finding) with input as rule_input("")
-}
-
 test_violation {
-	violations with data.benchmark_data_adapter as data_adapter
-}
-
-passes {
-	test.assert_pass(finding) with input as rule_input("--audit-log-path=/var/log/apiserver/audit.log")
+	eval_fail with input as rule_input("")
 }
 
 test_pass {
-	passes with data.benchmark_data_adapter as data_adapter
+	eval_pass with input as rule_input("--audit-log-path=/var/log/apiserver/audit.log")
 }
 
 test_not_evaluated {
-	not finding with input as test_data.process_input("some_process", []) with data.benchmark_data_adapter as data_adapter
+	not_eval with input as test_data.process_input("some_process", [])
 }
 
 rule_input(argument) = test_data.process_input("kube-apiserver", [argument])
+
+eval_fail {
+	test.assert_fail(finding) with data.benchmark_data_adapter as data_adapter
+}
+
+eval_pass {
+	test.assert_pass(finding) with data.benchmark_data_adapter as data_adapter
+}
+
+not_eval {
+	not finding with data.benchmark_data_adapter as data_adapter
+}

--- a/bundle/compliance/cis_k8s/rules/cis_1_2_2/test.rego
+++ b/bundle/compliance/cis_k8s/rules/cis_1_2_2/test.rego
@@ -4,24 +4,28 @@ import data.compliance.cis_k8s.data_adapter
 import data.kubernetes_common.test_data
 import data.lib.test
 
-violations {
-	test.assert_fail(finding) with input as rule_input("--token-auth-file=<path/to/token/auth/file>")
-}
-
 test_violation {
-	violations with data.benchmark_data_adapter as data_adapter
-}
-
-passes {
-	test.assert_pass(finding) with input as rule_input("")
+	eval_fail with input as rule_input("--token-auth-file=<path/to/token/auth/file>")
 }
 
 test_pass {
-	passes with data.benchmark_data_adapter as data_adapter
+	eval_pass with input as rule_input("")
 }
 
 test_not_evaluated {
-	not finding with input as test_data.process_input("some_process", []) with data.benchmark_data_adapter as data_adapter
+	not_eval with input as test_data.process_input("some_process", [])
 }
 
 rule_input(argument) = test_data.process_input("kube-apiserver", [argument])
+
+eval_fail {
+	test.assert_fail(finding) with data.benchmark_data_adapter as data_adapter
+}
+
+eval_pass {
+	test.assert_pass(finding) with data.benchmark_data_adapter as data_adapter
+}
+
+not_eval {
+	not finding with data.benchmark_data_adapter as data_adapter
+}

--- a/bundle/compliance/cis_k8s/rules/cis_1_2_20/test.rego
+++ b/bundle/compliance/cis_k8s/rules/cis_1_2_20/test.rego
@@ -4,26 +4,30 @@ import data.compliance.cis_k8s.data_adapter
 import data.kubernetes_common.test_data
 import data.lib.test
 
-violations {
-	test.assert_fail(finding) with input as rule_input("")
-	test.assert_fail(finding) with input as rule_input("--audit-log-maxage=29")
-}
-
 test_violation {
-	violations with data.benchmark_data_adapter as data_adapter
-}
-
-passes {
-	test.assert_pass(finding) with input as rule_input("--audit-log-maxage=30")
-	test.assert_pass(finding) with input as rule_input("--audit-log-maxage=60")
+	eval_fail with input as rule_input("")
+	eval_fail with input as rule_input("--audit-log-maxage=29")
 }
 
 test_pass {
-	passes with data.benchmark_data_adapter as data_adapter
+	eval_pass with input as rule_input("--audit-log-maxage=30")
+	eval_pass with input as rule_input("--audit-log-maxage=60")
 }
 
 test_not_evaluated {
-	not finding with input as test_data.process_input("some_process", []) with data.benchmark_data_adapter as data_adapter
+	not_eval with input as test_data.process_input("some_process", [])
 }
 
 rule_input(argument) = test_data.process_input("kube-apiserver", [argument])
+
+eval_fail {
+	test.assert_fail(finding) with data.benchmark_data_adapter as data_adapter
+}
+
+eval_pass {
+	test.assert_pass(finding) with data.benchmark_data_adapter as data_adapter
+}
+
+not_eval {
+	not finding with data.benchmark_data_adapter as data_adapter
+}

--- a/bundle/compliance/cis_k8s/rules/cis_1_2_21/test.rego
+++ b/bundle/compliance/cis_k8s/rules/cis_1_2_21/test.rego
@@ -4,26 +4,30 @@ import data.compliance.cis_k8s.data_adapter
 import data.kubernetes_common.test_data
 import data.lib.test
 
-violations {
-	test.assert_fail(finding) with input as rule_input("")
-	test.assert_fail(finding) with input as rule_input("--audit-log-maxbackup=9")
-}
-
 test_violation {
-	violations with data.benchmark_data_adapter as data_adapter
-}
-
-passes {
-	test.assert_pass(finding) with input as rule_input("--audit-log-maxbackup=10")
-	test.assert_pass(finding) with input as rule_input("--audit-log-maxbackup=20")
+	eval_fail with input as rule_input("")
+	eval_fail with input as rule_input("--audit-log-maxbackup=9")
 }
 
 test_pass {
-	passes with data.benchmark_data_adapter as data_adapter
+	eval_pass with input as rule_input("--audit-log-maxbackup=10")
+	eval_pass with input as rule_input("--audit-log-maxbackup=20")
 }
 
 test_not_evaluated {
-	not finding with input as test_data.process_input("some_process", []) with data.benchmark_data_adapter as data_adapter
+	not_eval with input as test_data.process_input("some_process", [])
 }
 
 rule_input(argument) = test_data.process_input("kube-apiserver", [argument])
+
+eval_fail {
+	test.assert_fail(finding) with data.benchmark_data_adapter as data_adapter
+}
+
+eval_pass {
+	test.assert_pass(finding) with data.benchmark_data_adapter as data_adapter
+}
+
+not_eval {
+	not finding with data.benchmark_data_adapter as data_adapter
+}

--- a/bundle/compliance/cis_k8s/rules/cis_1_2_22/test.rego
+++ b/bundle/compliance/cis_k8s/rules/cis_1_2_22/test.rego
@@ -4,26 +4,30 @@ import data.compliance.cis_k8s.data_adapter
 import data.kubernetes_common.test_data
 import data.lib.test
 
-violations {
-	test.assert_fail(finding) with input as rule_input("")
-	test.assert_fail(finding) with input as rule_input("--audit-log-maxsize=99")
-}
-
 test_violation {
-	violations with data.benchmark_data_adapter as data_adapter
-}
-
-passes {
-	test.assert_pass(finding) with input as rule_input("--audit-log-maxsize=100")
-	test.assert_pass(finding) with input as rule_input("--audit-log-maxsize=200")
+	eval_fail with input as rule_input("")
+	eval_fail with input as rule_input("--audit-log-maxsize=99")
 }
 
 test_pass {
-	passes with data.benchmark_data_adapter as data_adapter
+	eval_pass with input as rule_input("--audit-log-maxsize=100")
+	eval_pass with input as rule_input("--audit-log-maxsize=200")
 }
 
 test_not_evaluated {
-	not finding with input as test_data.process_input("some_process", []) with data.benchmark_data_adapter as data_adapter
+	not_eval with input as test_data.process_input("some_process", [])
 }
 
 rule_input(argument) = test_data.process_input("kube-apiserver", [argument])
+
+eval_fail {
+	test.assert_fail(finding) with data.benchmark_data_adapter as data_adapter
+}
+
+eval_pass {
+	test.assert_pass(finding) with data.benchmark_data_adapter as data_adapter
+}
+
+not_eval {
+	not finding with data.benchmark_data_adapter as data_adapter
+}

--- a/bundle/compliance/cis_k8s/rules/cis_1_2_23/test.rego
+++ b/bundle/compliance/cis_k8s/rules/cis_1_2_23/test.rego
@@ -4,28 +4,32 @@ import data.compliance.cis_k8s.data_adapter
 import data.kubernetes_common.test_data
 import data.lib.test
 
-violations {
-	test.assert_fail(finding) with input as rule_input("--request-timeout=30s")
-	test.assert_fail(finding) with input as rule_input("--request-timeout=59s")
-}
-
 test_violation {
-	violations with data.benchmark_data_adapter as data_adapter
-}
-
-passes {
-	test.assert_pass(finding) with input as rule_input("")
-	test.assert_pass(finding) with input as rule_input("--request-timeout=61s")
-	test.assert_pass(finding) with input as rule_input("--request-timeout=2m")
-	test.assert_pass(finding) with input as rule_input("--request-timeout=1h35m2s")
+	eval_fail with input as rule_input("--request-timeout=30s")
+	eval_fail with input as rule_input("--request-timeout=59s")
 }
 
 test_pass {
-	passes with data.benchmark_data_adapter as data_adapter
+	eval_pass with input as rule_input("")
+	eval_pass with input as rule_input("--request-timeout=61s")
+	eval_pass with input as rule_input("--request-timeout=2m")
+	eval_pass with input as rule_input("--request-timeout=1h35m2s")
 }
 
 test_not_evaluated {
-	not finding with input as test_data.process_input("some_process", []) with data.benchmark_data_adapter as data_adapter
+	not_eval with input as test_data.process_input("some_process", [])
 }
 
 rule_input(argument) = test_data.process_input("kube-apiserver", [argument])
+
+eval_fail {
+	test.assert_fail(finding) with data.benchmark_data_adapter as data_adapter
+}
+
+eval_pass {
+	test.assert_pass(finding) with data.benchmark_data_adapter as data_adapter
+}
+
+not_eval {
+	not finding with data.benchmark_data_adapter as data_adapter
+}

--- a/bundle/compliance/cis_k8s/rules/cis_1_2_24/test.rego
+++ b/bundle/compliance/cis_k8s/rules/cis_1_2_24/test.rego
@@ -4,25 +4,29 @@ import data.compliance.cis_k8s.data_adapter
 import data.kubernetes_common.test_data
 import data.lib.test
 
-violations {
-	test.assert_fail(finding) with input as rule_input("--service-account-lookup=false")
-}
-
 test_violation {
-	violations with data.benchmark_data_adapter as data_adapter
-}
-
-passes {
-	test.assert_pass(finding) with input as rule_input("")
-	test.assert_pass(finding) with input as rule_input("--service-account-lookup=true")
+	eval_fail with input as rule_input("--service-account-lookup=false")
 }
 
 test_pass {
-	passes with data.benchmark_data_adapter as data_adapter
+	eval_pass with input as rule_input("")
+	eval_pass with input as rule_input("--service-account-lookup=true")
 }
 
 test_not_evaluated {
-	not finding with input as test_data.process_input("some_process", []) with data.benchmark_data_adapter as data_adapter
+	not_eval with input as test_data.process_input("some_process", [])
 }
 
 rule_input(argument) = test_data.process_input("kube-apiserver", [argument])
+
+eval_fail {
+	test.assert_fail(finding) with data.benchmark_data_adapter as data_adapter
+}
+
+eval_pass {
+	test.assert_pass(finding) with data.benchmark_data_adapter as data_adapter
+}
+
+not_eval {
+	not finding with data.benchmark_data_adapter as data_adapter
+}

--- a/bundle/compliance/cis_k8s/rules/cis_1_2_25/test.rego
+++ b/bundle/compliance/cis_k8s/rules/cis_1_2_25/test.rego
@@ -4,24 +4,28 @@ import data.compliance.cis_k8s.data_adapter
 import data.kubernetes_common.test_data
 import data.lib.test
 
-violations {
-	test.assert_fail(finding) with input as rule_input("")
-}
-
 test_violation {
-	violations with data.benchmark_data_adapter as data_adapter
-}
-
-passes {
-	test.assert_pass(finding) with input as rule_input("--service-account-key-file=<filename>")
+	eval_fail with input as rule_input("")
 }
 
 test_pass {
-	passes with data.benchmark_data_adapter as data_adapter
+	eval_pass with input as rule_input("--service-account-key-file=<filename>")
 }
 
 test_not_evaluated {
-	not finding with input as test_data.process_input("some_process", []) with data.benchmark_data_adapter as data_adapter
+	not_eval with input as test_data.process_input("some_process", [])
 }
 
 rule_input(argument) = test_data.process_input("kube-apiserver", [argument])
+
+eval_fail {
+	test.assert_fail(finding) with data.benchmark_data_adapter as data_adapter
+}
+
+eval_pass {
+	test.assert_pass(finding) with data.benchmark_data_adapter as data_adapter
+}
+
+not_eval {
+	not finding with data.benchmark_data_adapter as data_adapter
+}

--- a/bundle/compliance/cis_k8s/rules/cis_1_2_26/test.rego
+++ b/bundle/compliance/cis_k8s/rules/cis_1_2_26/test.rego
@@ -4,26 +4,30 @@ import data.compliance.cis_k8s.data_adapter
 import data.kubernetes_common.test_data
 import data.lib.test
 
-violations {
-	test.assert_fail(finding) with input as rule_input([""])
-	test.assert_fail(finding) with input as rule_input(["--etcd-certfile=<path/to/etcd-cert>"])
-	test.assert_fail(finding) with input as rule_input(["--etcd-keyfile=<path/to/etcd-key>"])
-}
-
 test_violation {
-	violations with data.benchmark_data_adapter as data_adapter
-}
-
-passes {
-	test.assert_pass(finding) with input as rule_input(["--etcd-certfile=<path/to/etcd-cert>", "--etcd-keyfile=<path/to/etcd-key>"])
+	eval_fail with input as rule_input([""])
+	eval_fail with input as rule_input(["--etcd-certfile=<path/to/etcd-cert>"])
+	eval_fail with input as rule_input(["--etcd-keyfile=<path/to/etcd-key>"])
 }
 
 test_pass {
-	passes with data.benchmark_data_adapter as data_adapter
+	eval_pass with input as rule_input(["--etcd-certfile=<path/to/etcd-cert>", "--etcd-keyfile=<path/to/etcd-key>"])
 }
 
 test_not_evaluated {
-	not finding with input as test_data.process_input("some_process", [""]) with data.benchmark_data_adapter as data_adapter
+	not_eval with input as test_data.process_input("some_process", [""])
 }
 
 rule_input(argument) = test_data.process_input("kube-apiserver", argument)
+
+eval_fail {
+	test.assert_fail(finding) with data.benchmark_data_adapter as data_adapter
+}
+
+eval_pass {
+	test.assert_pass(finding) with data.benchmark_data_adapter as data_adapter
+}
+
+not_eval {
+	not finding with data.benchmark_data_adapter as data_adapter
+}

--- a/bundle/compliance/cis_k8s/rules/cis_1_2_27/test.rego
+++ b/bundle/compliance/cis_k8s/rules/cis_1_2_27/test.rego
@@ -4,26 +4,30 @@ import data.compliance.cis_k8s.data_adapter
 import data.kubernetes_common.test_data
 import data.lib.test
 
-violations {
-	test.assert_fail(finding) with input as rule_input([""])
-	test.assert_fail(finding) with input as rule_input(["--tls-cert-file=<path/to/tls-cert>"])
-	test.assert_fail(finding) with input as rule_input(["--tls-private-key-file=<path/to/tls-key>"])
-}
-
 test_violation {
-	violations with data.benchmark_data_adapter as data_adapter
-}
-
-passes {
-	test.assert_pass(finding) with input as rule_input(["--tls-private-key-file=<path/to/tls-key>", "--tls-cert-file=<path/to/tls-cert>"])
+	eval_fail with input as rule_input([""])
+	eval_fail with input as rule_input(["--tls-cert-file=<path/to/tls-cert>"])
+	eval_fail with input as rule_input(["--tls-private-key-file=<path/to/tls-key>"])
 }
 
 test_pass {
-	passes with data.benchmark_data_adapter as data_adapter
+	eval_pass with input as rule_input(["--tls-private-key-file=<path/to/tls-key>", "--tls-cert-file=<path/to/tls-cert>"])
 }
 
 test_not_evaluated {
-	not finding with input as test_data.process_input("some_process", [""]) with data.benchmark_data_adapter as data_adapter
+	not_eval with input as test_data.process_input("some_process", [""])
 }
 
 rule_input(argument) = test_data.process_input("kube-apiserver", argument)
+
+eval_fail {
+	test.assert_fail(finding) with data.benchmark_data_adapter as data_adapter
+}
+
+eval_pass {
+	test.assert_pass(finding) with data.benchmark_data_adapter as data_adapter
+}
+
+not_eval {
+	not finding with data.benchmark_data_adapter as data_adapter
+}

--- a/bundle/compliance/cis_k8s/rules/cis_1_2_28/test.rego
+++ b/bundle/compliance/cis_k8s/rules/cis_1_2_28/test.rego
@@ -4,24 +4,28 @@ import data.compliance.cis_k8s.data_adapter
 import data.kubernetes_common.test_data
 import data.lib.test
 
-violations {
-	test.assert_fail(finding) with input as rule_input("")
-}
-
 test_violation {
-	violations with data.benchmark_data_adapter as data_adapter
-}
-
-passes {
-	test.assert_pass(finding) with input as rule_input("--client-ca-file=<path/to/client-ca-file>")
+	eval_fail with input as rule_input("")
 }
 
 test_pass {
-	passes with data.benchmark_data_adapter as data_adapter
+	eval_pass with input as rule_input("--client-ca-file=<path/to/client-ca-file>")
 }
 
 test_not_evaluated {
-	not finding with input as test_data.process_input("some_process", []) with data.benchmark_data_adapter as data_adapter
+	not_eval with input as test_data.process_input("some_process", [])
 }
 
 rule_input(argument) = test_data.process_input("kube-apiserver", [argument])
+
+eval_fail {
+	test.assert_fail(finding) with data.benchmark_data_adapter as data_adapter
+}
+
+eval_pass {
+	test.assert_pass(finding) with data.benchmark_data_adapter as data_adapter
+}
+
+not_eval {
+	not finding with data.benchmark_data_adapter as data_adapter
+}

--- a/bundle/compliance/cis_k8s/rules/cis_1_2_29/test.rego
+++ b/bundle/compliance/cis_k8s/rules/cis_1_2_29/test.rego
@@ -4,24 +4,28 @@ import data.compliance.cis_k8s.data_adapter
 import data.kubernetes_common.test_data
 import data.lib.test
 
-violations {
-	test.assert_fail(finding) with input as rule_input("")
-}
-
 test_violation {
-	violations with data.benchmark_data_adapter as data_adapter
-}
-
-passes {
-	test.assert_pass(finding) with input as rule_input("--etcd-cafile=<path/to/ca-file>")
+	eval_fail with input as rule_input("")
 }
 
 test_pass {
-	passes with data.benchmark_data_adapter as data_adapter
+	eval_pass with input as rule_input("--etcd-cafile=<path/to/ca-file>")
 }
 
 test_not_evaluated {
-	not finding with input as test_data.process_input("some_process", []) with data.benchmark_data_adapter as data_adapter
+	not_eval with input as test_data.process_input("some_process", [])
 }
 
 rule_input(argument) = test_data.process_input("kube-apiserver", [argument])
+
+eval_fail {
+	test.assert_fail(finding) with data.benchmark_data_adapter as data_adapter
+}
+
+eval_pass {
+	test.assert_pass(finding) with data.benchmark_data_adapter as data_adapter
+}
+
+not_eval {
+	not finding with data.benchmark_data_adapter as data_adapter
+}

--- a/bundle/compliance/cis_k8s/rules/cis_1_2_32/test.rego
+++ b/bundle/compliance/cis_k8s/rules/cis_1_2_32/test.rego
@@ -4,28 +4,32 @@ import data.compliance.cis_k8s.data_adapter
 import data.kubernetes_common.test_data
 import data.lib.test
 
-violations {
-	test.assert_fail(finding) with input as rule_input("")
-	test.assert_fail(finding) with input as rule_input("--tls-cipher-suites=SOME_CIPHER")
-	test.assert_fail(finding) with input as rule_input("--tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,SOME_CIPHER")
-}
-
 test_violation {
-	violations with data.benchmark_data_adapter as data_adapter
-}
-
-passes {
-	test.assert_pass(finding) with input as rule_input("--tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256")
-	test.assert_pass(finding) with input as rule_input("--tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384")
-	test.assert_pass(finding) with input as rule_input("--tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384")
+	eval_fail with input as rule_input("")
+	eval_fail with input as rule_input("--tls-cipher-suites=SOME_CIPHER")
+	eval_fail with input as rule_input("--tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,SOME_CIPHER")
 }
 
 test_pass {
-	passes with data.benchmark_data_adapter as data_adapter
+	eval_pass with input as rule_input("--tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256")
+	eval_pass with input as rule_input("--tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384")
+	eval_pass with input as rule_input("--tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384")
 }
 
 test_not_evaluated {
-	not finding with input as test_data.process_input("some_process", []) with data.benchmark_data_adapter as data_adapter
+	not_eval with input as test_data.process_input("some_process", [])
 }
 
 rule_input(argument) = test_data.process_input("kube-apiserver", [argument])
+
+eval_fail {
+	test.assert_fail(finding) with data.benchmark_data_adapter as data_adapter
+}
+
+eval_pass {
+	test.assert_pass(finding) with data.benchmark_data_adapter as data_adapter
+}
+
+not_eval {
+	not finding with data.benchmark_data_adapter as data_adapter
+}

--- a/bundle/compliance/cis_k8s/rules/cis_1_2_4/test.rego
+++ b/bundle/compliance/cis_k8s/rules/cis_1_2_4/test.rego
@@ -4,25 +4,29 @@ import data.compliance.cis_k8s.data_adapter
 import data.kubernetes_common.test_data
 import data.lib.test
 
-violations {
-	test.assert_fail(finding) with input as rule_input("--kubelet-https=false")
-}
-
 test_violation {
-	violations with data.benchmark_data_adapter as data_adapter
-}
-
-passes {
-	test.assert_pass(finding) with input as rule_input("--kubelet-https=true")
-	test.assert_pass(finding) with input as rule_input("")
+	eval_fail with input as rule_input("--kubelet-https=false")
 }
 
 test_pass {
-	passes with data.benchmark_data_adapter as data_adapter
+	eval_pass with input as rule_input("--kubelet-https=true")
+	eval_pass with input as rule_input("")
 }
 
 test_not_evaluated {
-	not finding with input as test_data.process_input("some_process", []) with data.benchmark_data_adapter as data_adapter
+	not_eval with input as test_data.process_input("some_process", [])
 }
 
 rule_input(argument) = test_data.process_input("kube-apiserver", [argument])
+
+eval_fail {
+	test.assert_fail(finding) with data.benchmark_data_adapter as data_adapter
+}
+
+eval_pass {
+	test.assert_pass(finding) with data.benchmark_data_adapter as data_adapter
+}
+
+not_eval {
+	not finding with data.benchmark_data_adapter as data_adapter
+}

--- a/bundle/compliance/cis_k8s/rules/cis_1_2_5/test.rego
+++ b/bundle/compliance/cis_k8s/rules/cis_1_2_5/test.rego
@@ -4,26 +4,30 @@ import data.compliance.cis_k8s.data_adapter
 import data.kubernetes_common.test_data
 import data.lib.test
 
-violations {
-	test.assert_fail(finding) with input as rule_input([""])
-	test.assert_fail(finding) with input as rule_input(["--kubelet-client-key=<path/to/client-cert>"])
-	test.assert_fail(finding) with input as rule_input(["--kubelet-client-certificate=<path/to/client-key>"])
-}
-
 test_violation {
-	violations with data.benchmark_data_adapter as data_adapter
-}
-
-passes {
-	test.assert_pass(finding) with input as rule_input(["--kubelet-client-certificate=<path/to/client-key>", "--kubelet-client-key=<path/to/client-cert>"])
+	eval_fail with input as rule_input([""])
+	eval_fail with input as rule_input(["--kubelet-client-key=<path/to/client-cert>"])
+	eval_fail with input as rule_input(["--kubelet-client-certificate=<path/to/client-key>"])
 }
 
 test_pass {
-	passes with data.benchmark_data_adapter as data_adapter
+	eval_pass with input as rule_input(["--kubelet-client-certificate=<path/to/client-key>", "--kubelet-client-key=<path/to/client-cert>"])
 }
 
 test_not_evaluated {
-	not finding with input as test_data.process_input("some_process", [""]) with data.benchmark_data_adapter as data_adapter
+	not_eval with input as test_data.process_input("some_process", [""])
 }
 
 rule_input(argument) = test_data.process_input("kube-apiserver", argument)
+
+eval_fail {
+	test.assert_fail(finding) with data.benchmark_data_adapter as data_adapter
+}
+
+eval_pass {
+	test.assert_pass(finding) with data.benchmark_data_adapter as data_adapter
+}
+
+not_eval {
+	not finding with data.benchmark_data_adapter as data_adapter
+}

--- a/bundle/compliance/cis_k8s/rules/cis_1_2_6/test.rego
+++ b/bundle/compliance/cis_k8s/rules/cis_1_2_6/test.rego
@@ -4,24 +4,28 @@ import data.compliance.cis_k8s.data_adapter
 import data.kubernetes_common.test_data
 import data.lib.test
 
-violations {
-	test.assert_fail(finding) with input as rule_input("")
-}
-
 test_violation {
-	violations with data.benchmark_data_adapter as data_adapter
-}
-
-passes {
-	test.assert_pass(finding) with input as rule_input("--kubelet-certificate-authority=<ca-string>")
+	eval_fail with input as rule_input("")
 }
 
 test_pass {
-	passes with data.benchmark_data_adapter as data_adapter
+	eval_pass with input as rule_input("--kubelet-certificate-authority=<ca-string>")
 }
 
 test_not_evaluated {
-	not finding with input as test_data.process_input("some_process", []) with data.benchmark_data_adapter as data_adapter
+	not_eval with input as test_data.process_input("some_process", [])
 }
 
 rule_input(argument) = test_data.process_input("kube-apiserver", [argument])
+
+eval_fail {
+	test.assert_fail(finding) with data.benchmark_data_adapter as data_adapter
+}
+
+eval_pass {
+	test.assert_pass(finding) with data.benchmark_data_adapter as data_adapter
+}
+
+not_eval {
+	not finding with data.benchmark_data_adapter as data_adapter
+}

--- a/bundle/compliance/cis_k8s/rules/cis_1_2_7/test.rego
+++ b/bundle/compliance/cis_k8s/rules/cis_1_2_7/test.rego
@@ -4,26 +4,30 @@ import data.compliance.cis_k8s.data_adapter
 import data.kubernetes_common.test_data
 import data.lib.test
 
-violations {
-	test.assert_fail(finding) with input as rule_input("--authorization-mode=AlwaysAllow")
-	test.assert_fail(finding) with input as rule_input("--authorization-mode=RBAC,AlwaysAllow")
-}
-
 test_violation {
-	violations with data.benchmark_data_adapter as data_adapter
-}
-
-passes {
-	test.assert_pass(finding) with input as rule_input("--authorization-mode=RBAC")
-	test.assert_pass(finding) with input as rule_input("")
+	eval_fail with input as rule_input("--authorization-mode=AlwaysAllow")
+	eval_fail with input as rule_input("--authorization-mode=RBAC,AlwaysAllow")
 }
 
 test_pass {
-	passes with data.benchmark_data_adapter as data_adapter
+	eval_pass with input as rule_input("--authorization-mode=RBAC")
+	eval_pass with input as rule_input("")
 }
 
 test_not_evaluated {
-	not finding with input as test_data.process_input("some_process", []) with data.benchmark_data_adapter as data_adapter
+	not_eval with input as test_data.process_input("some_process", [])
 }
 
 rule_input(argument) = test_data.process_input("kube-apiserver", [argument])
+
+eval_fail {
+	test.assert_fail(finding) with data.benchmark_data_adapter as data_adapter
+}
+
+eval_pass {
+	test.assert_pass(finding) with data.benchmark_data_adapter as data_adapter
+}
+
+not_eval {
+	not finding with data.benchmark_data_adapter as data_adapter
+}

--- a/bundle/compliance/cis_k8s/rules/cis_1_2_8/test.rego
+++ b/bundle/compliance/cis_k8s/rules/cis_1_2_8/test.rego
@@ -4,26 +4,30 @@ import data.compliance.cis_k8s.data_adapter
 import data.kubernetes_common.test_data
 import data.lib.test
 
-violations {
-	test.assert_fail(finding) with input as rule_input("")
-	test.assert_fail(finding) with input as rule_input("--authorization-mode=RBAC")
-}
-
 test_violation {
-	violations with data.benchmark_data_adapter as data_adapter
-}
-
-passes {
-	test.assert_pass(finding) with input as rule_input("--authorization-mode=Node")
-	test.assert_pass(finding) with input as rule_input("--authorization-mode=RBAC,Node")
+	eval_fail with input as rule_input("")
+	eval_fail with input as rule_input("--authorization-mode=RBAC")
 }
 
 test_pass {
-	passes with data.benchmark_data_adapter as data_adapter
+	eval_pass with input as rule_input("--authorization-mode=Node")
+	eval_pass with input as rule_input("--authorization-mode=RBAC,Node")
 }
 
 test_not_evaluated {
-	not finding with input as test_data.process_input("some_process", []) with data.benchmark_data_adapter as data_adapter
+	not_eval with input as test_data.process_input("some_process", [])
 }
 
 rule_input(argument) = test_data.process_input("kube-apiserver", [argument])
+
+eval_fail {
+	test.assert_fail(finding) with data.benchmark_data_adapter as data_adapter
+}
+
+eval_pass {
+	test.assert_pass(finding) with data.benchmark_data_adapter as data_adapter
+}
+
+not_eval {
+	not finding with data.benchmark_data_adapter as data_adapter
+}

--- a/bundle/compliance/cis_k8s/rules/cis_1_2_9/test.rego
+++ b/bundle/compliance/cis_k8s/rules/cis_1_2_9/test.rego
@@ -4,26 +4,30 @@ import data.compliance.cis_k8s.data_adapter
 import data.kubernetes_common.test_data
 import data.lib.test
 
-violations {
-	test.assert_fail(finding) with input as rule_input("")
-	test.assert_fail(finding) with input as rule_input("--authorization-mode=Node")
-}
-
 test_violation {
-	violations with data.benchmark_data_adapter as data_adapter
-}
-
-passes {
-	test.assert_pass(finding) with input as rule_input("--authorization-mode=RBAC")
-	test.assert_pass(finding) with input as rule_input("--authorization-mode=Node,RBAC")
+	eval_fail with input as rule_input("")
+	eval_fail with input as rule_input("--authorization-mode=Node")
 }
 
 test_pass {
-	passes with data.benchmark_data_adapter as data_adapter
+	eval_pass with input as rule_input("--authorization-mode=RBAC")
+	eval_pass with input as rule_input("--authorization-mode=Node,RBAC")
 }
 
 test_not_evaluated {
-	not finding with input as test_data.process_input("some_process", []) with data.benchmark_data_adapter as data_adapter
+	not_eval with input as test_data.process_input("some_process", [])
 }
 
 rule_input(argument) = test_data.process_input("kube-apiserver", [argument])
+
+eval_fail {
+	test.assert_fail(finding) with data.benchmark_data_adapter as data_adapter
+}
+
+eval_pass {
+	test.assert_pass(finding) with data.benchmark_data_adapter as data_adapter
+}
+
+not_eval {
+	not finding with data.benchmark_data_adapter as data_adapter
+}

--- a/bundle/compliance/cis_k8s/rules/cis_1_3_2/test.rego
+++ b/bundle/compliance/cis_k8s/rules/cis_1_3_2/test.rego
@@ -4,25 +4,29 @@ import data.compliance.cis_k8s.data_adapter
 import data.kubernetes_common.test_data
 import data.lib.test
 
-violations {
-	test.assert_fail(finding) with input as rule_input("")
-	test.assert_fail(finding) with input as rule_input("--profiling=true")
-}
-
 test_violation {
-	violations with data.benchmark_data_adapter as data_adapter
-}
-
-passes {
-	test.assert_pass(finding) with input as rule_input("--profiling=false")
+	eval_fail with input as rule_input("")
+	eval_fail with input as rule_input("--profiling=true")
 }
 
 test_pass {
-	passes with data.benchmark_data_adapter as data_adapter
+	eval_pass with input as rule_input("--profiling=false")
 }
 
 test_not_evaluated {
-	not finding with input as test_data.process_input("some_process", []) with data.benchmark_data_adapter as data_adapter
+	not_eval with input as test_data.process_input("some_process", [])
 }
 
 rule_input(argument) = test_data.process_input("kube-controller", [argument])
+
+eval_fail {
+	test.assert_fail(finding) with data.benchmark_data_adapter as data_adapter
+}
+
+eval_pass {
+	test.assert_pass(finding) with data.benchmark_data_adapter as data_adapter
+}
+
+not_eval {
+	not finding with data.benchmark_data_adapter as data_adapter
+}

--- a/bundle/compliance/cis_k8s/rules/cis_1_3_3/test.rego
+++ b/bundle/compliance/cis_k8s/rules/cis_1_3_3/test.rego
@@ -4,25 +4,29 @@ import data.compliance.cis_k8s.data_adapter
 import data.kubernetes_common.test_data
 import data.lib.test
 
-violations {
-	test.assert_fail(finding) with input as rule_input("")
-	test.assert_fail(finding) with input as rule_input("--use-service-account-credentials=false")
-}
-
 test_violation {
-	violations with data.benchmark_data_adapter as data_adapter
-}
-
-passes {
-	test.assert_pass(finding) with input as rule_input("--use-service-account-credentials=true")
+	eval_fail with input as rule_input("")
+	eval_fail with input as rule_input("--use-service-account-credentials=false")
 }
 
 test_pass {
-	passes with data.benchmark_data_adapter as data_adapter
+	eval_pass with input as rule_input("--use-service-account-credentials=true")
 }
 
 test_not_evaluated {
-	not finding with input as test_data.process_input("some_process", []) with data.benchmark_data_adapter as data_adapter
+	not_eval with input as test_data.process_input("some_process", [])
 }
 
 rule_input(argument) = test_data.process_input("kube-controller", [argument])
+
+eval_fail {
+	test.assert_fail(finding) with data.benchmark_data_adapter as data_adapter
+}
+
+eval_pass {
+	test.assert_pass(finding) with data.benchmark_data_adapter as data_adapter
+}
+
+not_eval {
+	not finding with data.benchmark_data_adapter as data_adapter
+}

--- a/bundle/compliance/cis_k8s/rules/cis_1_3_4/test.rego
+++ b/bundle/compliance/cis_k8s/rules/cis_1_3_4/test.rego
@@ -4,24 +4,28 @@ import data.compliance.cis_k8s.data_adapter
 import data.kubernetes_common.test_data
 import data.lib.test
 
-violations {
-	test.assert_fail(finding) with input as rule_input("")
-}
-
 test_violation {
-	violations with data.benchmark_data_adapter as data_adapter
-}
-
-passes {
-	test.assert_pass(finding) with input as rule_input("--service-account-private-key-file=<filename>")
+	eval_fail with input as rule_input("")
 }
 
 test_pass {
-	passes with data.benchmark_data_adapter as data_adapter
+	eval_pass with input as rule_input("--service-account-private-key-file=<filename>")
 }
 
 test_not_evaluated {
-	not finding with input as test_data.process_input("some_process", []) with data.benchmark_data_adapter as data_adapter
+	not_eval with input as test_data.process_input("some_process", [])
 }
 
 rule_input(argument) = test_data.process_input("kube-controller", [argument])
+
+eval_fail {
+	test.assert_fail(finding) with data.benchmark_data_adapter as data_adapter
+}
+
+eval_pass {
+	test.assert_pass(finding) with data.benchmark_data_adapter as data_adapter
+}
+
+not_eval {
+	not finding with data.benchmark_data_adapter as data_adapter
+}

--- a/bundle/compliance/cis_k8s/rules/cis_1_3_5/test.rego
+++ b/bundle/compliance/cis_k8s/rules/cis_1_3_5/test.rego
@@ -4,24 +4,28 @@ import data.compliance.cis_k8s.data_adapter
 import data.kubernetes_common.test_data
 import data.lib.test
 
-violations {
-	test.assert_fail(finding) with input as rule_input("")
-}
-
 test_violation {
-	violations with data.benchmark_data_adapter as data_adapter
-}
-
-passes {
-	test.assert_pass(finding) with input as rule_input("--root-ca-file=<path/to/file>")
+	eval_fail with input as rule_input("")
 }
 
 test_pass {
-	passes with data.benchmark_data_adapter as data_adapter
+	eval_pass with input as rule_input("--root-ca-file=<path/to/file>")
 }
 
 test_not_evaluated {
-	not finding with input as test_data.process_input("some_process", []) with data.benchmark_data_adapter as data_adapter
+	not_eval with input as test_data.process_input("some_process", [])
 }
 
 rule_input(argument) = test_data.process_input("kube-controller", [argument])
+
+eval_fail {
+	test.assert_fail(finding) with data.benchmark_data_adapter as data_adapter
+}
+
+eval_pass {
+	test.assert_pass(finding) with data.benchmark_data_adapter as data_adapter
+}
+
+not_eval {
+	not finding with data.benchmark_data_adapter as data_adapter
+}

--- a/bundle/compliance/cis_k8s/rules/cis_1_3_6/test.rego
+++ b/bundle/compliance/cis_k8s/rules/cis_1_3_6/test.rego
@@ -4,26 +4,30 @@ import data.compliance.cis_k8s.data_adapter
 import data.kubernetes_common.test_data
 import data.lib.test
 
-violations {
-	test.assert_fail(finding) with input as rule_input("")
-	test.assert_fail(finding) with input as rule_input("--feature-gates=RotateKubeletServerCertificate=false")
-}
-
 test_violation {
-	violations with data.benchmark_data_adapter as data_adapter
-}
-
-passes {
-	test.assert_pass(finding) with input as rule_input("--feature-gates=RotateKubeletServerCertificate=true")
-	true
+	eval_fail with input as rule_input("")
+	eval_fail with input as rule_input("--feature-gates=RotateKubeletServerCertificate=false")
 }
 
 test_pass {
-	passes with data.benchmark_data_adapter as data_adapter
+	eval_pass with input as rule_input("--feature-gates=RotateKubeletServerCertificate=true")
+	true
 }
 
 test_not_evaluated {
-	not finding with input as test_data.process_input("some_process", []) with data.benchmark_data_adapter as data_adapter
+	not_eval with input as test_data.process_input("some_process", [])
 }
 
 rule_input(argument) = test_data.process_input("kube-controller", [argument])
+
+eval_fail {
+	test.assert_fail(finding) with data.benchmark_data_adapter as data_adapter
+}
+
+eval_pass {
+	test.assert_pass(finding) with data.benchmark_data_adapter as data_adapter
+}
+
+not_eval {
+	not finding with data.benchmark_data_adapter as data_adapter
+}

--- a/bundle/compliance/cis_k8s/rules/cis_1_3_7/test.rego
+++ b/bundle/compliance/cis_k8s/rules/cis_1_3_7/test.rego
@@ -4,25 +4,29 @@ import data.compliance.cis_k8s.data_adapter
 import data.kubernetes_common.test_data
 import data.lib.test
 
-violations {
-	test.assert_fail(finding) with input as rule_input("")
-	test.assert_fail(finding) with input as rule_input("--bind-address=127.0.0.2")
-}
-
 test_violation {
-	violations with data.benchmark_data_adapter as data_adapter
-}
-
-passes {
-	test.assert_pass(finding) with input as rule_input("--bind-address=127.0.0.1")
+	eval_fail with input as rule_input("")
+	eval_fail with input as rule_input("--bind-address=127.0.0.2")
 }
 
 test_pass {
-	passes with data.benchmark_data_adapter as data_adapter
+	eval_pass with input as rule_input("--bind-address=127.0.0.1")
 }
 
 test_not_evaluated {
-	not finding with input as test_data.process_input("some_process", []) with data.benchmark_data_adapter as data_adapter
+	not_eval with input as test_data.process_input("some_process", [])
 }
 
 rule_input(argument) = test_data.process_input("kube-controller", [argument])
+
+eval_fail {
+	test.assert_fail(finding) with data.benchmark_data_adapter as data_adapter
+}
+
+eval_pass {
+	test.assert_pass(finding) with data.benchmark_data_adapter as data_adapter
+}
+
+not_eval {
+	not finding with data.benchmark_data_adapter as data_adapter
+}

--- a/bundle/compliance/cis_k8s/rules/cis_1_4_1/test.rego
+++ b/bundle/compliance/cis_k8s/rules/cis_1_4_1/test.rego
@@ -4,25 +4,29 @@ import data.compliance.cis_k8s.data_adapter
 import data.kubernetes_common.test_data
 import data.lib.test
 
-violations {
-	test.assert_fail(finding) with input as rule_input("")
-	test.assert_fail(finding) with input as rule_input("--profiling=true")
-}
-
 test_violation {
-	violations with data.benchmark_data_adapter as data_adapter
-}
-
-passes {
-	test.assert_pass(finding) with input as rule_input("--profiling=false")
+	eval_fail with input as rule_input("")
+	eval_fail with input as rule_input("--profiling=true")
 }
 
 test_pass {
-	passes with data.benchmark_data_adapter as data_adapter
+	eval_pass with input as rule_input("--profiling=false")
 }
 
 test_not_evaluated {
-	not finding with input as test_data.process_input("some_process", []) with data.benchmark_data_adapter as data_adapter
+	not_eval with input as test_data.process_input("some_process", [])
 }
 
 rule_input(argument) = test_data.process_input("kube-scheduler", [argument])
+
+eval_fail {
+	test.assert_fail(finding) with data.benchmark_data_adapter as data_adapter
+}
+
+eval_pass {
+	test.assert_pass(finding) with data.benchmark_data_adapter as data_adapter
+}
+
+not_eval {
+	not finding with data.benchmark_data_adapter as data_adapter
+}

--- a/bundle/compliance/cis_k8s/rules/cis_1_4_2/test.rego
+++ b/bundle/compliance/cis_k8s/rules/cis_1_4_2/test.rego
@@ -4,25 +4,29 @@ import data.compliance.cis_k8s.data_adapter
 import data.kubernetes_common.test_data
 import data.lib.test
 
-violations {
-	test.assert_fail(finding) with input as rule_input("")
-	test.assert_fail(finding) with input as rule_input("--bind-address=0.0.0.0")
-}
-
 test_violation {
-	violations with data.benchmark_data_adapter as data_adapter
-}
-
-passes {
-	test.assert_pass(finding) with input as rule_input("--bind-address=127.0.0.1")
+	eval_fail with input as rule_input("")
+	eval_fail with input as rule_input("--bind-address=0.0.0.0")
 }
 
 test_pass {
-	passes with data.benchmark_data_adapter as data_adapter
+	eval_pass with input as rule_input("--bind-address=127.0.0.1")
 }
 
 test_not_evaluated {
-	not finding with input as test_data.process_input("some_process", []) with data.benchmark_data_adapter as data_adapter
+	not_eval with input as test_data.process_input("some_process", [])
 }
 
 rule_input(argument) = test_data.process_input("kube-scheduler", [argument])
+
+eval_fail {
+	test.assert_fail(finding) with data.benchmark_data_adapter as data_adapter
+}
+
+eval_pass {
+	test.assert_pass(finding) with data.benchmark_data_adapter as data_adapter
+}
+
+not_eval {
+	not finding with data.benchmark_data_adapter as data_adapter
+}

--- a/bundle/compliance/cis_k8s/rules/cis_2_1/test.rego
+++ b/bundle/compliance/cis_k8s/rules/cis_2_1/test.rego
@@ -4,26 +4,30 @@ import data.compliance.cis_k8s.data_adapter
 import data.kubernetes_common.test_data
 import data.lib.test
 
-violations {
-	test.assert_fail(finding) with input as rule_input("")
-	test.assert_fail(finding) with input as rule_input("--cert-file=</path/to/ca-file>")
-	test.assert_fail(finding) with input as rule_input("--key-file=</path/to/key-file>")
-}
-
 test_violation {
-	violations with data.benchmark_data_adapter as data_adapter
-}
-
-passes {
-	test.assert_pass(finding) with input as rule_input("--cert-file=</path/to/ca-file> --key-file=</path/to/key-file>")
+	eval_fail with input as rule_input("")
+	eval_fail with input as rule_input("--cert-file=</path/to/ca-file>")
+	eval_fail with input as rule_input("--key-file=</path/to/key-file>")
 }
 
 test_pass {
-	passes with data.benchmark_data_adapter as data_adapter
+	eval_pass with input as rule_input("--cert-file=</path/to/ca-file> --key-file=</path/to/key-file>")
 }
 
 test_not_evaluated {
-	not finding with input as test_data.process_input("some_process", []) with data.benchmark_data_adapter as data_adapter
+	not_eval with input as test_data.process_input("some_process", [])
 }
 
 rule_input(argument) = test_data.process_input("etcd", [argument])
+
+eval_fail {
+	test.assert_fail(finding) with data.benchmark_data_adapter as data_adapter
+}
+
+eval_pass {
+	test.assert_pass(finding) with data.benchmark_data_adapter as data_adapter
+}
+
+not_eval {
+	not finding with data.benchmark_data_adapter as data_adapter
+}

--- a/bundle/compliance/cis_k8s/rules/cis_2_2/test.rego
+++ b/bundle/compliance/cis_k8s/rules/cis_2_2/test.rego
@@ -4,25 +4,29 @@ import data.compliance.cis_k8s.data_adapter
 import data.kubernetes_common.test_data
 import data.lib.test
 
-violations {
-	test.assert_fail(finding) with input as rule_input("")
-	test.assert_fail(finding) with input as rule_input("--client-cert-auth=false")
-}
-
 test_violation {
-	violations with data.benchmark_data_adapter as data_adapter
-}
-
-passes {
-	test.assert_pass(finding) with input as rule_input("--client-cert-auth=true")
+	eval_fail with input as rule_input("")
+	eval_fail with input as rule_input("--client-cert-auth=false")
 }
 
 test_pass {
-	passes with data.benchmark_data_adapter as data_adapter
+	eval_pass with input as rule_input("--client-cert-auth=true")
 }
 
 test_not_evaluated {
-	not finding with input as test_data.process_input("some_process", []) with data.benchmark_data_adapter as data_adapter
+	not_eval with input as test_data.process_input("some_process", [])
 }
 
 rule_input(argument) = test_data.process_input("etcd", [argument])
+
+eval_fail {
+	test.assert_fail(finding) with data.benchmark_data_adapter as data_adapter
+}
+
+eval_pass {
+	test.assert_pass(finding) with data.benchmark_data_adapter as data_adapter
+}
+
+not_eval {
+	not finding with data.benchmark_data_adapter as data_adapter
+}

--- a/bundle/compliance/cis_k8s/rules/cis_2_3/test.rego
+++ b/bundle/compliance/cis_k8s/rules/cis_2_3/test.rego
@@ -4,25 +4,29 @@ import data.compliance.cis_k8s.data_adapter
 import data.kubernetes_common.test_data
 import data.lib.test
 
-violations {
-	test.assert_fail(finding) with input as rule_input("--auto-tls=true")
-}
-
 test_violation {
-	violations with data.benchmark_data_adapter as data_adapter
-}
-
-passes {
-	test.assert_pass(finding) with input as rule_input("")
-	test.assert_pass(finding) with input as rule_input("--auto-tls=false")
+	eval_fail with input as rule_input("--auto-tls=true")
 }
 
 test_pass {
-	passes with data.benchmark_data_adapter as data_adapter
+	eval_pass with input as rule_input("")
+	eval_pass with input as rule_input("--auto-tls=false")
 }
 
 test_not_evaluated {
-	not finding with input as test_data.process_input("some_process", []) with data.benchmark_data_adapter as data_adapter
+	not_eval with input as test_data.process_input("some_process", [])
 }
 
 rule_input(argument) = test_data.process_input("etcd", [argument])
+
+eval_fail {
+	test.assert_fail(finding) with data.benchmark_data_adapter as data_adapter
+}
+
+eval_pass {
+	test.assert_pass(finding) with data.benchmark_data_adapter as data_adapter
+}
+
+not_eval {
+	not finding with data.benchmark_data_adapter as data_adapter
+}

--- a/bundle/compliance/cis_k8s/rules/cis_2_4/test.rego
+++ b/bundle/compliance/cis_k8s/rules/cis_2_4/test.rego
@@ -4,26 +4,30 @@ import data.compliance.cis_k8s.data_adapter
 import data.kubernetes_common.test_data
 import data.lib.test
 
-violations {
-	test.assert_fail(finding) with input as rule_input([""])
-	test.assert_fail(finding) with input as rule_input(["--peer-cert-file=</path/to/peer-cert-file>"])
-	test.assert_fail(finding) with input as rule_input(["--peer-key-file=</path/to/peer-key-file>"])
-}
-
 test_violation {
-	violations with data.benchmark_data_adapter as data_adapter
-}
-
-passes {
-	test.assert_pass(finding) with input as rule_input(["--peer-cert-file=</path/to/peer-cert-file>", "--peer-key-file=</path/to/peer-key-file>"])
+	eval_fail with input as rule_input([""])
+	eval_fail with input as rule_input(["--peer-cert-file=</path/to/peer-cert-file>"])
+	eval_fail with input as rule_input(["--peer-key-file=</path/to/peer-key-file>"])
 }
 
 test_pass {
-	passes with data.benchmark_data_adapter as data_adapter
+	eval_pass with input as rule_input(["--peer-cert-file=</path/to/peer-cert-file>", "--peer-key-file=</path/to/peer-key-file>"])
 }
 
 test_not_evaluated {
-	not finding with input as test_data.process_input("some_process", [""]) with data.benchmark_data_adapter as data_adapter
+	not_eval with input as test_data.process_input("some_process", [""])
 }
 
 rule_input(argument) = test_data.process_input("etcd", argument)
+
+eval_fail {
+	test.assert_fail(finding) with data.benchmark_data_adapter as data_adapter
+}
+
+eval_pass {
+	test.assert_pass(finding) with data.benchmark_data_adapter as data_adapter
+}
+
+not_eval {
+	not finding with data.benchmark_data_adapter as data_adapter
+}

--- a/bundle/compliance/cis_k8s/rules/cis_2_5/test.rego
+++ b/bundle/compliance/cis_k8s/rules/cis_2_5/test.rego
@@ -4,25 +4,29 @@ import data.compliance.cis_k8s.data_adapter
 import data.kubernetes_common.test_data
 import data.lib.test
 
-violations {
-	test.assert_fail(finding) with input as rule_input("")
-	test.assert_fail(finding) with input as rule_input("--peer-client-cert-auth=false")
-}
-
 test_violation {
-	violations with data.benchmark_data_adapter as data_adapter
-}
-
-passes {
-	test.assert_pass(finding) with input as rule_input("--peer-client-cert-auth=true")
+	eval_fail with input as rule_input("")
+	eval_fail with input as rule_input("--peer-client-cert-auth=false")
 }
 
 test_pass {
-	passes with data.benchmark_data_adapter as data_adapter
+	eval_pass with input as rule_input("--peer-client-cert-auth=true")
 }
 
 test_not_evaluated {
-	not finding with input as test_data.process_input("some_process", []) with data.benchmark_data_adapter as data_adapter
+	not_eval with input as test_data.process_input("some_process", [])
 }
 
 rule_input(argument) = test_data.process_input("etcd", [argument])
+
+eval_fail {
+	test.assert_fail(finding) with data.benchmark_data_adapter as data_adapter
+}
+
+eval_pass {
+	test.assert_pass(finding) with data.benchmark_data_adapter as data_adapter
+}
+
+not_eval {
+	not finding with data.benchmark_data_adapter as data_adapter
+}

--- a/bundle/compliance/cis_k8s/rules/cis_2_6/test.rego
+++ b/bundle/compliance/cis_k8s/rules/cis_2_6/test.rego
@@ -4,25 +4,29 @@ import data.compliance.cis_k8s.data_adapter
 import data.kubernetes_common.test_data
 import data.lib.test
 
-violations {
-	test.assert_fail(finding) with input as rule_input("--peer-auto-tls=true")
-}
-
 test_violation {
-	violations with data.benchmark_data_adapter as data_adapter
-}
-
-passes {
-	test.assert_pass(finding) with input as rule_input("")
-	test.assert_pass(finding) with input as rule_input("-peer-auto-tls=false")
+	eval_fail with input as rule_input("--peer-auto-tls=true")
 }
 
 test_pass {
-	passes with data.benchmark_data_adapter as data_adapter
+	eval_pass with input as rule_input("")
+	eval_pass with input as rule_input("-peer-auto-tls=false")
 }
 
 test_not_evaluated {
-	not finding with input as test_data.process_input("some_process", []) with data.benchmark_data_adapter as data_adapter
+	not_eval with input as test_data.process_input("some_process", [])
 }
 
 rule_input(argument) = test_data.process_input("etcd", [argument])
+
+eval_fail {
+	test.assert_fail(finding) with data.benchmark_data_adapter as data_adapter
+}
+
+eval_pass {
+	test.assert_pass(finding) with data.benchmark_data_adapter as data_adapter
+}
+
+not_eval {
+	not finding with data.benchmark_data_adapter as data_adapter
+}

--- a/bundle/compliance/cis_k8s/rules/cis_4_2_1/test.rego
+++ b/bundle/compliance/cis_k8s/rules/cis_4_2_1/test.rego
@@ -4,31 +4,23 @@ import data.compliance.cis_k8s.data_adapter
 import data.kubernetes_common.test_data
 import data.lib.test
 
-violations {
-	test.assert_fail(finding) with input as rule_input("")
-	test.assert_fail(finding) with input as rule_input("--anonymous-auth=true")
-	test.assert_fail(finding) with input as rule_input_with_external("--anonymous-auth=true", create_process_config(true))
-	test.assert_fail(finding) with input as rule_input_with_external("--anonymous-auth=true", create_process_config(false))
-	test.assert_fail(finding) with input as rule_input_with_external("", create_process_config(true))
-}
-
 test_violation {
-	violations with data.benchmark_data_adapter as data_adapter
-}
-
-passes {
-	test.assert_pass(finding) with input as rule_input("--anonymous-auth=false")
-	test.assert_pass(finding) with input as rule_input_with_external("--anonymous-auth=false", create_process_config(true))
-	test.assert_pass(finding) with input as rule_input_with_external("--anonymous-auth=false", create_process_config(false))
-	test.assert_pass(finding) with input as rule_input_with_external("", create_process_config(false))
+	eval_fail with input as rule_input("")
+	eval_fail with input as rule_input("--anonymous-auth=true")
+	eval_fail with input as rule_input_with_external("--anonymous-auth=true", create_process_config(true))
+	eval_fail with input as rule_input_with_external("--anonymous-auth=true", create_process_config(false))
+	eval_fail with input as rule_input_with_external("", create_process_config(true))
 }
 
 test_pass {
-	passes with data.benchmark_data_adapter as data_adapter
+	eval_pass with input as rule_input("--anonymous-auth=false")
+	eval_pass with input as rule_input_with_external("--anonymous-auth=false", create_process_config(true))
+	eval_pass with input as rule_input_with_external("--anonymous-auth=false", create_process_config(false))
+	eval_pass with input as rule_input_with_external("", create_process_config(false))
 }
 
 test_not_evaluated {
-	not finding with input as test_data.process_input("some_process", []) with data.benchmark_data_adapter as data_adapter
+	not_eval with input as test_data.process_input("some_process", [])
 }
 
 rule_input(argument) = test_data.process_input_with_external_data("kubelet", [argument], {})
@@ -43,3 +35,15 @@ create_process_config(anonymous_enabled) = {"config": {"authentication": {
 		"enabled": true,
 	},
 }}}
+
+eval_fail {
+	test.assert_fail(finding) with data.benchmark_data_adapter as data_adapter
+}
+
+eval_pass {
+	test.assert_pass(finding) with data.benchmark_data_adapter as data_adapter
+}
+
+not_eval {
+	not finding with data.benchmark_data_adapter as data_adapter
+}

--- a/bundle/compliance/cis_k8s/rules/cis_4_2_10/test.rego
+++ b/bundle/compliance/cis_k8s/rules/cis_4_2_10/test.rego
@@ -4,28 +4,20 @@ import data.compliance.cis_k8s.data_adapter
 import data.kubernetes_common.test_data
 import data.lib.test
 
-violations {
-	test.assert_fail(finding) with input as rule_input("")
-	test.assert_fail(finding) with input as rule_input("--tls-cert-file=<path/to/tls-cert>")
-	test.assert_fail(finding) with input as rule_input("--tls-private-key-file=<path/to/tls-key>")
-}
-
 test_violation {
-	violations with data.benchmark_data_adapter as data_adapter
-}
-
-passes {
-	test.assert_pass(finding) with input as rule_input("--tls-private-key-file=<path/to/tls-key> --tls-cert-file=<path/to/tls-cert>")
-	test.assert_pass(finding) with input as rule_input_with_external("--tls-private-key-file=<path/to/tls-key> --tls-cert-file=<path/to/tls-cert>", create_process_config("<path/to/tls-key>", "<path/to/tls-cert>"))
-	test.assert_pass(finding) with input as rule_input_with_external("", create_process_config("<path/to/tls-key>", "<path/to/tls-cert>"))
+	eval_fail with input as rule_input("")
+	eval_fail with input as rule_input("--tls-cert-file=<path/to/tls-cert>")
+	eval_fail with input as rule_input("--tls-private-key-file=<path/to/tls-key>")
 }
 
 test_pass {
-	passes with data.benchmark_data_adapter as data_adapter
+	eval_pass with input as rule_input("--tls-private-key-file=<path/to/tls-key> --tls-cert-file=<path/to/tls-cert>")
+	eval_pass with input as rule_input_with_external("--tls-private-key-file=<path/to/tls-key> --tls-cert-file=<path/to/tls-cert>", create_process_config("<path/to/tls-key>", "<path/to/tls-cert>"))
+	eval_pass with input as rule_input_with_external("", create_process_config("<path/to/tls-key>", "<path/to/tls-cert>"))
 }
 
 test_not_evaluated {
-	not finding with input as test_data.process_input("some_process", [""]) with data.benchmark_data_adapter as data_adapter
+	not_eval with input as test_data.process_input("some_process", [""])
 }
 
 rule_input(argument) = test_data.process_input_with_external_data("kubelet", [argument], {})
@@ -33,3 +25,15 @@ rule_input(argument) = test_data.process_input_with_external_data("kubelet", [ar
 rule_input_with_external(argument, external_data) = test_data.process_input_with_external_data("kubelet", [argument], external_data)
 
 create_process_config(tlsCertFile, tlsPrivateKeyFile) = {"config": {"tlsCertFile": tlsCertFile, "tlsPrivateKeyFile": tlsPrivateKeyFile}}
+
+eval_fail {
+	test.assert_fail(finding) with data.benchmark_data_adapter as data_adapter
+}
+
+eval_pass {
+	test.assert_pass(finding) with data.benchmark_data_adapter as data_adapter
+}
+
+not_eval {
+	not finding with data.benchmark_data_adapter as data_adapter
+}

--- a/bundle/compliance/cis_k8s/rules/cis_4_2_11/test.rego
+++ b/bundle/compliance/cis_k8s/rules/cis_4_2_11/test.rego
@@ -4,30 +4,22 @@ import data.compliance.cis_k8s.data_adapter
 import data.kubernetes_common.test_data
 import data.lib.test
 
-violations {
-	test.assert_fail(finding) with input as rule_input("--rotate-certificates=false")
-	test.assert_fail(finding) with input as rule_input_with_external("", create_process_config(false))
-	test.assert_fail(finding) with input as rule_input_with_external("--rotate-certificates=false", create_process_config(true))
-}
-
 test_violation {
-	violations with data.benchmark_data_adapter as data_adapter
-}
-
-passes {
-	test.assert_pass(finding) with input as rule_input("")
-	test.assert_pass(finding) with input as rule_input("--rotate-certificates=true")
-	test.assert_pass(finding) with input as rule_input_with_external("--rotate-certificates=true", create_process_config(false))
-	test.assert_pass(finding) with input as rule_input_with_external("--rotate-certificates=true", create_process_config(true))
-	test.assert_pass(finding) with input as rule_input_with_external("", create_process_config(true))
+	eval_fail with input as rule_input("--rotate-certificates=false")
+	eval_fail with input as rule_input_with_external("", create_process_config(false))
+	eval_fail with input as rule_input_with_external("--rotate-certificates=false", create_process_config(true))
 }
 
 test_pass {
-	passes with data.benchmark_data_adapter as data_adapter
+	eval_pass with input as rule_input("")
+	eval_pass with input as rule_input("--rotate-certificates=true")
+	eval_pass with input as rule_input_with_external("--rotate-certificates=true", create_process_config(false))
+	eval_pass with input as rule_input_with_external("--rotate-certificates=true", create_process_config(true))
+	eval_pass with input as rule_input_with_external("", create_process_config(true))
 }
 
 test_not_evaluated {
-	not finding with input as test_data.process_input("some_process", []) with data.benchmark_data_adapter as data_adapter
+	not_eval with input as test_data.process_input("some_process", [])
 }
 
 rule_input(argument) = test_data.process_input("kubelet", [argument])
@@ -35,3 +27,15 @@ rule_input(argument) = test_data.process_input("kubelet", [argument])
 rule_input_with_external(argument, external_data) = test_data.process_input_with_external_data("kubelet", [argument], external_data)
 
 create_process_config(rotateCertificates) = {"config": {"rotateCertificates": rotateCertificates}}
+
+eval_fail {
+	test.assert_fail(finding) with data.benchmark_data_adapter as data_adapter
+}
+
+eval_pass {
+	test.assert_pass(finding) with data.benchmark_data_adapter as data_adapter
+}
+
+not_eval {
+	not finding with data.benchmark_data_adapter as data_adapter
+}

--- a/bundle/compliance/cis_k8s/rules/cis_4_2_12/test.rego
+++ b/bundle/compliance/cis_k8s/rules/cis_4_2_12/test.rego
@@ -4,37 +4,29 @@ import data.compliance.cis_k8s.data_adapter
 import data.kubernetes_common.test_data
 import data.lib.test
 
-violations {
-	test.assert_fail(finding) with input as rule_input("--feature-gates=RotateKubeletServerCertificate=false")
-	test.assert_fail(finding) with input as rule_input_with_external("--feature-gates=RotateKubeletServerCertificate=false", create_process_config(false, false))
-	test.assert_fail(finding) with input as rule_input_with_external("--feature-gates=RotateKubeletServerCertificate=false", create_process_config(true, false))
-	test.assert_fail(finding) with input as rule_input_with_external("--feature-gates=RotateKubeletServerCertificate=false", create_process_config(true, false))
-}
-
 test_violation {
-	violations with data.benchmark_data_adapter as data_adapter
-}
-
-passes {
-	test.assert_pass(finding) with input as rule_input("")
-	test.assert_pass(finding) with input as rule_input_with_external("", create_process_config(false, false))
-	test.assert_pass(finding) with input as rule_input("--feature-gates=RotateKubeletServerCertificate=true")
-	test.assert_pass(finding) with input as rule_input("--rotate-server-certificates=true")
-	test.assert_pass(finding) with input as rule_input_with_external("--feature-gates=RotateKubeletServerCertificate=true", create_process_config(true, false))
-	test.assert_pass(finding) with input as rule_input_with_external("--feature-gates=RotateKubeletServerCertificate=true", create_process_config(false, false))
-	test.assert_pass(finding) with input as rule_input_with_external("--feature-gates=RotateKubeletServerCertificate=true", create_process_config(false, true))
-	test.assert_pass(finding) with input as rule_input_with_external("--feature-gates=Rotate=true", create_process_config(true, false))
-	test.assert_pass(finding) with input as rule_input_with_external("", create_process_config(true, false))
-	test.assert_pass(finding) with input as rule_input_with_external("", create_process_config(false, true))
-	test.assert_pass(finding) with input as rule_input_with_external("", create_process_config(true, true))
+	eval_fail with input as rule_input("--feature-gates=RotateKubeletServerCertificate=false")
+	eval_fail with input as rule_input_with_external("--feature-gates=RotateKubeletServerCertificate=false", create_process_config(false, false))
+	eval_fail with input as rule_input_with_external("--feature-gates=RotateKubeletServerCertificate=false", create_process_config(true, false))
+	eval_fail with input as rule_input_with_external("--feature-gates=RotateKubeletServerCertificate=false", create_process_config(true, false))
 }
 
 test_pass {
-	passes with data.benchmark_data_adapter as data_adapter
+	eval_pass with input as rule_input("")
+	eval_pass with input as rule_input_with_external("", create_process_config(false, false))
+	eval_pass with input as rule_input("--feature-gates=RotateKubeletServerCertificate=true")
+	eval_pass with input as rule_input("--rotate-server-certificates=true")
+	eval_pass with input as rule_input_with_external("--feature-gates=RotateKubeletServerCertificate=true", create_process_config(true, false))
+	eval_pass with input as rule_input_with_external("--feature-gates=RotateKubeletServerCertificate=true", create_process_config(false, false))
+	eval_pass with input as rule_input_with_external("--feature-gates=RotateKubeletServerCertificate=true", create_process_config(false, true))
+	eval_pass with input as rule_input_with_external("--feature-gates=Rotate=true", create_process_config(true, false))
+	eval_pass with input as rule_input_with_external("", create_process_config(true, false))
+	eval_pass with input as rule_input_with_external("", create_process_config(false, true))
+	eval_pass with input as rule_input_with_external("", create_process_config(true, true))
 }
 
 test_not_evaluated {
-	not finding with input as test_data.process_input("some_process", []) with data.benchmark_data_adapter as data_adapter
+	not_eval with input as test_data.process_input("some_process", [])
 }
 
 rule_input(argument) = test_data.process_input("kubelet", [argument])
@@ -42,3 +34,15 @@ rule_input(argument) = test_data.process_input("kubelet", [argument])
 rule_input_with_external(argument, external_data) = test_data.process_input_with_external_data("kubelet", [argument], external_data)
 
 create_process_config(rotateCertificates, serverTLSBootstrap) = {"config": {"serverTLSBootstrap": serverTLSBootstrap, "featureGates": {"RotateKubeletServerCertificate": rotateCertificates}}}
+
+eval_fail {
+	test.assert_fail(finding) with data.benchmark_data_adapter as data_adapter
+}
+
+eval_pass {
+	test.assert_pass(finding) with data.benchmark_data_adapter as data_adapter
+}
+
+not_eval {
+	not finding with data.benchmark_data_adapter as data_adapter
+}

--- a/bundle/compliance/cis_k8s/rules/cis_4_2_13/test.rego
+++ b/bundle/compliance/cis_k8s/rules/cis_4_2_13/test.rego
@@ -4,32 +4,24 @@ import data.compliance.cis_k8s.data_adapter
 import data.kubernetes_common.test_data
 import data.lib.test
 
-violations {
-	test.assert_fail(finding) with input as rule_input("--tls-cipher-suites=SOME_CIPHER")
-	test.assert_fail(finding) with input as rule_input("--tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,SOME_CIPHER")
-	test.assert_fail(finding) with input as rule_input_with_external("", create_process_config(["SOME_CIPHER"]))
-	test.assert_fail(finding) with input as rule_input_with_external("", create_process_config(["TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,SOME_CIPHER", "SOME_CIPHER"]))
-}
-
 test_violation {
-	violations with data.benchmark_data_adapter as data_adapter
-}
-
-passes {
-	test.assert_pass(finding) with input as rule_input("")
-	test.assert_pass(finding) with input as rule_input("--tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256")
-	test.assert_pass(finding) with input as rule_input("--tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384")
-	test.assert_pass(finding) with input as rule_input("--tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384")
-	test.assert_pass(finding) with input as rule_input_with_external("", create_process_config(["TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"]))
-	test.assert_pass(finding) with input as rule_input_with_external("", create_process_config(["TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256", "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384"]))
+	eval_fail with input as rule_input("--tls-cipher-suites=SOME_CIPHER")
+	eval_fail with input as rule_input("--tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,SOME_CIPHER")
+	eval_fail with input as rule_input_with_external("", create_process_config(["SOME_CIPHER"]))
+	eval_fail with input as rule_input_with_external("", create_process_config(["TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,SOME_CIPHER", "SOME_CIPHER"]))
 }
 
 test_pass {
-	passes with data.benchmark_data_adapter as data_adapter
+	eval_pass with input as rule_input("")
+	eval_pass with input as rule_input("--tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256")
+	eval_pass with input as rule_input("--tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384")
+	eval_pass with input as rule_input("--tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384")
+	eval_pass with input as rule_input_with_external("", create_process_config(["TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"]))
+	eval_pass with input as rule_input_with_external("", create_process_config(["TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256", "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384"]))
 }
 
 test_not_evaluated {
-	not finding with input as test_data.process_input("some_process", []) with data.benchmark_data_adapter as data_adapter
+	not_eval with input as test_data.process_input("some_process", [])
 }
 
 rule_input(argument) = test_data.process_input("kubelet", [argument])
@@ -37,3 +29,15 @@ rule_input(argument) = test_data.process_input("kubelet", [argument])
 rule_input_with_external(argument, external_data) = test_data.process_input_with_external_data("kubelet", [argument], external_data)
 
 create_process_config(cipherSuites) = {"config": {"TLSCipherSuites": cipherSuites}}
+
+eval_fail {
+	test.assert_fail(finding) with data.benchmark_data_adapter as data_adapter
+}
+
+eval_pass {
+	test.assert_pass(finding) with data.benchmark_data_adapter as data_adapter
+}
+
+not_eval {
+	not finding with data.benchmark_data_adapter as data_adapter
+}

--- a/bundle/compliance/cis_k8s/rules/cis_4_2_2/test.rego
+++ b/bundle/compliance/cis_k8s/rules/cis_4_2_2/test.rego
@@ -4,29 +4,21 @@ import data.compliance.cis_k8s.data_adapter
 import data.kubernetes_common.test_data
 import data.lib.test
 
-violations {
-	test.assert_fail(finding) with input as rule_input("")
-	test.assert_fail(finding) with input as rule_input("--authorization-mode=AlwaysAllow")
-	test.assert_fail(finding) with input as rule_input_with_external("--authorization-mode=AlwaysAllow", create_process_config("AlwaysAllow"))
-	test.assert_fail(finding) with input as rule_input_with_external("", create_process_config("AlwaysAllow"))
-}
-
 test_violation {
-	violations with data.benchmark_data_adapter as data_adapter
-}
-
-passes {
-	test.assert_pass(finding) with input as rule_input("--authorization-mode=Webhook")
-	test.assert_pass(finding) with input as rule_input_with_external("--authorization-mode=Webhook", create_process_config("AlwaysAllow"))
-	test.assert_pass(finding) with input as rule_input_with_external("", create_process_config("Webhook"))
+	eval_fail with input as rule_input("")
+	eval_fail with input as rule_input("--authorization-mode=AlwaysAllow")
+	eval_fail with input as rule_input_with_external("--authorization-mode=AlwaysAllow", create_process_config("AlwaysAllow"))
+	eval_fail with input as rule_input_with_external("", create_process_config("AlwaysAllow"))
 }
 
 test_pass {
-	passes with data.benchmark_data_adapter as data_adapter
+	eval_pass with input as rule_input("--authorization-mode=Webhook")
+	eval_pass with input as rule_input_with_external("--authorization-mode=Webhook", create_process_config("AlwaysAllow"))
+	eval_pass with input as rule_input_with_external("", create_process_config("Webhook"))
 }
 
 test_not_evaluated {
-	not finding with input as test_data.process_input("some_process", []) with data.benchmark_data_adapter as data_adapter
+	not_eval with input as test_data.process_input("some_process", [])
 }
 
 rule_input(argument) = test_data.process_input("kubelet", [argument])
@@ -40,3 +32,15 @@ create_process_config(authz_mode) = {"config": {"authorization": {
 		"cacheUnauthorizedTTL": "0s",
 	},
 }}}
+
+eval_fail {
+	test.assert_fail(finding) with data.benchmark_data_adapter as data_adapter
+}
+
+eval_pass {
+	test.assert_pass(finding) with data.benchmark_data_adapter as data_adapter
+}
+
+not_eval {
+	not finding with data.benchmark_data_adapter as data_adapter
+}

--- a/bundle/compliance/cis_k8s/rules/cis_4_2_3/test.rego
+++ b/bundle/compliance/cis_k8s/rules/cis_4_2_3/test.rego
@@ -4,26 +4,18 @@ import data.compliance.cis_k8s.data_adapter
 import data.kubernetes_common.test_data
 import data.lib.test
 
-violations {
-	test.assert_fail(finding) with input as rule_input("")
-}
-
 test_violation {
-	violations with data.benchmark_data_adapter as data_adapter
-}
-
-passes {
-	test.assert_pass(finding) with input as rule_input("--client-ca-file=<path/to/client-ca-file>")
-	test.assert_pass(finding) with input as rule_input_with_external("--client-ca-file=<path/to/client-ca-file>", create_process_config("<path/to/client-ca-file>"))
-	test.assert_pass(finding) with input as rule_input_with_external("", create_process_config("<path/to/client-ca-file>"))
+	eval_fail with input as rule_input("")
 }
 
 test_pass {
-	passes with data.benchmark_data_adapter as data_adapter
+	eval_pass with input as rule_input("--client-ca-file=<path/to/client-ca-file>")
+	eval_pass with input as rule_input_with_external("--client-ca-file=<path/to/client-ca-file>", create_process_config("<path/to/client-ca-file>"))
+	eval_pass with input as rule_input_with_external("", create_process_config("<path/to/client-ca-file>"))
 }
 
 test_not_evaluated {
-	not finding with input as test_data.process_input("some_process", []) with data.benchmark_data_adapter as data_adapter
+	not_eval with input as test_data.process_input("some_process", [])
 }
 
 rule_input(argument) = test_data.process_input("kubelet", [argument])
@@ -38,3 +30,15 @@ create_process_config(client_CA_path) = {"config": {"authentication": {
 		"enabled": true,
 	},
 }}}
+
+eval_fail {
+	test.assert_fail(finding) with data.benchmark_data_adapter as data_adapter
+}
+
+eval_pass {
+	test.assert_pass(finding) with data.benchmark_data_adapter as data_adapter
+}
+
+not_eval {
+	not finding with data.benchmark_data_adapter as data_adapter
+}

--- a/bundle/compliance/cis_k8s/rules/cis_4_2_4/test.rego
+++ b/bundle/compliance/cis_k8s/rules/cis_4_2_4/test.rego
@@ -4,30 +4,22 @@ import data.compliance.cis_k8s.data_adapter
 import data.kubernetes_common.test_data
 import data.lib.test
 
-violations {
-	test.assert_fail(finding) with input as rule_input("")
-	test.assert_fail(finding) with input as rule_input("--read-only-port=10")
-	test.assert_fail(finding) with input as rule_input_with_external("--read-only-port=10", create_process_config(0))
-	test.assert_fail(finding) with input as rule_input_with_external("", create_process_config(10))
-}
-
 test_violation {
-	violations with data.benchmark_data_adapter as data_adapter
-}
-
-passes {
-	test.assert_pass(finding) with input as rule_input("--read-only-port=0")
-	test.assert_pass(finding) with input as rule_input_with_external("--read-only-port=0", create_process_config(10))
-	test.assert_pass(finding) with input as rule_input_with_external("--read-only-port=0", create_process_config(0))
-	test.assert_pass(finding) with input as rule_input_with_external("", create_process_config(0))
+	eval_fail with input as rule_input("")
+	eval_fail with input as rule_input("--read-only-port=10")
+	eval_fail with input as rule_input_with_external("--read-only-port=10", create_process_config(0))
+	eval_fail with input as rule_input_with_external("", create_process_config(10))
 }
 
 test_pass {
-	passes with data.benchmark_data_adapter as data_adapter
+	eval_pass with input as rule_input("--read-only-port=0")
+	eval_pass with input as rule_input_with_external("--read-only-port=0", create_process_config(10))
+	eval_pass with input as rule_input_with_external("--read-only-port=0", create_process_config(0))
+	eval_pass with input as rule_input_with_external("", create_process_config(0))
 }
 
 test_not_evaluated {
-	not finding with input as test_data.process_input("some_process", []) with data.benchmark_data_adapter as data_adapter
+	not_eval with input as test_data.process_input("some_process", [])
 }
 
 rule_input(argument) = test_data.process_input_with_external_data("kubelet", [argument], {})
@@ -35,3 +27,15 @@ rule_input(argument) = test_data.process_input_with_external_data("kubelet", [ar
 rule_input_with_external(argument, external_data) = test_data.process_input_with_external_data("kubelet", [argument], external_data)
 
 create_process_config(port) = {"config": {"readOnlyPort": port}}
+
+eval_fail {
+	test.assert_fail(finding) with data.benchmark_data_adapter as data_adapter
+}
+
+eval_pass {
+	test.assert_pass(finding) with data.benchmark_data_adapter as data_adapter
+}
+
+not_eval {
+	not finding with data.benchmark_data_adapter as data_adapter
+}

--- a/bundle/compliance/cis_k8s/rules/cis_4_2_5/test.rego
+++ b/bundle/compliance/cis_k8s/rules/cis_4_2_5/test.rego
@@ -4,31 +4,23 @@ import data.compliance.cis_k8s.data_adapter
 import data.kubernetes_common.test_data
 import data.lib.test
 
-violations {
-	test.assert_fail(finding) with input as rule_input("--streaming-connection-idle-timeout=0")
-	test.assert_fail(finding) with input as rule_input_with_external("--streaming-connection-idle-timeout=0", create_process_config(0))
-	test.assert_fail(finding) with input as rule_input_with_external("--streaming-connection-idle-timeout=0", create_process_config(10))
-	test.assert_fail(finding) with input as rule_input_with_external("", create_process_config(0))
-}
-
 test_violation {
-	violations with data.benchmark_data_adapter as data_adapter
-}
-
-passes {
-	test.assert_pass(finding) with input as rule_input("")
-	test.assert_pass(finding) with input as rule_input("--streaming-connection-idle-timeout=10")
-	test.assert_pass(finding) with input as rule_input_with_external("--streaming-connection-idle-timeout=10", create_process_config(0))
-	test.assert_pass(finding) with input as rule_input_with_external("--streaming-connection-idle-timeout=10", create_process_config(10))
-	test.assert_pass(finding) with input as rule_input_with_external("", create_process_config(10))
+	eval_fail with input as rule_input("--streaming-connection-idle-timeout=0")
+	eval_fail with input as rule_input_with_external("--streaming-connection-idle-timeout=0", create_process_config(0))
+	eval_fail with input as rule_input_with_external("--streaming-connection-idle-timeout=0", create_process_config(10))
+	eval_fail with input as rule_input_with_external("", create_process_config(0))
 }
 
 test_pass {
-	passes with data.benchmark_data_adapter as data_adapter
+	eval_pass with input as rule_input("")
+	eval_pass with input as rule_input("--streaming-connection-idle-timeout=10")
+	eval_pass with input as rule_input_with_external("--streaming-connection-idle-timeout=10", create_process_config(0))
+	eval_pass with input as rule_input_with_external("--streaming-connection-idle-timeout=10", create_process_config(10))
+	eval_pass with input as rule_input_with_external("", create_process_config(10))
 }
 
 test_not_evaluated {
-	not finding with input as test_data.process_input("some_process", []) with data.benchmark_data_adapter as data_adapter
+	not_eval with input as test_data.process_input("some_process", [])
 }
 
 rule_input(argument) = test_data.process_input_with_external_data("kubelet", [argument], {})
@@ -36,3 +28,15 @@ rule_input(argument) = test_data.process_input_with_external_data("kubelet", [ar
 rule_input_with_external(argument, external_data) = test_data.process_input_with_external_data("kubelet", [argument], external_data)
 
 create_process_config(connection_timeout) = {"config": {"streamingConnectionIdleTimeout": connection_timeout}}
+
+eval_fail {
+	test.assert_fail(finding) with data.benchmark_data_adapter as data_adapter
+}
+
+eval_pass {
+	test.assert_pass(finding) with data.benchmark_data_adapter as data_adapter
+}
+
+not_eval {
+	not finding with data.benchmark_data_adapter as data_adapter
+}

--- a/bundle/compliance/cis_k8s/rules/cis_4_2_6/test.rego
+++ b/bundle/compliance/cis_k8s/rules/cis_4_2_6/test.rego
@@ -4,29 +4,21 @@ import data.compliance.cis_k8s.data_adapter
 import data.kubernetes_common.test_data
 import data.lib.test
 
-violations {
-	test.assert_fail(finding) with input as rule_input("")
-	test.assert_fail(finding) with input as rule_input("--protect-kernel-defaults=false")
-	test.assert_fail(finding) with input as rule_input_with_external("--protect-kernel-defaults=false", create_process_config(true))
-}
-
 test_violation {
-	violations with data.benchmark_data_adapter as data_adapter
-}
-
-passes {
-	test.assert_pass(finding) with input as rule_input("--protect-kernel-defaults=true")
-	test.assert_pass(finding) with input as rule_input_with_external("--protect-kernel-defaults=true", create_process_config(false))
-	test.assert_pass(finding) with input as rule_input_with_external("--protect-kernel-defaults=true", create_process_config(false))
-	test.assert_pass(finding) with input as rule_input_with_external("", create_process_config(true))
+	eval_fail with input as rule_input("")
+	eval_fail with input as rule_input("--protect-kernel-defaults=false")
+	eval_fail with input as rule_input_with_external("--protect-kernel-defaults=false", create_process_config(true))
 }
 
 test_pass {
-	passes with data.benchmark_data_adapter as data_adapter
+	eval_pass with input as rule_input("--protect-kernel-defaults=true")
+	eval_pass with input as rule_input_with_external("--protect-kernel-defaults=true", create_process_config(false))
+	eval_pass with input as rule_input_with_external("--protect-kernel-defaults=true", create_process_config(false))
+	eval_pass with input as rule_input_with_external("", create_process_config(true))
 }
 
 test_not_evaluated {
-	not finding with input as test_data.process_input("some_process", []) with data.benchmark_data_adapter as data_adapter
+	not_eval with input as test_data.process_input("some_process", [])
 }
 
 rule_input(argument) = test_data.process_input("kubelet", [argument])
@@ -34,3 +26,15 @@ rule_input(argument) = test_data.process_input("kubelet", [argument])
 rule_input_with_external(argument, external_data) = test_data.process_input_with_external_data("kubelet", [argument], external_data)
 
 create_process_config(kernel_protection_enabled) = {"config": {"protectKernelDefaults": kernel_protection_enabled}}
+
+eval_fail {
+	test.assert_fail(finding) with data.benchmark_data_adapter as data_adapter
+}
+
+eval_pass {
+	test.assert_pass(finding) with data.benchmark_data_adapter as data_adapter
+}
+
+not_eval {
+	not finding with data.benchmark_data_adapter as data_adapter
+}

--- a/bundle/compliance/cis_k8s/rules/cis_4_2_7/test.rego
+++ b/bundle/compliance/cis_k8s/rules/cis_4_2_7/test.rego
@@ -4,30 +4,22 @@ import data.compliance.cis_k8s.data_adapter
 import data.kubernetes_common.test_data
 import data.lib.test
 
-violations {
-	test.assert_fail(finding) with input as rule_input("--make-iptables-util-chains=false")
-	test.assert_fail(finding) with input as rule_input_with_external("", create_process_config(false))
-	test.assert_fail(finding) with input as rule_input_with_external("--make-iptables-util-chains=false", create_process_config(true))
-}
-
 test_violation {
-	violations with data.benchmark_data_adapter as data_adapter
-}
-
-passes {
-	test.assert_pass(finding) with input as rule_input("")
-	test.assert_pass(finding) with input as rule_input("--make-iptables-util-chains=true")
-	test.assert_pass(finding) with input as rule_input_with_external("--make-iptables-util-chains=true", create_process_config(false))
-	test.assert_pass(finding) with input as rule_input_with_external("--make-iptables-util-chains=true", create_process_config(true))
-	test.assert_pass(finding) with input as rule_input_with_external("", create_process_config(true))
+	eval_fail with input as rule_input("--make-iptables-util-chains=false")
+	eval_fail with input as rule_input_with_external("", create_process_config(false))
+	eval_fail with input as rule_input_with_external("--make-iptables-util-chains=false", create_process_config(true))
 }
 
 test_pass {
-	passes with data.benchmark_data_adapter as data_adapter
+	eval_pass with input as rule_input("")
+	eval_pass with input as rule_input("--make-iptables-util-chains=true")
+	eval_pass with input as rule_input_with_external("--make-iptables-util-chains=true", create_process_config(false))
+	eval_pass with input as rule_input_with_external("--make-iptables-util-chains=true", create_process_config(true))
+	eval_pass with input as rule_input_with_external("", create_process_config(true))
 }
 
 test_not_evaluated {
-	not finding with input as test_data.process_input("some_process", []) with data.benchmark_data_adapter as data_adapter
+	not_eval with input as test_data.process_input("some_process", [])
 }
 
 rule_input(argument) = test_data.process_input("kubelet", [argument])
@@ -35,3 +27,15 @@ rule_input(argument) = test_data.process_input("kubelet", [argument])
 rule_input_with_external(argument, external_data) = test_data.process_input_with_external_data("kubelet", [argument], external_data)
 
 create_process_config(makeIPTablesUtilChains) = {"config": {"makeIPTablesUtilChains": makeIPTablesUtilChains}}
+
+eval_fail {
+	test.assert_fail(finding) with data.benchmark_data_adapter as data_adapter
+}
+
+eval_pass {
+	test.assert_pass(finding) with data.benchmark_data_adapter as data_adapter
+}
+
+not_eval {
+	not finding with data.benchmark_data_adapter as data_adapter
+}

--- a/bundle/compliance/cis_k8s/rules/cis_4_2_8/test.rego
+++ b/bundle/compliance/cis_k8s/rules/cis_4_2_8/test.rego
@@ -4,27 +4,31 @@ import data.compliance.cis_k8s.data_adapter
 import data.kubernetes_common.test_data
 import data.lib.test
 
-violations {
-	test.assert_fail(finding) with input as rule_input("--hostname-override=overide")
-}
-
 test_violation {
-	violations with data.benchmark_data_adapter as data_adapter
-}
-
-passes {
-	test.assert_pass(finding) with input as rule_input("--some-key=value")
-	test.assert_pass(finding) with input as rule_input("")
+	eval_fail with input as rule_input("--hostname-override=overide")
 }
 
 test_pass {
-	passes with data.benchmark_data_adapter as data_adapter
+	eval_pass with input as rule_input("--some-key=value")
+	eval_pass with input as rule_input("")
 }
 
 test_not_evaluated {
-	not finding with input as test_data.process_input("some_process", []) with data.benchmark_data_adapter as data_adapter
+	not_eval with input as test_data.process_input("some_process", [])
 }
 
 rule_input(argument) = test_data.process_input_with_external_data("kubelet", [argument], {})
 
 rule_input_with_external(argument, external_data) = test_data.process_input_with_external_data("kubelet", [argument], external_data)
+
+eval_fail {
+	test.assert_fail(finding) with data.benchmark_data_adapter as data_adapter
+}
+
+eval_pass {
+	test.assert_pass(finding) with data.benchmark_data_adapter as data_adapter
+}
+
+not_eval {
+	not finding with data.benchmark_data_adapter as data_adapter
+}

--- a/bundle/compliance/cis_k8s/rules/cis_4_2_9/test.rego
+++ b/bundle/compliance/cis_k8s/rules/cis_4_2_9/test.rego
@@ -4,31 +4,23 @@ import data.compliance.cis_k8s.data_adapter
 import data.kubernetes_common.test_data
 import data.lib.test
 
-violations {
-	test.assert_fail(finding) with input as rule_input("--event-qps=10")
-	test.assert_fail(finding) with input as rule_input_with_external("--event-qps=10", create_process_config(0))
-	test.assert_fail(finding) with input as rule_input_with_external("--event-qps=10", create_process_config(10))
-	test.assert_fail(finding) with input as rule_input_with_external("", create_process_config(10))
-	test.assert_fail(finding) with input as rule_input("")
-}
-
 test_violation {
-	violations with data.benchmark_data_adapter as data_adapter
-}
-
-passes {
-	test.assert_pass(finding) with input as rule_input("--event-qps=0")
-	test.assert_pass(finding) with input as rule_input_with_external("--event-qps=0", create_process_config(0))
-	test.assert_pass(finding) with input as rule_input_with_external("--event-qps=0", create_process_config(10))
-	test.assert_pass(finding) with input as rule_input_with_external("", create_process_config(0))
+	eval_fail with input as rule_input("--event-qps=10")
+	eval_fail with input as rule_input_with_external("--event-qps=10", create_process_config(0))
+	eval_fail with input as rule_input_with_external("--event-qps=10", create_process_config(10))
+	eval_fail with input as rule_input_with_external("", create_process_config(10))
+	eval_fail with input as rule_input("")
 }
 
 test_pass {
-	passes with data.benchmark_data_adapter as data_adapter
+	eval_pass with input as rule_input("--event-qps=0")
+	eval_pass with input as rule_input_with_external("--event-qps=0", create_process_config(0))
+	eval_pass with input as rule_input_with_external("--event-qps=0", create_process_config(10))
+	eval_pass with input as rule_input_with_external("", create_process_config(0))
 }
 
 test_not_evaluated {
-	not finding with input as test_data.process_input("some_process", []) with data.benchmark_data_adapter as data_adapter
+	not_eval with input as test_data.process_input("some_process", [])
 }
 
 rule_input(argument) = test_data.process_input_with_external_data("kubelet", [argument], {})
@@ -36,3 +28,15 @@ rule_input(argument) = test_data.process_input_with_external_data("kubelet", [ar
 rule_input_with_external(argument, external_data) = test_data.process_input_with_external_data("kubelet", [argument], external_data)
 
 create_process_config(eventRecordQPS) = {"config": {"eventRecordQPS": eventRecordQPS}}
+
+eval_fail {
+	test.assert_fail(finding) with data.benchmark_data_adapter as data_adapter
+}
+
+eval_pass {
+	test.assert_pass(finding) with data.benchmark_data_adapter as data_adapter
+}
+
+not_eval {
+	not finding with data.benchmark_data_adapter as data_adapter
+}

--- a/bundle/compliance/policy/process/ensure_appropriate_arguments.rego
+++ b/bundle/compliance/policy/process/ensure_appropriate_arguments.rego
@@ -4,7 +4,7 @@ import data.benchmark_data_adapter
 import data.compliance.lib.common as lib_common
 import data.compliance.policy.process.data_adapter
 
-process_args := data_adapter.process_args(benchmark_data_adapter.process_args_seperator)
+process_args := benchmark_data_adapter.process_args
 
 finding(entities) = result {
 	# set result

--- a/bundle/compliance/policy/process/ensure_arguments_and_config.rego
+++ b/bundle/compliance/policy/process/ensure_arguments_and_config.rego
@@ -4,7 +4,7 @@ import data.benchmark_data_adapter
 import data.compliance.lib.common as lib_common
 import data.compliance.policy.process.data_adapter
 
-process_args := data_adapter.process_args(benchmark_data_adapter.process_args_seperator)
+process_args := benchmark_data_adapter.process_args
 
 finding(rule_evaluation) = result {
 	data_adapter.is_kubelet

--- a/bundle/compliance/policy/process/ensure_arguments_contain_key.rego
+++ b/bundle/compliance/policy/process/ensure_arguments_contain_key.rego
@@ -5,7 +5,7 @@ import data.compliance.lib.assert
 import data.compliance.lib.common as lib_common
 import data.compliance.policy.process.data_adapter
 
-process_args := data_adapter.process_args(benchmark_data_adapter.process_args_seperator)
+process_args := benchmark_data_adapter.process_args
 
 finding(rule_evaluation) = result {
 	# set result

--- a/bundle/compliance/policy/process/ensure_arguments_contain_key_value.rego
+++ b/bundle/compliance/policy/process/ensure_arguments_contain_key_value.rego
@@ -5,7 +5,7 @@ import data.compliance.lib.assert
 import data.compliance.lib.common as lib_common
 import data.compliance.policy.process.data_adapter
 
-process_args := data_adapter.process_args(benchmark_data_adapter.process_args_seperator)
+process_args := benchmark_data_adapter.process_args
 
 finding(rule_evaluation) = result {
 	# set result

--- a/bundle/compliance/policy/process/ensure_arguments_contain_value.rego
+++ b/bundle/compliance/policy/process/ensure_arguments_contain_value.rego
@@ -6,7 +6,7 @@ import data.compliance.lib.common as lib_common
 import data.compliance.policy.process.common as process_common
 import data.compliance.policy.process.data_adapter
 
-process_args := data_adapter.process_args(benchmark_data_adapter.process_args_seperator)
+process_args := benchmark_data_adapter.process_args
 
 finding(rule_evaluation) = result {
 	data_adapter.is_kube_apiserver

--- a/bundle/compliance/policy/process/ensure_arguments_goe.rego
+++ b/bundle/compliance/policy/process/ensure_arguments_goe.rego
@@ -4,7 +4,7 @@ import data.benchmark_data_adapter
 import data.compliance.lib.common as lib_common
 import data.compliance.policy.process.data_adapter
 
-process_args := data_adapter.process_args(benchmark_data_adapter.process_args_seperator)
+process_args := benchmark_data_adapter.process_args
 
 finding(entity, value) = result {
 	data_adapter.is_kube_apiserver

--- a/bundle/compliance/policy/process/ensure_arguments_if_contain_equal.rego
+++ b/bundle/compliance/policy/process/ensure_arguments_if_contain_equal.rego
@@ -5,7 +5,7 @@ import data.compliance.lib.assert
 import data.compliance.lib.common as lib_common
 import data.compliance.policy.process.data_adapter
 
-process_args := data_adapter.process_args(benchmark_data_adapter.process_args_seperator)
+process_args := benchmark_data_adapter.process_args
 
 default rule_evaluation = false
 

--- a/bundle/compliance/policy/process/ensure_arguments_lte.rego
+++ b/bundle/compliance/policy/process/ensure_arguments_lte.rego
@@ -4,7 +4,7 @@ import data.benchmark_data_adapter
 import data.compliance.lib.common as lib_common
 import data.compliance.policy.process.data_adapter
 
-process_args := data_adapter.process_args(benchmark_data_adapter.process_args_seperator)
+process_args := benchmark_data_adapter.process_args
 
 finding(entity, value) = result {
 	data_adapter.is_kube_apiserver

--- a/bundle/compliance/policy/process/ensure_arguments_not_contain_multiple_values.rego
+++ b/bundle/compliance/policy/process/ensure_arguments_not_contain_multiple_values.rego
@@ -5,7 +5,7 @@ import data.compliance.lib.common as lib_common
 import data.compliance.policy.process.common as process_common
 import data.compliance.policy.process.data_adapter
 
-process_args := data_adapter.process_args(benchmark_data_adapter.process_args_seperator)
+process_args := benchmark_data_adapter.process_args
 
 default rule_evaluation = true
 

--- a/bundle/compliance/policy/process/ensure_arguments_not_contain_value_appropriate.rego
+++ b/bundle/compliance/policy/process/ensure_arguments_not_contain_value_appropriate.rego
@@ -5,7 +5,7 @@ import data.compliance.lib.common as lib_common
 import data.compliance.policy.process.common as process_common
 import data.compliance.policy.process.data_adapter
 
-process_args := data_adapter.process_args(benchmark_data_adapter.process_args_seperator)
+process_args := benchmark_data_adapter.process_args
 
 finding(entity, value) = result {
 	data_adapter.is_kube_apiserver

--- a/bundle/compliance/policy/process/ensure_ciphers.rego
+++ b/bundle/compliance/policy/process/ensure_ciphers.rego
@@ -4,7 +4,7 @@ import data.benchmark_data_adapter
 import data.compliance.lib.common as lib_common
 import data.compliance.policy.process.data_adapter
 
-process_args := data_adapter.process_args(benchmark_data_adapter.process_args_seperator)
+process_args := benchmark_data_adapter.process_args
 
 is_process_args_includes_non_supported_cipher(supported_ciphers) {
 	ciphers := split(process_args["--tls-cipher-suites"], ",")


### PR DESCRIPTION
Changed parsing logic of process arguments and improved evaluation time for process resources by ~3.23x (faster).
Prior to change:
```
    "timer_rego_query_eval_ns": 47741250
```
After the change:
```
    "timer_rego_query_eval_ns": 14774584
```

- https://github.com/elastic/csp-security-policies/issues/134