### PR TITLE
Rolling back OPA version to latest, besides fmt that fails on latest

### DIFF
--- a/.github/workflows/test-policies.yml
+++ b/.github/workflows/test-policies.yml
@@ -18,22 +18,22 @@ jobs:
           args: "fmt ./bundle --fail=true --diff"
 
       - name: OPA format list failed files
-        uses: docker://openpolicyagent/opa:0.45.0
+        uses: docker://openpolicyagent/opa
         if: always()
         with:
           args: "fmt ./bundle --list"
 
       - name: OPA build
-        uses: docker://openpolicyagent/opa:0.45.0
+        uses: docker://openpolicyagent/opa
         with:
           args: "build -b ./bundle -e ./bundle/compliance"
 
       - name: OPA test
-        uses: docker://openpolicyagent/opa:0.45.0
+        uses: docker://openpolicyagent/opa
         with:
           args: "test -b ./bundle -v"
 
       - name: OPA check -strict
-        uses: docker://openpolicyagent/opa:0.45.0
+        uses: docker://openpolicyagent/opa
         with:
           args: "check --strict --bundle ./bundle"


### PR DESCRIPTION
We've decided to roll back and still use OPA's latest version for all of the checks.
Only leave the fmt with the working last working version.