### PR TITLE
remove `muted` and `enabled` properties from the csp_rule_template

### DIFF
--- a/cis_policies_generator/src/generateRuleTemplates.ts
+++ b/cis_policies_generator/src/generateRuleTemplates.ts
@@ -13,8 +13,6 @@ export const generateRuleTemplates = function (benchmark: string) {
       "utf-8"
     );
     const rule_obj = YAML.parse(exist_raw_rule).metadata;
-    rule_obj.enabled = true;
-    rule_obj.muted = false;
     rule_obj.rego_rule_id = rule;
 
     const integration_rule = migrateCspRuleMetadata({id: rule_obj.id, type: 'csp-rule-template', attributes: rule_obj});
@@ -33,12 +31,10 @@ export const generateRuleTemplates = function (benchmark: string) {
  * - introducing `metadata` field
  */
 function migrateCspRuleMetadata(doc: any): CspRuleTemplate {
-  const { enabled, muted, ...metadata } = doc.attributes;
+  const { ...metadata } = doc.attributes;
   return {
     ...doc,
     attributes: {
-      enabled,
-      muted,
       metadata: {
         ...metadata,
         impact: metadata.impact || undefined,

--- a/cis_policies_generator/src/types.d.ts
+++ b/cis_policies_generator/src/types.d.ts
@@ -86,8 +86,6 @@ interface CspRuleTemplate {
 }
 
 interface CspRuleTemplateAttr {
-    enabled: boolean;
-    muted: boolean;
     metadata: RuleSchema;
 }
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

### Summary of your changes
<!--
Please provide a detailed description of the changes introduced by this Pull Request.
Provide a description of the main changes, as well as any additional information the code reviewer should be aware of before beginning the review process.
-->
We would like to deprecate the state of the CSP-rule templates.
In order to do it, we would like to change the CSP-rule-template generator such that it won't create csp-template with either of its state fields (`muted` and `enabled`).

### Related Issues
<!--
- Related: https://github.com/elastic/kibana/issues/143524
-->

### Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary README/documentation (if appropriate)

> **Note** Make sure to bump cloudbeat `go.mod` after merging this PR.
