### PR TITLE
File evaluation performance improvement

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,13 +60,11 @@ should contain a beat/agent output and the `activated_rules` (not mandatory - wi
 {
   "type": "file",
   "activated_rules": {
-    "cis_k8s": [
-      "cis_1_1_1"
-    ]
+    "cis_k8s": ["cis_1_1_1"]
   },
   "sub_type": "file",
   "resource": {
-    "mode": "0700",
+    "mode": "700",
     "path": "/hostfs/etc/kubernetes/manifests/kube-apiserver.yaml",
     "owner": "etc",
     "group": "root",
@@ -97,7 +95,7 @@ opa eval data.main.findings --format pretty -i input.json -b ./bundle > output.j
   "result": {
     "evaluation": "failed",
     "evidence": {
-      "filemode": "0700"
+      "filemode": "700"
     },
     "expected": {
       "filemode": "644"
@@ -187,7 +185,7 @@ curl --location --request POST 'http://localhost:8181/v1/data/main' \
         "type": "file",
         "resource": {
             "type": "file",
-            "mode": "0700",
+            "mode": "700",
             "path": "/hostfs/etc/kubernetes/manifests/kube-apiserver.yaml",
             "uid": "etc",
             "name": "kube-apiserver.yaml",

--- a/bundle/compliance/cis_eks/rules/cis_3_1_1/test.rego
+++ b/bundle/compliance/cis_eks/rules/cis_3_1_1/test.rego
@@ -4,15 +4,15 @@ import data.kubernetes_common.test_data
 import data.lib.test
 
 test_violation {
-	test.assert_fail(finding) with input as rule_input("kubeconfig", "0700")
+	test.assert_fail(finding) with input as rule_input("kubeconfig", "700")
 }
 
 test_pass {
-	test.assert_pass(finding) with input as rule_input("kubeconfig", "0644")
+	test.assert_pass(finding) with input as rule_input("kubeconfig", "644")
 }
 
 test_not_evaluated {
-	not finding with input as rule_input("file.txt", "0644")
+	not finding with input as rule_input("file.txt", "644")
 }
 
 rule_input(filename, filemode) = filesystem_input {

--- a/bundle/compliance/cis_eks/rules/cis_3_1_2/test.rego
+++ b/bundle/compliance/cis_eks/rules/cis_3_1_2/test.rego
@@ -18,6 +18,6 @@ test_not_evaluated {
 }
 
 rule_input(filename, user, group) = filesystem_input {
-	filemode := "0644"
+	filemode := "644"
 	filesystem_input = test_data.filesystem_input(filename, filemode, user, group)
 }

--- a/bundle/compliance/cis_eks/rules/cis_3_1_3/test.rego
+++ b/bundle/compliance/cis_eks/rules/cis_3_1_3/test.rego
@@ -4,15 +4,15 @@ import data.kubernetes_common.test_data
 import data.lib.test
 
 test_violation {
-	test.assert_fail(finding) with input as rule_input("kubelet-config.json", "0700")
+	test.assert_fail(finding) with input as rule_input("kubelet-config.json", "700")
 }
 
 test_pass {
-	test.assert_pass(finding) with input as rule_input("kubelet-config.json", "0644")
+	test.assert_pass(finding) with input as rule_input("kubelet-config.json", "644")
 }
 
 test_not_evaluated {
-	not finding with input as rule_input("file.txt", "0644")
+	not finding with input as rule_input("file.txt", "644")
 }
 
 rule_input(filename, filemode) = filesystem_input {

--- a/bundle/compliance/cis_eks/rules/cis_3_1_4/test.rego
+++ b/bundle/compliance/cis_eks/rules/cis_3_1_4/test.rego
@@ -18,6 +18,6 @@ test_not_evaluated {
 }
 
 rule_input(filename, user, group) = filesystem_input {
-	filemode := "0644"
+	filemode := "644"
 	filesystem_input = test_data.filesystem_input(filename, filemode, user, group)
 }

--- a/bundle/compliance/cis_k8s/rules/cis_1_1_1/test.rego
+++ b/bundle/compliance/cis_k8s/rules/cis_1_1_1/test.rego
@@ -4,15 +4,15 @@ import data.kubernetes_common.test_data
 import data.lib.test
 
 test_violation {
-	test.assert_fail(finding) with input as rule_input("kube-apiserver.yaml", "0700")
+	test.assert_fail(finding) with input as rule_input("kube-apiserver.yaml", "700")
 }
 
 test_pass {
-	test.assert_pass(finding) with input as rule_input("kube-apiserver.yaml", "0644")
+	test.assert_pass(finding) with input as rule_input("kube-apiserver.yaml", "644")
 }
 
 test_not_evaluated {
-	not finding with input as rule_input("file.txt", "0644")
+	not finding with input as rule_input("file.txt", "644")
 }
 
 rule_input(filename, filemode) = filesystem_input {

--- a/bundle/compliance/cis_k8s/rules/cis_1_1_11/test.rego
+++ b/bundle/compliance/cis_k8s/rules/cis_1_1_11/test.rego
@@ -4,19 +4,19 @@ import data.kubernetes_common.test_data
 import data.lib.test
 
 test_violation {
-	test.assert_fail(finding) with input as rule_input("var/lib/etcd", "0710")
-	test.assert_fail(finding) with input as rule_input("var/lib/etcd/some_file.txt", "0710")
+	test.assert_fail(finding) with input as rule_input("var/lib/etcd", "710")
+	test.assert_fail(finding) with input as rule_input("var/lib/etcd/some_file.txt", "710")
 }
 
 test_pass {
-	test.assert_pass(finding) with input as rule_input("var/lib/etcd", "0600")
-	test.assert_pass(finding) with input as rule_input("var/lib/etcd/some_file.txt", "0600")
+	test.assert_pass(finding) with input as rule_input("var/lib/etcd", "600")
+	test.assert_pass(finding) with input as rule_input("var/lib/etcd/some_file.txt", "600")
 }
 
 test_not_evaluated {
-	not finding with input as rule_input("file.txt", "0644")
-	not finding with input as rule_input("var/lib/etcdd", "0710")
-	not finding with input as rule_input("var/lib/etcdd/some_file.txt", "0710")
+	not finding with input as rule_input("file.txt", "644")
+	not finding with input as rule_input("var/lib/etcdd", "710")
+	not finding with input as rule_input("var/lib/etcdd/some_file.txt", "710")
 }
 
 rule_input(filename, filemode) = filesystem_input {

--- a/bundle/compliance/cis_k8s/rules/cis_1_1_12/test.rego
+++ b/bundle/compliance/cis_k8s/rules/cis_1_1_12/test.rego
@@ -22,6 +22,6 @@ test_not_evaluated {
 }
 
 rule_input(filename, user, group) = filesystem_input {
-	filemode := "0644"
+	filemode := "644"
 	filesystem_input = test_data.filesystem_input(filename, filemode, user, group)
 }

--- a/bundle/compliance/cis_k8s/rules/cis_1_1_13/test.rego
+++ b/bundle/compliance/cis_k8s/rules/cis_1_1_13/test.rego
@@ -4,19 +4,19 @@ import data.kubernetes_common.test_data
 import data.lib.test
 
 test_violation {
-	test.assert_fail(finding) with input as rule_input("admin.conf", "0700")
+	test.assert_fail(finding) with input as rule_input("admin.conf", "700")
 }
 
 test_violation_too {
-	test.assert_fail(finding) with input as rule_input("admin.conf", "0644")
+	test.assert_fail(finding) with input as rule_input("admin.conf", "644")
 }
 
 test_pass {
-	test.assert_pass(finding) with input as rule_input("admin.conf", "0600")
+	test.assert_pass(finding) with input as rule_input("admin.conf", "600")
 }
 
 test_not_evaluated {
-	not finding with input as rule_input("file.txt", "0644")
+	not finding with input as rule_input("file.txt", "644")
 }
 
 rule_input(filename, filemode) = filesystem_input {

--- a/bundle/compliance/cis_k8s/rules/cis_1_1_14/test.rego
+++ b/bundle/compliance/cis_k8s/rules/cis_1_1_14/test.rego
@@ -18,6 +18,6 @@ test_not_evaluated {
 }
 
 rule_input(filename, user, group) = filesystem_input {
-	filemode := "0644"
+	filemode := "644"
 	filesystem_input = test_data.filesystem_input(filename, filemode, user, group)
 }

--- a/bundle/compliance/cis_k8s/rules/cis_1_1_15/test.rego
+++ b/bundle/compliance/cis_k8s/rules/cis_1_1_15/test.rego
@@ -4,15 +4,15 @@ import data.kubernetes_common.test_data
 import data.lib.test
 
 test_violation {
-	test.assert_fail(finding) with input as rule_input("scheduler.conf", "0700")
+	test.assert_fail(finding) with input as rule_input("scheduler.conf", "700")
 }
 
 test_pass {
-	test.assert_pass(finding) with input as rule_input("scheduler.conf", "0644")
+	test.assert_pass(finding) with input as rule_input("scheduler.conf", "644")
 }
 
 test_not_evaluated {
-	not finding with input as rule_input("file.txt", "0644")
+	not finding with input as rule_input("file.txt", "644")
 }
 
 rule_input(filename, filemode) = filesystem_input {

--- a/bundle/compliance/cis_k8s/rules/cis_1_1_16/test.rego
+++ b/bundle/compliance/cis_k8s/rules/cis_1_1_16/test.rego
@@ -18,6 +18,6 @@ test_not_evaluated {
 }
 
 rule_input(filename, user, group) = filesystem_input {
-	filemode := "0644"
+	filemode := "644"
 	filesystem_input = test_data.filesystem_input(filename, filemode, user, group)
 }

--- a/bundle/compliance/cis_k8s/rules/cis_1_1_17/test.rego
+++ b/bundle/compliance/cis_k8s/rules/cis_1_1_17/test.rego
@@ -4,15 +4,15 @@ import data.kubernetes_common.test_data
 import data.lib.test
 
 test_violation {
-	test.assert_fail(finding) with input as rule_input("controller-manager.conf", "0700")
+	test.assert_fail(finding) with input as rule_input("controller-manager.conf", "700")
 }
 
 test_pass {
-	test.assert_pass(finding) with input as rule_input("controller-manager.conf", "0644")
+	test.assert_pass(finding) with input as rule_input("controller-manager.conf", "644")
 }
 
 test_not_evaluated {
-	not finding with input as rule_input("file.txt", "0644")
+	not finding with input as rule_input("file.txt", "644")
 }
 
 rule_input(filename, filemode) = filesystem_input {

--- a/bundle/compliance/cis_k8s/rules/cis_1_1_18/test.rego
+++ b/bundle/compliance/cis_k8s/rules/cis_1_1_18/test.rego
@@ -18,6 +18,6 @@ test_not_evaluated {
 }
 
 rule_input(filename, user, group) = filesystem_input {
-	filemode := "0644"
+	filemode := "644"
 	filesystem_input = test_data.filesystem_input(filename, filemode, user, group)
 }

--- a/bundle/compliance/cis_k8s/rules/cis_1_1_19/test.rego
+++ b/bundle/compliance/cis_k8s/rules/cis_1_1_19/test.rego
@@ -22,6 +22,6 @@ test_not_evaluated {
 }
 
 rule_input(filename, user, group) = filesystem_input {
-	filemode := "0644"
+	filemode := "644"
 	filesystem_input = test_data.filesystem_input(filename, filemode, user, group)
 }

--- a/bundle/compliance/cis_k8s/rules/cis_1_1_2/test.rego
+++ b/bundle/compliance/cis_k8s/rules/cis_1_1_2/test.rego
@@ -18,6 +18,6 @@ test_not_evaluated {
 }
 
 rule_input(filename, user, group) = filesystem_input {
-	filemode := "0644"
+	filemode := "644"
 	filesystem_input = test_data.filesystem_input(filename, filemode, user, group)
 }

--- a/bundle/compliance/cis_k8s/rules/cis_1_1_20/test.rego
+++ b/bundle/compliance/cis_k8s/rules/cis_1_1_20/test.rego
@@ -4,15 +4,15 @@ import data.kubernetes_common.test_data
 import data.lib.test
 
 test_violation {
-	test.assert_fail(finding) with input as rule_input("/etc/kubernetes/pki/client.crt", "0700")
+	test.assert_fail(finding) with input as rule_input("/etc/kubernetes/pki/client.crt", "700")
 }
 
 test_pass {
-	test.assert_pass(finding) with input as rule_input("/etc/kubernetes/pki/client.crt", "0644")
+	test.assert_pass(finding) with input as rule_input("/etc/kubernetes/pki/client.crt", "644")
 }
 
 test_not_evaluated {
-	not finding with input as rule_input("/etc/kubernetes/pki/client.key", "0644")
+	not finding with input as rule_input("/etc/kubernetes/pki/client.key", "644")
 }
 
 rule_input(filename, filemode) = filesystem_input {

--- a/bundle/compliance/cis_k8s/rules/cis_1_1_21/test.rego
+++ b/bundle/compliance/cis_k8s/rules/cis_1_1_21/test.rego
@@ -4,15 +4,15 @@ import data.kubernetes_common.test_data
 import data.lib.test
 
 test_violation {
-	test.assert_fail(finding) with input as rule_input("/etc/kubernetes/pki/client.key", "0700")
+	test.assert_fail(finding) with input as rule_input("/etc/kubernetes/pki/client.key", "700")
 }
 
 test_pass {
-	test.assert_pass(finding) with input as rule_input("/etc/kubernetes/pki/client.key", "0600")
+	test.assert_pass(finding) with input as rule_input("/etc/kubernetes/pki/client.key", "600")
 }
 
 test_not_evaluated {
-	not finding with input as rule_input("/etc/kubernetes/pki/client.crt", "0600")
+	not finding with input as rule_input("/etc/kubernetes/pki/client.crt", "600")
 }
 
 rule_input(filename, filemode) = filesystem_input {

--- a/bundle/compliance/cis_k8s/rules/cis_1_1_3/test.rego
+++ b/bundle/compliance/cis_k8s/rules/cis_1_1_3/test.rego
@@ -4,15 +4,15 @@ import data.kubernetes_common.test_data
 import data.lib.test
 
 test_violation {
-	test.assert_fail(finding) with input as rule_input("kube-controller-manager.yaml", "0700")
+	test.assert_fail(finding) with input as rule_input("kube-controller-manager.yaml", "700")
 }
 
 test_pass {
-	test.assert_pass(finding) with input as rule_input("kube-controller-manager.yaml", "0644")
+	test.assert_pass(finding) with input as rule_input("kube-controller-manager.yaml", "644")
 }
 
 test_not_evaluated {
-	not finding with input as rule_input("file.txt", "0644")
+	not finding with input as rule_input("file.txt", "644")
 }
 
 rule_input(filename, filemode) = filesystem_input {

--- a/bundle/compliance/cis_k8s/rules/cis_1_1_4/test.rego
+++ b/bundle/compliance/cis_k8s/rules/cis_1_1_4/test.rego
@@ -18,6 +18,6 @@ test_not_evaluated {
 }
 
 rule_input(filename, user, group) = filesystem_input {
-	filemode := "0644"
+	filemode := "644"
 	filesystem_input = test_data.filesystem_input(filename, filemode, user, group)
 }

--- a/bundle/compliance/cis_k8s/rules/cis_1_1_5/test.rego
+++ b/bundle/compliance/cis_k8s/rules/cis_1_1_5/test.rego
@@ -4,15 +4,15 @@ import data.kubernetes_common.test_data
 import data.lib.test
 
 test_violation {
-	test.assert_fail(finding) with input as rule_input("kube-scheduler.yaml", "0700")
+	test.assert_fail(finding) with input as rule_input("kube-scheduler.yaml", "700")
 }
 
 test_pass {
-	test.assert_pass(finding) with input as rule_input("kube-scheduler.yaml", "0644")
+	test.assert_pass(finding) with input as rule_input("kube-scheduler.yaml", "644")
 }
 
 test_not_evaluated {
-	not finding with input as rule_input("file.txt", "0644")
+	not finding with input as rule_input("file.txt", "644")
 }
 
 rule_input(filename, filemode) = filesystem_input {

--- a/bundle/compliance/cis_k8s/rules/cis_1_1_6/test.rego
+++ b/bundle/compliance/cis_k8s/rules/cis_1_1_6/test.rego
@@ -18,6 +18,6 @@ test_not_evaluated {
 }
 
 rule_input(filename, user, group) = filesystem_input {
-	filemode := "0644"
+	filemode := "644"
 	filesystem_input = test_data.filesystem_input(filename, filemode, user, group)
 }

--- a/bundle/compliance/cis_k8s/rules/cis_1_1_7/test.rego
+++ b/bundle/compliance/cis_k8s/rules/cis_1_1_7/test.rego
@@ -4,15 +4,15 @@ import data.kubernetes_common.test_data
 import data.lib.test
 
 test_violation {
-	test.assert_fail(finding) with input as rule_input("etcd.yaml", "0700")
+	test.assert_fail(finding) with input as rule_input("etcd.yaml", "700")
 }
 
 test_pass {
-	test.assert_pass(finding) with input as rule_input("etcd.yaml", "0644")
+	test.assert_pass(finding) with input as rule_input("etcd.yaml", "644")
 }
 
 test_not_evaluated {
-	not finding with input as rule_input("file.txt", "0644")
+	not finding with input as rule_input("file.txt", "644")
 }
 
 rule_input(filename, filemode) = filesystem_input {

--- a/bundle/compliance/cis_k8s/rules/cis_1_1_8/test.rego
+++ b/bundle/compliance/cis_k8s/rules/cis_1_1_8/test.rego
@@ -18,6 +18,6 @@ test_not_evaluated {
 }
 
 rule_input(filename, user, group) = filesystem_input {
-	filemode := "0644"
+	filemode := "644"
 	filesystem_input = test_data.filesystem_input(filename, filemode, user, group)
 }

--- a/bundle/compliance/cis_k8s/rules/cis_4_1_1/test.rego
+++ b/bundle/compliance/cis_k8s/rules/cis_4_1_1/test.rego
@@ -4,15 +4,15 @@ import data.kubernetes_common.test_data
 import data.lib.test
 
 test_violation {
-	test.assert_fail(finding) with input as rule_input("10-kubeadm.conf", "0700")
+	test.assert_fail(finding) with input as rule_input("10-kubeadm.conf", "700")
 }
 
 test_pass {
-	test.assert_pass(finding) with input as rule_input("10-kubeadm.conf", "0644")
+	test.assert_pass(finding) with input as rule_input("10-kubeadm.conf", "644")
 }
 
 test_not_evaluated {
-	not finding with input as rule_input("file.txt", "0644")
+	not finding with input as rule_input("file.txt", "644")
 }
 
 rule_input(filename, filemode) = filesystem_input {

--- a/bundle/compliance/cis_k8s/rules/cis_4_1_10/test.rego
+++ b/bundle/compliance/cis_k8s/rules/cis_4_1_10/test.rego
@@ -18,6 +18,6 @@ test_not_evaluated {
 }
 
 rule_input(filename, user, group) = filesystem_input {
-	filemode := "0644"
+	filemode := "644"
 	filesystem_input = test_data.filesystem_input(filename, filemode, user, group)
 }

--- a/bundle/compliance/cis_k8s/rules/cis_4_1_2/test.rego
+++ b/bundle/compliance/cis_k8s/rules/cis_4_1_2/test.rego
@@ -18,6 +18,6 @@ test_not_evaluated {
 }
 
 rule_input(filename, user, group) = filesystem_input {
-	filemode := "0644"
+	filemode := "644"
 	filesystem_input = test_data.filesystem_input(filename, filemode, user, group)
 }

--- a/bundle/compliance/cis_k8s/rules/cis_4_1_5/test.rego
+++ b/bundle/compliance/cis_k8s/rules/cis_4_1_5/test.rego
@@ -4,15 +4,15 @@ import data.kubernetes_common.test_data
 import data.lib.test
 
 test_violation {
-	test.assert_fail(finding) with input as rule_input("kubelet.conf", "0700")
+	test.assert_fail(finding) with input as rule_input("kubelet.conf", "700")
 }
 
 test_pass {
-	test.assert_pass(finding) with input as rule_input("kubelet.conf", "0644")
+	test.assert_pass(finding) with input as rule_input("kubelet.conf", "644")
 }
 
 test_not_evaluated {
-	not finding with input as rule_input("file.txt", "0644")
+	not finding with input as rule_input("file.txt", "644")
 }
 
 rule_input(filename, filemode) = filesystem_input {

--- a/bundle/compliance/cis_k8s/rules/cis_4_1_6/test.rego
+++ b/bundle/compliance/cis_k8s/rules/cis_4_1_6/test.rego
@@ -18,6 +18,6 @@ test_not_evaluated {
 }
 
 rule_input(filename, user, group) = filesystem_input {
-	filemode := "0644"
+	filemode := "644"
 	filesystem_input = test_data.filesystem_input(filename, filemode, user, group)
 }

--- a/bundle/compliance/cis_k8s/rules/cis_4_1_9/test.rego
+++ b/bundle/compliance/cis_k8s/rules/cis_4_1_9/test.rego
@@ -4,15 +4,15 @@ import data.kubernetes_common.test_data
 import data.lib.test
 
 test_violation {
-	test.assert_fail(finding) with input as rule_input("config.yaml", "0700")
+	test.assert_fail(finding) with input as rule_input("config.yaml", "700")
 }
 
 test_pass {
-	test.assert_pass(finding) with input as rule_input("config.yaml", "0644")
+	test.assert_pass(finding) with input as rule_input("config.yaml", "644")
 }
 
 test_not_evaluated {
-	not finding with input as rule_input("file.txt", "0644")
+	not finding with input as rule_input("file.txt", "644")
 }
 
 rule_input(filename, filemode) = filesystem_input {

--- a/bundle/compliance/cis_k8s/schemas/input_schema.json
+++ b/bundle/compliance/cis_k8s/schemas/input_schema.json
@@ -9,7 +9,7 @@
     },
     {
       "type": "file",
-      "mode": "0700",
+      "mode": "700",
       "path": "/hostfs/etc/kubernetes/manifests/kube-apiserver.yaml",
       "owner": "root",
       "filename": "kube-apiserver.yaml",
@@ -25,10 +25,7 @@
           "command": "kube-apiserver --disable-admission-plugins=PodNodeSelector,NamespaceLifecycle"
         }
       ],
-      "required": [
-        "type",
-        "command"
-      ],
+      "required": ["type", "command"],
       "properties": {
         "type": {
           "type": "string",
@@ -50,21 +47,14 @@
       "examples": [
         {
           "type": "file",
-          "mode": "0700",
+          "mode": "700",
           "path": "/hostfs/etc/kubernetes/manifests/kube-apiserver.yaml",
           "owner": "root",
           "name": "kube-apiserver.yaml",
           "group": "root"
         }
       ],
-      "required": [
-        "type",
-        "mode",
-        "path",
-        "owner",
-        "name",
-        "group"
-      ],
+      "required": ["type", "mode", "path", "owner", "name", "group"],
       "properties": {
         "type": {
           "type": "string",
@@ -74,37 +64,27 @@
         "mode": {
           "type": "string",
           "title": "The mode schema",
-          "examples": [
-            "0700"
-          ]
+          "examples": ["700"]
         },
         "path": {
           "type": "string",
           "title": "The path schema",
-          "examples": [
-            "/hostfs/etc/kubernetes/manifests/kube-apiserver.yaml"
-          ]
+          "examples": ["/hostfs/etc/kubernetes/manifests/kube-apiserver.yaml"]
         },
         "owner": {
           "type": "string",
           "title": "The user schema",
-          "examples": [
-            "root"
-          ]
+          "examples": ["root"]
         },
         "name": {
           "type": "string",
           "title": "The filename schema",
-          "examples": [
-            "kube-apiserver.yaml"
-          ]
+          "examples": ["kube-apiserver.yaml"]
         },
         "group": {
           "type": "string",
           "title": "The group owner schema",
-          "examples": [
-            "root"
-          ]
+          "examples": ["root"]
         }
       }
     }

--- a/bundle/compliance/policy/file/common.rego
+++ b/bundle/compliance/policy/file/common.rego
@@ -22,7 +22,7 @@ file_permission_match_exact(filemode, user, group, other) {
 	permissions = parse_permission(filemode)
 
 	# filemode format {user}{group}{other} e.g. 644
-	check_permissions_exact(permissions, [user, group, other])
+	permissions == [user, group, other]
 } else = false {
 	true
 }
@@ -42,12 +42,6 @@ parse_permission(filemode) = permissions {
 
 check_permissions(permissions, max_permissions) {
 	assert.all_true([r | r = bits.and(permissions[p], bits.negate(max_permissions[p])) == 0])
-} else = false {
-	true
-}
-
-check_permissions_exact(permissions, target_permissions) {
-	assert.all_true([r | r = permissions[p] == target_permissions[p]])
 } else = false {
 	true
 }

--- a/bundle/compliance/policy/file/common.rego
+++ b/bundle/compliance/policy/file/common.rego
@@ -27,17 +27,10 @@ file_permission_match_exact(filemode, user, group, other) {
 	true
 }
 
-# in some os filemodes starts with 0 to indicate that the value is Octal (base 8)
-# remove prefix if needed, and return a list of file premission [user, group, other]
+# return a list of file premission [user, group, other]
 parse_permission(filemode) = permissions {
-	# if prefix exist we should start the substring from 1, else 0
-	start = count(filemode) - 3
-
-	# remove prefix (if needed) and split
-	str_permissions = split(substring(filemode, start, 3), "")
-
 	# cast to numbers
-	permissions := [to_number(p) | p = str_permissions[_]]
+	permissions := [to_number(p) | p = split(filemode, "")[_]]
 }
 
 check_permissions(permissions, max_permissions) {

--- a/bundle/compliance/policy/file/common_test.rego
+++ b/bundle/compliance/policy/file/common_test.rego
@@ -52,31 +52,12 @@ test_file_permission_match {
 	assert.all_true(results)
 }
 
-test_file_permission_match_octal {
-	users := [0, 1, 2, 3, 4, 5, 6, 7]
-	groups := [0, 1, 2, 3, 4, 5, 6, 7]
-	others := [0, 1, 2, 3, 4, 5, 6, 7]
-
-	# some file premission are in octal notation (prefix 0)
-	prefix_results := {file_permission_match(filemode, 7, 7, 7) | filemode := sprintf("0%d%d%d", [users[u], groups[g], others[o]])}
-	assert.all_true(prefix_results)
-}
-
 test_file_permission_match_user_mismatch {
 	max_users := [0, 1, 2, 3, 4, 5, 6]
 
 	filemode := "700"
 	results := {file_permission_match(filemode, max_users[u], 7, 7)}
 	assert.all_false(results)
-}
-
-test_file_permission_match_user_mismatch_octal {
-	max_users := [0, 1, 2, 3, 4, 5, 6]
-
-	# some file premission are in octal notation (prefix 0)
-	octal_filemode := "0700"
-	octal_results := {file_permission_match(octal_filemode, max_users[u], 7, 7)}
-	assert.all_false(octal_results)
 }
 
 test_file_permission_match_group_mismatch {
@@ -87,30 +68,12 @@ test_file_permission_match_group_mismatch {
 	assert.all_false(results)
 }
 
-test_file_permission_match_group_mismatch_octal {
-	max_groups := [0, 1, 2, 3, 4, 5, 6]
-
-	# some file premission are in octal notation (prefix 0)
-	octal_filemode := "0070"
-	octal_results := {file_permission_match(octal_filemode, 7, max_groups[g], 7)}
-	assert.all_false(octal_results)
-}
-
 test_file_permission_match_other_mismatch {
 	max_others := [0, 1, 2, 3, 4, 5, 6]
 
 	filemode := "007"
 	results := {file_permission_match(filemode, 7, 7, max_others[o])}
 	assert.all_false(results)
-}
-
-test_file_permission_match_other_mismatch_octal {
-	max_others := [0, 1, 2, 3, 4, 5, 6]
-
-	# some file premission are in octal notation (prefix 0)
-	octal_filemode := "0007"
-	octal_results := {file_permission_match(octal_filemode, 7, 7, max_others[o])}
-	assert.all_false(octal_results)
 }
 
 test_file_in_path {

--- a/bundle/compliance/policy/file/ensure_permissions.rego
+++ b/bundle/compliance/policy/file/ensure_permissions.rego
@@ -9,7 +9,7 @@ finding(rule_evaluation) := result {
 	result := lib_common.generate_result(
 		lib_common.calculate_result(rule_evaluation.evaluation),
 		{"filemode": rule_evaluation.mode},
-		{"filemode": ((rule_evaluation.user * 100) + (rule_evaluation.group * 10)) + rule_evaluation.other},
+		{"filemode": sprintf("%d%d%d", [rule_evaluation.user, rule_evaluation.group, rule_evaluation.other])},
 	)
 }
 


### PR DESCRIPTION
Improved evaluation time of `file` resource type.
Created a cycle of 100 evaluations in order to measure the improvement.

We had a code that parses octal values that is quite heavy.
Investigating the `cloudbeat` code, I saw that this scenario shouldn't happen in the supporting infrastructures and code flows.
Deployed `EKS` and `Kind` multiple node clusters and saw that the permission values are without the octal prefix as expected from my investigation.

Old `timer_rego_query_eval_ns`:
Average 11644097.55
Median 11546250
Largest 14063542
Smallest 10516459

New `timer_rego_query_eval_ns`:
Average 10758306.74
Median 10418125
Largest 13495917
Smallest 9423167

As you can see there is an improvement in all cases (worst case, best case, average, median).