### PR TITLE
replace nan values with empty strings

### DIFF
--- a/.github/workflows/test-policies.yml
+++ b/.github/workflows/test-policies.yml
@@ -78,7 +78,7 @@ jobs:
           poetry install
 
       - name: Update rule metadata
-        run: poetry run python ./dev/update_rule_metadata.py
+        run: poetry run python ./dev/generate_rule_metadata.py
 
       - name: Rule metadata mismatch - to fix run our pre-commit hooks
         run: git diff --exit-code

--- a/.github/workflows/test-policies.yml
+++ b/.github/workflows/test-policies.yml
@@ -60,3 +60,25 @@ jobs:
 
       - name: Fail Rules.md is not updated - to fix run our pre-commit hooks
         run: git diff --exit-code
+
+  update-rule-metadata:
+    name: Update rule metadata
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+
+      - name: Install dependencies
+        run: |
+          pip install poetry
+          poetry install
+
+      - name: Update rule metadata
+        run: poetry run python ./dev/update_rule_metadata.py
+
+      - name: Rule metadata mismatch - to fix run our pre-commit hooks
+        run: git diff --exit-code

--- a/.github/workflows/test-policies.yml
+++ b/.github/workflows/test-policies.yml
@@ -62,7 +62,7 @@ jobs:
         run: git diff --exit-code
 
   update-rule-metadata:
-    name: Update rule metadata
+    name: Update rules metadata
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/bundle/compliance/cis_aws/rules/cis_1_10/data.yaml
+++ b/bundle/compliance/cis_aws/rules/cis_1_10/data.yaml
@@ -1,48 +1,35 @@
 metadata:
-  id: 28a5bba7-8585-5a49-91db-97ac5b2a838b
-  rule_number: 1.10
+  id: 918459ca-19ff-5d1f-9291-d1ba7964a140
   name: Ensure multi-factor authentication (MFA) is enabled for all IAM users that
     have a console password
-  profile_applicability: "* Level 1"
-  description: Multi-Factor Authentication (MFA) adds an extra layer of
-    authentication assurance beyond traditional credentials. With MFA enabled,
-    when a user signs in to the AWS Console, they will be prompted for their
-    user name and password as well as for an authentication code from their
-    physical or virtual MFA token. It is recommended that MFA be enabled for all
-    accounts that have a console password.
-  version: "1.0"
-  rationale: Enabling MFA provides increased security for console access as it
-    requires the authenticating principal to possess a device that displays a
-    time-sensitive key and have knowledge of a credential.
-  audit: >
-    Perform the following to determine if a MFA device is enabled for all IAM
-    users having a console password:
+  rule_number: '1.10'
+  profile_applicability: '* Level 1'
+  description: |-
+    Multi-Factor Authentication (MFA) adds an extra layer of authentication assurance beyond traditional credentials.
+    With MFA enabled, when a user signs in to the AWS Console, they will be prompted for their user name and password as well as for an authentication code from their physical or virtual MFA token.
+    It is recommended that MFA be enabled for all accounts that have a console password.
+  rationale: |-
+    Enabling MFA provides increased security for console access as it requires the authenticating principal to possess a device that displays a time-sensitive key and have knowledge of a credential.
+  audit: |-
+    Perform the following to determine if a MFA device is enabled for all IAM users having a console password:
 
     **From Console:**
 
     1. Open the IAM console at [https://console.aws.amazon.com/iam/](https://console.aws.amazon.com/iam/).
-
     2. In the left pane, select `Users` 
-
     3. If the `MFA` or `Password age` columns are not visible in the table, click the gear icon at the upper right corner of the table and ensure a checkmark is next to both, then click `Close`.
-
     4. Ensure that for each user where the `Password age` column shows a password age, the `MFA` column shows `Virtual`, `U2F Security Key`, or `Hardware`.
-
 
     **From Command Line:**
 
-    1. Run the following command (OSX/Linux/UNIX) to generate a list of all IAM users along with their password and MFA status:
-
+    5. Run the following command (OSX/Linux/UNIX) to generate a list of all IAM users along with their password and MFA status:
     ```
      aws iam generate-credential-report
     ```
-
     ```
      aws iam get-credential-report --query 'Content' --output text | base64 -d | cut -d, -f1,4,8 
     ```
-
-    2. The output of this command will produce a table similar to the following:
-
+    6. The output of this command will produce a table similar to the following:
     ```
      user,password_enabled,mfa_active
      elise,false,false
@@ -52,30 +39,26 @@ metadata:
      paras,true,true
      anitha,false,false 
     ```
-    
-    3. For any column having `password_enabled` set to `true` , ensure `mfa_active` is also set to `true.`
-  remediation: >
+    7. For any column having `password_enabled` set to `true` , ensure `mfa_active` is also set to `true.`
+  remediation: |-
     Perform the following to enable MFA:
 
     **From Console:**
 
     1. Sign in to the AWS Management Console and open the IAM console at 'https://console.aws.amazon.com/iam/'
-
     2. In the left pane, select `Users`.
-
     3. In the `User Name` list, choose the name of the intended MFA user.
-
     4. Choose the `Security Credentials` tab, and then choose `Manage MFA Device`.
-
     5. In the `Manage MFA Device wizard`, choose `Virtual MFA` device, and then choose `Continue`.
 
-     IAM generates and displays configuration information for the virtual MFA device, including a QR code graphic. The graphic is a representation of the 'secret configuration key' that is available for manual entry on devices that do not support QR codes.
+     IAM generates and displays configuration information for the virtual MFA device, including a QR code graphic.
+    The graphic is a representation of the 'secret configuration key' that is available for manual entry on devices that do not support QR codes.
 
     6. Open your virtual MFA application. (For a list of apps that you can use for hosting virtual MFA devices, see Virtual MFA Applications at https://aws.amazon.com/iam/details/mfa/#Virtual_MFA_Applications). If the virtual MFA application supports multiple accounts (multiple virtual MFA devices), choose the option to create a new account (a new virtual MFA device).
-
     7. Determine whether the MFA app supports QR codes, and then do one of the following:
 
-     - Use the app to scan the QR code. For example, you might choose the camera icon or choose an option similar to Scan code, and then use the device's camera to scan the code.
+     - Use the app to scan the QR code.
+    For example, you might choose the camera icon or choose an option similar to Scan code, and then use the device's camera to scan the code.
      - In the Manage MFA Device wizard, choose Show secret key for manual configuration, and then type the secret configuration key into your MFA application.
 
      When you are finished, the virtual MFA device starts generating one-time passwords.
@@ -83,22 +66,22 @@ metadata:
     8. In the `Manage MFA Device wizard`, in the `MFA Code 1 box`, type the `one-time password` that currently appears in the virtual MFA device. Wait up to 30 seconds for the device to generate a new one-time password. Then type the second `one-time password` into the `MFA Code 2 box`.
 
     9. Click `Assign MFA`.
-  impact: AWS will soon end support for SMS multi-factor authentication (MFA). New
-    customers are not allowed to use this feature. We recommend that existing
-    customers switch to one of the following alternative methods of MFA.
-  default_value: ""
-  references: |
-    - https://tools.ietf.org/html/rfc6238
-    - https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_mfa.html
-    - https://docs.aws.amazon.com/IAM/latest/UserGuide/best-practices.html#enable-mfa-for-privileged-users
-    - https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_mfa_enable_virtual.html
-    - https://blogs.aws.amazon.com/security/post/Tx2SJJYE082KBUK/How-to-Delegate-Management-of-Multi-Factor-Authentication-to-AWS-IAM-Users
-  tags:
-    - CIS
-    - AWS
-    - CIS 1.10
-    - Identity and Access Management
+  impact: |-
+    AWS will soon end support for SMS multi-factor authentication (MFA). New customers are not allowed to use this feature. We recommend that existing customers switch to one of the following alternative methods of MFA.
+  default_value: ''
+  references: |-
+    1. https://tools.ietf.org/html/rfc6238
+    2. https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_mfa.html
+    3. https://docs.aws.amazon.com/IAM/latest/UserGuide/best-practices.html#enable-mfa-for-privileged-users
+    4. https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_mfa_enable_virtual.html
+    5. https://blogs.aws.amazon.com/security/post/Tx2SJJYE082KBUK/How-to-Delegate-Management-of-Multi-Factor-Authentication-to-AWS-IAM-Users
   section: Identity and Access Management
+  version: '1.0'
+  tags:
+  - CIS
+  - AWS
+  - CIS 1.10
+  - Identity and Access Management
   benchmark:
     name: CIS Amazon Web Services Foundations
     version: v1.5.0

--- a/bundle/compliance/cis_aws/rules/cis_1_11/data.yaml
+++ b/bundle/compliance/cis_aws/rules/cis_1_11/data.yaml
@@ -1,60 +1,49 @@
 metadata:
-  id: 5adfb522-a144-5261-bee5-084295c1ec2e
-  rule_number: 1.11
+  id: 68d542ca-5524-5f53-b168-4622b51f7568
   name: Do not setup access keys during initial user setup for all IAM users that
     have a console password
-  profile_applicability: "* Level 1"
-  description: >-
-    AWS console defaults to no check boxes selected when creating a new
-    IAM user. When creating the IAM User credentials you have to determine what
-    type of access they require. 
+  rule_number: '1.11'
+  profile_applicability: '* Level 1'
+  description: |-
+    AWS console defaults to no check boxes selected when creating a new IAM user.
+    When cerating the IAM User credentials you have to determine what type of access they require.
 
-    Programmatic access: The IAM user might need to make API calls, use the AWS CLI, or use the Tools for Windows PowerShell. In that case, create an access key (access key ID and a secret access key) for that user. 
+
+    Programmatic access: The IAM user might need to make API calls, use the AWS CLI, or use the Tools for Windows PowerShell.
+    In that case, create an access key (access key ID and a secret access key) for that user.
+
+
     AWS Management Console access: If the user needs to access the AWS Management Console, create a password for the user.
-  version: "1.0"
-  rationale: >
-    Requiring the additional steps be taken by the user for programmatic
-    access after their profile has been created will give a stronger indication
-    of intent that access keys are [a] necessary for their work and [b] once the
-    access key is established on an account that the keys may be in use
-    somewhere in the organization.
+  rationale: |-
+    Requiring the additional steps be taken by the user for programmatic access after their profile has been created will give a stronger indication of intent that access keys are [a] necessary for their work and [b] once the access key is established on an account that the keys may be in use somewhere in the organization.
+
     **Note**: Even if it is known the user will need access keys, require them to create the keys themselves or put in a support ticket to have them created as a separate step from user creation.
-  audit: >
-    Perform the following to determine if access keys were created upon user
-    creation and are being used and rotated as prescribed:
+  audit: |-
+    Perform the following to determine if access keys were created upon user creation and are being used and rotated as prescribed:
 
     **From Console:**
 
     1. Login to the AWS Management Console
-
     2. Click `Services` 
-
     3. Click `IAM` 
-
     4. Click on a User where column `Password age` and `Access key age` is not set to `None`
-
     5. Click on `Security credentials` Tab
-
     6. Compare the user 'Creation time` to the Access Key `Created` date.
+    7. For any that match, the key was created during initial user setup.
 
-    6. For any that match, the key was created during initial user setup.
-
-    - Keys that were created at the same time as the user profile and do not have a last used date should be deleted. Refer to the remediation below.
+    - Keys that were created at the same time as the user profile and do not have a last used date should be deleted.
+    Refer to the remediation below.
 
     **From Command Line:**
 
-    1. Run the following command (OSX/Linux/UNIX) to generate a list of all IAM users along with their access keys utilization:
-
+    8. Run the following command (OSX/Linux/UNIX) to generate a list of all IAM users along with their access keys utilization:
     ```
      aws iam generate-credential-report
     ```
-
     ```
      aws iam get-credential-report --query 'Content' --output text | base64 -d | cut -d, -f1,4,9,11,14,16
     ```
-
-    2. The output of this command will produce a table similar to the following:
-
+    9. The output of this command will produce a table similar to the following:
     ```
     user,password_enabled,access_key_1_active,access_key_1_last_used_date,access_key_2_active,access_key_2_last_used_date
      elise,false,true,2015-04-16T15:14:00+00:00,false,N/A
@@ -64,47 +53,38 @@ metadata:
      paras,true,true,2016-08-28T12:04:00+00:00,true,2016-03-04T10:11:00+00:00
      anitha,true,true,2016-06-08T11:43:00+00:00,true,N/A 
     ```
-
-    3. For any user having `password_enabled` set to `true` AND `access_key_last_used_date` set to `N/A` refer to the remediation below.
-  remediation: >
-    Perform the following to delete access keys that do not pass the
-    audit:
+    10. For any user having `password_enabled` set to `true` AND `access_key_last_used_date` set to `N/A` refer to the remediation below.
+  remediation: |-
+    Perform the following to delete access keys that do not pass the audit:
 
     **From Console:**
 
     1. Login to the AWS Management Console:
-
     2. Click `Services` 
-
     3. Click `IAM` 
-
     4. Click on `Users` 
-
     5. Click on `Security Credentials` 
-
     6. As an Administrator 
      - Click on the X `(Delete)` for keys that were created at the same time as the user profile but have not been used.
     7. As an IAM User
      - Click on the X `(Delete)` for keys that were created at the same time as the user profile but have not been used.
 
     **From Command Line:**
-
     ```
-
     aws iam delete-access-key --access-key-id <access-key-id-listed> --user-name <users-name>
-
     ```
-  impact: ""
-  default_value: ""
-  references: |
-    - https://docs.aws.amazon.com/cli/latest/reference/iam/delete-access-key.html
-    - https://docs.aws.amazon.com/IAM/latest/UserGuide/id_users_create.html
-  tags:
-    - CIS
-    - AWS
-    - CIS 1.11
-    - Identity and Access Management
+  impact: ''
+  default_value: ''
+  references: |-
+    1. https://docs.aws.amazon.com/cli/latest/reference/iam/delete-access-key.html
+    2. https://docs.aws.amazon.com/IAM/latest/UserGuide/id_users_create.html
   section: Identity and Access Management
+  version: '1.0'
+  tags:
+  - CIS
+  - AWS
+  - CIS 1.11
+  - Identity and Access Management
   benchmark:
     name: CIS Amazon Web Services Foundations
     version: v1.5.0

--- a/bundle/compliance/cis_aws/rules/cis_1_12/data.yaml
+++ b/bundle/compliance/cis_aws/rules/cis_1_12/data.yaml
@@ -1,35 +1,25 @@
 metadata:
-  id: b31ed651-653a-5316-a647-a8abf036ab06
-  rule_number: 1.12
+  id: c21c1512-65e5-5831-9b94-2e2653ee84a4
   name: Ensure credentials unused for 45 days or greater are disabled
-  profile_applicability: "* Level 1"
-  description: AWS IAM users can access AWS resources using different types of
-    credentials, such as passwords or access keys. It is recommended that all
-    credentials that have been unused in 45 or greater days be deactivated or
-    removed.
-  version: "1.0"
-  rationale: Disabling or removing unnecessary credentials will reduce the window
-    of opportunity for credentials associated with a compromised or abandoned
-    account to be used.
-  audit: >
+  rule_number: '1.12'
+  profile_applicability: '* Level 1'
+  description: |-
+    AWS IAM users can access AWS resources using different types of credentials, such as passwords or access keys.
+    It is recommended that all credentials that have been unused in 45 or greater days be deactivated or removed.
+  rationale: |-
+    Disabling or removing unnecessary credentials will reduce the window of opportunity for credentials associated with a compromised or abandoned account to be used.
+  audit: |-
     Perform the following to determine if unused credentials exist:
 
     **From Console:**
 
     1. Login to the AWS Management Console
-
     2. Click `Services` 
-
     3. Click `IAM`
-
     4. Click on `Users`
-
     5. Click the `Settings` (gear) icon.
-
     6. Select `Console last sign-in`, `Access key last used`, and `Access Key Id`
-
     7. Click on `Close` 
-
     8. Check and ensure that `Console last sign-in` is less than 45 days ago.
 
     **Note** - `Never` means the user has never logged in.
@@ -39,13 +29,10 @@ metadata:
     If the user hasn't signed into the Console in the last 45 days or Access keys are over 45 days old refer to the remediation.
 
     **From Command Line:**
-    
 
     **Download Credential Report:**
 
-
-    1. Run the following commands:
-
+    10. Run the following commands:
     ```
      aws iam generate-credential-report
 
@@ -54,72 +41,54 @@ metadata:
 
     **Ensure unused credentials do not exist:**
 
-
-    2. For each user having `password_enabled` set to `TRUE` , ensure `password_last_used_date` is less than `45` days ago.
-
+    11. For each user having `password_enabled` set to `TRUE` , ensure `password_last_used_date` is less than `45` days ago.
 
     - When `password_enabled` is set to `TRUE` and `password_last_used` is set to `No_Information` , ensure `password_last_changed` is less than 45 days ago.
 
-
-    3. For each user having an `access_key_1_active` or `access_key_2_active` to `TRUE` , ensure the corresponding `access_key_n_last_used_date` is less than `45` days ago.
-
+    12. For each user having an `access_key_1_active` or `access_key_2_active` to `TRUE` , ensure the corresponding `access_key_n_last_used_date` is less than `45` days ago.
 
     - When a user having an `access_key_x_active` (where x is 1 or 2) to `TRUE` and corresponding access_key_x_last_used_date is set to `N/A', ensure `access_key_x_last_rotated` is less than 45 days ago.
-  remediation: >
+  remediation: |-
     **From Console:**
 
     Perform the following to manage Unused Password (IAM user console access)
 
     1. Login to the AWS Management Console:
-
     2. Click `Services` 
-
     3. Click `IAM` 
-
     4. Click on `Users` 
-
     5. Click on `Security Credentials` 
-
     6. Select user whose `Console last sign-in` is greater than 45 days
-
     7. Click `Security credentials`
-
     8. In section `Sign-in credentials`, `Console password` click `Manage` 
-
     9. Under Console Access select `Disable`
-
     10.Click `Apply`
-
 
     Perform the following to deactivate Access Keys:
 
-    1. Login to the AWS Management Console:
-
-    2. Click `Services` 
-
-    3. Click `IAM` 
-
-    4. Click on `Users` 
-
-    5. Click on `Security Credentials` 
-
-    6. Select any access keys that are over 45 days old and that have been used and 
+    11. Login to the AWS Management Console:
+    12. Click `Services` 
+    13. Click `IAM` 
+    14. Click on `Users` 
+    15. Click on `Security Credentials` 
+    16. Select any access keys that are over 45 days old and that have been used and 
      - Click on `Make Inactive`
-    7. Select any access keys that are over 45 days old and that have not been used and 
+    17. Select any access keys that are over 45 days old and that have not been used and 
      - Click the X to `Delete`
-  impact: ""
-  default_value: ""
-  references: |
-    - https://docs.aws.amazon.com/IAM/latest/UserGuide/best-practices.html#remove-credentials
-    - https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_finding-unused.html
-    - https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_passwords_admin-change-user.html
-    - https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html
-  tags:
-    - CIS
-    - AWS
-    - CIS 1.12
-    - Identity and Access Management
+  impact: ''
+  default_value: ''
+  references: |-
+    1. https://docs.aws.amazon.com/IAM/latest/UserGuide/best-practices.html#remove-credentials
+    2. https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_finding-unused.html
+    3. https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_passwords_admin-change-user.html
+    4. https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html
   section: Identity and Access Management
+  version: '1.0'
+  tags:
+  - CIS
+  - AWS
+  - CIS 1.12
+  - Identity and Access Management
   benchmark:
     name: CIS Amazon Web Services Foundations
     version: v1.5.0

--- a/bundle/compliance/cis_aws/rules/cis_1_13/data.yaml
+++ b/bundle/compliance/cis_aws/rules/cis_1_13/data.yaml
@@ -1,114 +1,86 @@
 metadata:
-  id: cd6925ae-743d-5525-a37a-65f4a8cd2cba
-  rule_number: 1.13
+  id: ab7e9325-5225-507b-bafc-d6650d216851
   name: Ensure there is only one active access key available for any single IAM user
-  profile_applicability: "* Level 1"
-  description: Access keys are long-term credentials for an IAM user or the AWS
-    account 'root' user. You can use access keys to sign programmatic requests
-    to the AWS CLI or AWS API (directly or using the AWS SDK)
-  version: "1.0"
-  rationale: Access keys are long-term credentials for an IAM user or the AWS
-    account 'root' user. You can use access keys to sign programmatic requests
-    to the AWS CLI or AWS API. One of the best ways to protect your account is
-    to not allow users to have multiple access keys.
-  audit: >
+  rule_number: '1.13'
+  profile_applicability: '* Level 1'
+  description: |-
+    Access keys are long-term credentials for an IAM user or the AWS account 'root' user.
+    You can use access keys to sign programmatic requests to the AWS CLI or AWS API (directly or using the AWS SDK)
+  rationale: |-
+    Access keys are long-term credentials for an IAM user or the AWS account 'root' user.
+    You can use access keys to sign programmatic requests to the AWS CLI or AWS API.
+    One of the best ways to protect your account is to not allow users to have multiple access keys.
+  audit: |-
     **From Console:**
 
     1. Sign in to the AWS Management Console and navigate to IAM dashboard at `https://console.aws.amazon.com/iam/`.
-
     2. In the left navigation panel, choose `Users`.
-
     3. Click on the IAM user name that you want to examine.
-
     4. On the IAM user configuration page, select `Security Credentials` tab.
-
     5. Under `Access Keys` section, in the Status column, check the current status for each access key associated with the IAM user. If the selected IAM user has more than one access key activated then the users access configuration does not adhere to security best practices and the risk of accidental exposures increases.
-
-    - Repeat steps no. 3 – 5 for each IAM user in your AWS account.
+    - Repeat steps no.
+    3 – 5 for each IAM user in your AWS account.
 
     **From Command Line:**
 
-
-    1. Run `list-users` command to list all IAM users within your account:
-
+    6. Run `list-users` command to list all IAM users within your account:
     ```
-
     aws iam list-users --query "Users[*].UserName"
-
     ```
-
     The command output should return an array that contains all your IAM user names.
 
-
-    2. Run `list-access-keys` command using the IAM user name list to return the current status of each access key associated with the selected IAM user:
-
+    7. Run `list-access-keys` command using the IAM user name list to return the current status of each access key associated with the selected IAM user:
     ```
-
     aws iam list-access-keys --user-name <user-name>
-
     ```
-
     The command output should expose the metadata `("Username", "AccessKeyId", "Status", "CreateDate")` for each access key on that user account.
 
+    8. Check the `Status` property value for each key returned to determine each keys current state. If the `Status` property value for more than one IAM access key is set to `Active`, the user access configuration does not adhere to this recommendation, refer to the remediation below.
 
-    3. Check the `Status` property value for each key returned to determine each keys current state. If the `Status` property value for more than one IAM access key is set to `Active`, the user access configuration does not adhere to this recommendation, refer to the remediation below.
-
-
-    - Repeat steps no. 2 and 3 for each IAM user in your AWS account.
-  remediation: >
+    - Repeat steps no.
+    2 and 3 for each IAM user in your AWS account.
+  remediation: |-
     **From Console:**
 
     1. Sign in to the AWS Management Console and navigate to IAM dashboard at `https://console.aws.amazon.com/iam/`.
-
     2. In the left navigation panel, choose `Users`.
-
     3. Click on the IAM user name that you want to examine.
-
     4. On the IAM user configuration page, select `Security Credentials` tab.
-
     5. In `Access Keys` section, choose one access key that is less than 90 days old. This should be the only active key used by this IAM user to access AWS resources programmatically. Test your application(s) to make sure that the chosen access key is working.
-
     6. In the same `Access Keys` section, identify your non-operational access keys (other than the chosen one) and deactivate it by clicking the `Make Inactive` link.
-
     7. If you receive the `Change Key Status` confirmation box, click `Deactivate` to switch off the selected key.
-
     8. Repeat steps no. 3 – 7 for each IAM user in your AWS account.
 
     **From Command Line:**
 
-    1. Using the IAM user and access key information provided in the `Audit CLI`, choose one access key that is less than 90 days old. This should be the only active key used by this IAM user to access AWS resources programmatically. Test your application(s) to make sure that the chosen access key is working.
+    9. Using the IAM user and access key information provided in the `Audit CLI`, choose one access key that is less than 90 days old. This should be the only active key used by this IAM user to access AWS resources programmatically. Test your application(s) to make sure that the chosen access key is working.
 
-
-    2. Run the `update-access-key` command below using the IAM user name and the non-operational access key IDs to deactivate the unnecessary key(s). Refer to the Audit section to identify the unnecessary access key ID for the selected IAM user
-
+    10. Run the `update-access-key` command below using the IAM user name and the non-operational access key IDs to deactivate the unnecessary key(s). Refer to the Audit section to identify the unnecessary access key ID for the selected IAM user
 
     **Note** - the command does not return any output:
-
     ```
     aws iam update-access-key --access-key-id <access-key-id> --status Inactive --user-name <user-name>
-
     ```
-    3. To confirm that the selected access key pair has been successfully `deactivated` run the `list-access-keys` audit command again for that IAM User:
-
+    11. To confirm that the selected access key pair has been successfully `deactivated` run the `list-access-keys` audit command again for that IAM User:
     ```
-
     aws iam list-access-keys --user-name <user-name>
-
     ```
-    - The command output should expose the metadata for each access key associated with the IAM user. If the non-operational key pair(s) `Status` is set to `Inactive`, the key has been successfully deactivated and the IAM user access configuration adheres now to this recommendation.
+    - The command output should expose the metadata for each access key associated with the IAM user.
+    If the non-operational key pair(s) `Status` is set to `Inactive`, the key has been successfully deactivated and the IAM user access configuration adheres now to this recommendation.
 
-    4. Repeat steps no. 1 – 3 for each IAM user in your AWS account.
-  impact: ""
-  default_value: ""
-  references: |
-    - https://docs.aws.amazon.com/general/latest/gr/aws-access-keys-best-practices.html
-    - https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html
-  tags:
-    - CIS
-    - AWS
-    - CIS 1.13
-    - Identity and Access Management
+    12. Repeat steps no. 1 – 3 for each IAM user in your AWS account.
+  impact: ''
+  default_value: ''
+  references: |-
+    1. https://docs.aws.amazon.com/general/latest/gr/aws-access-keys-best-practices.html
+    2. https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html
   section: Identity and Access Management
+  version: '1.0'
+  tags:
+  - CIS
+  - AWS
+  - CIS 1.13
+  - Identity and Access Management
   benchmark:
     name: CIS Amazon Web Services Foundations
     version: v1.5.0

--- a/bundle/compliance/cis_aws/rules/cis_1_14/data.yaml
+++ b/bundle/compliance/cis_aws/rules/cis_1_14/data.yaml
@@ -1,127 +1,92 @@
 metadata:
-  id: 716cf786-6d3b-5892-9f5b-06c9f2d985a5
-  rule_number: 1.14
+  id: fee5a5eb-0e97-5a20-aec0-eda1fd6b3580
   name: Ensure access keys are rotated every 90 days or less
-  profile_applicability: "* Level 1"
-  description: Access keys consist of an access key ID and secret access key,
-    which are used to sign programmatic requests that you make to AWS. AWS users
-    need their own access keys to make programmatic calls to AWS from the AWS
-    Command Line Interface (AWS CLI), Tools for Windows PowerShell, the AWS
-    SDKs, or direct HTTP calls using the APIs for individual AWS services. It is
-    recommended that all access keys be regularly rotated.
-  version: "1.0"
-  rationale: >
-    Rotating access keys will reduce the window of opportunity for an
-    access key that is associated with a compromised or terminated account to be
-    used.
+  rule_number: '1.14'
+  profile_applicability: '* Level 1'
+  description: |-
+    Access keys consist of an access key ID and secret access key, which are used to sign programmatic requests that you make to AWS.
+    AWS users need their own access keys to make programmatic calls to AWS from the AWS Command Line Interface (AWS CLI), Tools for Windows PowerShell, the AWS SDKs, or direct HTTP calls using the APIs for individual AWS services.
+    It is recommended that all access keys be regularly rotated.
+  rationale: |-
+    Rotating access keys will reduce the window of opportunity for an access key that is associated with a compromised or terminated account to be used.
 
     Access keys should be rotated to ensure that data cannot be accessed with an old key which might have been lost, cracked, or stolen.
-  audit: >
-    Perform the following to determine if access keys are rotated as
-    prescribed:
+  audit: |-
+    Perform the following to determine if access keys are rotated as prescribed:
 
     **From Console:**
 
     1. Go to Management Console (https://console.aws.amazon.com/iam)
-
     2. Click on `Users`
-
     3. Click `setting` icon
-
     4. Select `Console last sign-in`
-
     5. Click `Close`
-
     6. Ensure that `Access key age` is less than 90 days ago. note) `None` in the `Access key age` means the user has not used the access key.
 
     **From Command Line:**
 
     ```
-
     aws iam generate-credential-report
-
     aws iam get-credential-report --query 'Content' --output text | base64 -d
-
     ```
-
-    The `access_key_1_last_rotated` field in this file notes The date and time, in ISO 8601 date-time format, when the user's access key was created or last changed. If the user does not have an active access key, the value in this field is N/A (not applicable).
-  remediation: >
+    The `access_key_1_last_rotated` field in this file notes The date and time, in ISO 8601 date-time format, when the user's access key was created or last changed.
+    If the user does not have an active access key, the value in this field is N/A (not applicable).
+  remediation: |-
     Perform the following to rotate access keys:
 
     **From Console:**
 
     1. Go to Management Console (https://console.aws.amazon.com/iam)
-
     2. Click on `Users`
-
     3. Click on `Security Credentials` 
-
     4. As an Administrator 
      - Click on `Make Inactive` for keys that have not been rotated in `90` Days
     5. As an IAM User
      - Click on `Make Inactive` or `Delete` for keys which have not been rotated or used in `90` Days
     6. Click on `Create Access Key` 
-
     7. Update programmatic call with new Access Key credentials
-
 
     **From Command Line:**
 
-
-    1. While the first access key is still active, create a second access key, which is active by default. Run the following command:
-
+    8. While the first access key is still active, create a second access key, which is active by default. Run the following command:
     ```
-
     aws iam create-access-key
-
     ```
 
     At this point, the user has two active access keys.
 
-    2. Update all applications and tools to use the new access key.
-
-    3. Determine whether the first access key is still in use by using this command:
-
+    9. Update all applications and tools to use the new access key.
+    10. Determine whether the first access key is still in use by using this command:
     ```
-
     aws iam get-access-key-last-used
-
     ```
+    11. One approach is to wait several days and then check the old access key for any use before proceeding.
 
-    4. One approach is to wait several days and then check the old access key for any use before proceeding.
-
-
-    Even if step Step 3 indicates no use of the old key, it is recommended that you do not immediately delete the first access key. Instead, change the state of the first access key to Inactive using this command:
-
+    Even if step Step 3 indicates no use of the old key, it is recommended that you do not immediately delete the first access key.
+    Instead, change the state of the first access key to Inactive using this command:
     ```
-
     aws iam update-access-key
-
     ```
+    12. Use only the new access key to confirm that your applications are working. Any applications and tools that still use the original access key will stop working at this point because they no longer have access to AWS resources. If you find such an application or tool, you can switch its state back to Active to reenable the first access key. Then return to step Step 2 and update this application to use the new key.
 
-    5. Use only the new access key to confirm that your applications are working. Any applications and tools that still use the original access key will stop working at this point because they no longer have access to AWS resources. If you find such an application or tool, you can switch its state back to Active to reenable the first access key. Then return to step Step 2 and update this application to use the new key.
-
-
-    6. After you wait some period of time to ensure that all applications and tools have been updated, you can delete the first access key with this command:
-
+    13. After you wait some period of time to ensure that all applications and tools have been updated, you can delete the first access key with this command:
     ```
-
     aws iam delete-access-key
-
     ```
-  impact: ""
-  default_value: ""
-  references: |
-    - https://docs.aws.amazon.com/IAM/latest/UserGuide/best-practices.html#rotate-credentials
-    - https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_finding-unused.html
-    - https://docs.aws.amazon.com/general/latest/gr/managing-aws-access-keys.html
-    - https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html
-  tags:
-    - CIS
-    - AWS
-    - CIS 1.14
-    - Identity and Access Management
+  impact: ''
+  default_value: ''
+  references: |-
+    1. https://docs.aws.amazon.com/IAM/latest/UserGuide/best-practices.html#rotate-credentials
+    2. https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_finding-unused.html
+    3. https://docs.aws.amazon.com/general/latest/gr/managing-aws-access-keys.html
+    4. https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html
   section: Identity and Access Management
+  version: '1.0'
+  tags:
+  - CIS
+  - AWS
+  - CIS 1.14
+  - Identity and Access Management
   benchmark:
     name: CIS Amazon Web Services Foundations
     version: v1.5.0

--- a/bundle/compliance/cis_aws/rules/cis_1_8/data.yaml
+++ b/bundle/compliance/cis_aws/rules/cis_1_8/data.yaml
@@ -1,6 +1,6 @@
 metadata:
   id: 328079dd-6af7-5967-97cf-b6db063dd90f
-  name: Ensure IAM password policy requires minimum length of 14 or greater
+  name: Ensure IAM password policy requires minimum length of 14 or greater aaaaa
   rule_number: '1.8'
   profile_applicability: '* Level 1'
   description: |-

--- a/bundle/compliance/cis_aws/rules/cis_1_8/data.yaml
+++ b/bundle/compliance/cis_aws/rules/cis_1_8/data.yaml
@@ -40,7 +40,7 @@ metadata:
      aws iam update-account-password-policy --minimum-password-length 14
     ```
     Note: All commands starting with "aws iam update-account-password-policy" can be combined into a single command.
-  impact: None
+  impact: ''
   default_value: ''
   references: |-
     1. https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_passwords_account-policy.html
@@ -49,7 +49,7 @@ metadata:
   version: '1.0'
   tags:
   - CIS
-  - CIS_AWS
+  - AWS
   - CIS 1.8
   - Identity and Access Management
   benchmark:

--- a/bundle/compliance/cis_aws/rules/cis_1_8/data.yaml
+++ b/bundle/compliance/cis_aws/rules/cis_1_8/data.yaml
@@ -1,6 +1,6 @@
 metadata:
   id: 328079dd-6af7-5967-97cf-b6db063dd90f
-  name: Ensure IAM password policy requires minimum length of 14 or greater aaaaa
+  name: Ensure IAM password policy requires minimum length of 14 or greater
   rule_number: '1.8'
   profile_applicability: '* Level 1'
   description: |-

--- a/bundle/compliance/cis_aws/rules/cis_1_9/data.yaml
+++ b/bundle/compliance/cis_aws/rules/cis_1_9/data.yaml
@@ -40,7 +40,7 @@ metadata:
      aws iam update-account-password-policy --password-reuse-prevention 24
     ```
     Note: All commands starting with "aws iam update-account-password-policy" can be combined into a single command.
-  impact: None
+  impact: ''
   default_value: ''
   references: |-
     1. https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_passwords_account-policy.html
@@ -49,7 +49,7 @@ metadata:
   version: '1.0'
   tags:
   - CIS
-  - CIS_AWS
+  - AWS
   - CIS 1.9
   - Identity and Access Management
   benchmark:

--- a/bundle/compliance/cis_aws/rules/cis_5_1/data.yaml
+++ b/bundle/compliance/cis_aws/rules/cis_5_1/data.yaml
@@ -33,16 +33,16 @@ metadata:
      - Click `Edit inbound rules`
      - Either A) update the Source field to a range other than 0.0.0.0/0, or, B) Click `Delete` to remove the offending inbound rule
      - Click `Save`
-  impact: None
+  impact: ''
   default_value: ''
-  references:
-  - https://docs.aws.amazon.com/vpc/latest/userguide/vpc-network-acls.html
-  - https://docs.aws.amazon.com/vpc/latest/userguide/VPC_Security.html#VPC_Security_Comparison
+  references: |-
+    1. https://docs.aws.amazon.com/vpc/latest/userguide/vpc-network-acls.html
+    2. https://docs.aws.amazon.com/vpc/latest/userguide/VPC_Security.html#VPC_Security_Comparison
   section: Networking
   version: '1.0'
   tags:
   - CIS
-  - CIS_AWS
+  - AWS
   - CIS 5.1
   - Networking
   benchmark:

--- a/bundle/compliance/cis_eks/rules/cis_2_1_1/data.yaml
+++ b/bundle/compliance/cis_eks/rules/cis_2_1_1/data.yaml
@@ -60,7 +60,7 @@ metadata:
   version: '1.0'
   tags:
   - CIS
-  - CIS_EKS
+  - EKS
   - CIS 2.1.1
   - Logging
   benchmark:

--- a/bundle/compliance/cis_eks/rules/cis_3_1_1/data.yaml
+++ b/bundle/compliance/cis_eks/rules/cis_3_1_1/data.yaml
@@ -51,7 +51,7 @@ metadata:
   version: '1.0'
   tags:
   - CIS
-  - CIS_EKS
+  - EKS
   - CIS 3.1.1
   - Worker Node Configuration Files
   benchmark:

--- a/bundle/compliance/cis_eks/rules/cis_3_1_2/data.yaml
+++ b/bundle/compliance/cis_eks/rules/cis_3_1_2/data.yaml
@@ -48,7 +48,7 @@ metadata:
   version: '1.0'
   tags:
   - CIS
-  - CIS_EKS
+  - EKS
   - CIS 3.1.2
   - Worker Node Configuration Files
   benchmark:

--- a/bundle/compliance/cis_eks/rules/cis_3_1_3/data.yaml
+++ b/bundle/compliance/cis_eks/rules/cis_3_1_3/data.yaml
@@ -47,7 +47,7 @@ metadata:
   version: '1.0'
   tags:
   - CIS
-  - CIS_EKS
+  - EKS
   - CIS 3.1.3
   - Worker Node Configuration Files
   benchmark:

--- a/bundle/compliance/cis_eks/rules/cis_3_1_4/data.yaml
+++ b/bundle/compliance/cis_eks/rules/cis_3_1_4/data.yaml
@@ -46,7 +46,7 @@ metadata:
   version: '1.0'
   tags:
   - CIS
-  - CIS_EKS
+  - EKS
   - CIS 3.1.4
   - Worker Node Configuration Files
   benchmark:

--- a/bundle/compliance/cis_eks/rules/cis_3_2_1/data.yaml
+++ b/bundle/compliance/cis_eks/rules/cis_3_2_1/data.yaml
@@ -96,7 +96,7 @@ metadata:
   version: '1.0'
   tags:
   - CIS
-  - CIS_EKS
+  - EKS
   - CIS 3.2.1
   - Kubelet
   benchmark:

--- a/bundle/compliance/cis_eks/rules/cis_3_2_10/data.yaml
+++ b/bundle/compliance/cis_eks/rules/cis_3_2_10/data.yaml
@@ -64,7 +64,7 @@ metadata:
   version: '1.0'
   tags:
   - CIS
-  - CIS_EKS
+  - EKS
   - CIS 3.2.10
   - Kubelet
   benchmark:

--- a/bundle/compliance/cis_eks/rules/cis_3_2_11/data.yaml
+++ b/bundle/compliance/cis_eks/rules/cis_3_2_11/data.yaml
@@ -99,7 +99,7 @@ metadata:
   version: '1.0'
   tags:
   - CIS
-  - CIS_EKS
+  - EKS
   - CIS 3.2.11
   - Kubelet
   benchmark:

--- a/bundle/compliance/cis_eks/rules/cis_3_2_2/data.yaml
+++ b/bundle/compliance/cis_eks/rules/cis_3_2_2/data.yaml
@@ -98,7 +98,7 @@ metadata:
   version: '1.0'
   tags:
   - CIS
-  - CIS_EKS
+  - EKS
   - CIS 3.2.2
   - Kubelet
   benchmark:

--- a/bundle/compliance/cis_eks/rules/cis_3_2_3/data.yaml
+++ b/bundle/compliance/cis_eks/rules/cis_3_2_3/data.yaml
@@ -99,7 +99,7 @@ metadata:
   version: '1.0'
   tags:
   - CIS
-  - CIS_EKS
+  - EKS
   - CIS 3.2.3
   - Kubelet
   benchmark:

--- a/bundle/compliance/cis_eks/rules/cis_3_2_4/data.yaml
+++ b/bundle/compliance/cis_eks/rules/cis_3_2_4/data.yaml
@@ -58,7 +58,7 @@ metadata:
   version: '1.0'
   tags:
   - CIS
-  - CIS_EKS
+  - EKS
   - CIS 3.2.4
   - Kubelet
   benchmark:

--- a/bundle/compliance/cis_eks/rules/cis_3_2_5/data.yaml
+++ b/bundle/compliance/cis_eks/rules/cis_3_2_5/data.yaml
@@ -99,7 +99,7 @@ metadata:
   version: '1.0'
   tags:
   - CIS
-  - CIS_EKS
+  - EKS
   - CIS 3.2.5
   - Kubelet
   benchmark:

--- a/bundle/compliance/cis_eks/rules/cis_3_2_6/data.yaml
+++ b/bundle/compliance/cis_eks/rules/cis_3_2_6/data.yaml
@@ -98,7 +98,7 @@ metadata:
   version: '1.0'
   tags:
   - CIS
-  - CIS_EKS
+  - EKS
   - CIS 3.2.6
   - Kubelet
   benchmark:

--- a/bundle/compliance/cis_eks/rules/cis_3_2_7/data.yaml
+++ b/bundle/compliance/cis_eks/rules/cis_3_2_7/data.yaml
@@ -98,7 +98,7 @@ metadata:
   version: '1.0'
   tags:
   - CIS
-  - CIS_EKS
+  - EKS
   - CIS 3.2.7
   - Kubelet
   benchmark:

--- a/bundle/compliance/cis_eks/rules/cis_3_2_8/data.yaml
+++ b/bundle/compliance/cis_eks/rules/cis_3_2_8/data.yaml
@@ -67,7 +67,7 @@ metadata:
   version: '1.0'
   tags:
   - CIS
-  - CIS_EKS
+  - EKS
   - CIS 3.2.8
   - Kubelet
   benchmark:

--- a/bundle/compliance/cis_eks/rules/cis_3_2_9/data.yaml
+++ b/bundle/compliance/cis_eks/rules/cis_3_2_9/data.yaml
@@ -101,7 +101,7 @@ metadata:
   version: '1.0'
   tags:
   - CIS
-  - CIS_EKS
+  - EKS
   - CIS 3.2.9
   - Kubelet
   benchmark:

--- a/bundle/compliance/cis_eks/rules/cis_4_2_1/data.yaml
+++ b/bundle/compliance/cis_eks/rules/cis_4_2_1/data.yaml
@@ -80,7 +80,7 @@ metadata:
   version: '1.0'
   tags:
   - CIS
-  - CIS_EKS
+  - EKS
   - CIS 4.2.1
   - Pod Security Policies
   benchmark:

--- a/bundle/compliance/cis_eks/rules/cis_4_2_2/data.yaml
+++ b/bundle/compliance/cis_eks/rules/cis_4_2_2/data.yaml
@@ -38,7 +38,7 @@ metadata:
   version: '1.0'
   tags:
   - CIS
-  - CIS_EKS
+  - EKS
   - CIS 4.2.2
   - Pod Security Policies
   benchmark:

--- a/bundle/compliance/cis_eks/rules/cis_4_2_3/data.yaml
+++ b/bundle/compliance/cis_eks/rules/cis_4_2_3/data.yaml
@@ -36,7 +36,7 @@ metadata:
   version: '1.0'
   tags:
   - CIS
-  - CIS_EKS
+  - EKS
   - CIS 4.2.3
   - Pod Security Policies
   benchmark:

--- a/bundle/compliance/cis_eks/rules/cis_4_2_4/data.yaml
+++ b/bundle/compliance/cis_eks/rules/cis_4_2_4/data.yaml
@@ -36,7 +36,7 @@ metadata:
   version: '1.0'
   tags:
   - CIS
-  - CIS_EKS
+  - EKS
   - CIS 4.2.4
   - Pod Security Policies
   benchmark:

--- a/bundle/compliance/cis_eks/rules/cis_4_2_5/data.yaml
+++ b/bundle/compliance/cis_eks/rules/cis_4_2_5/data.yaml
@@ -38,7 +38,7 @@ metadata:
   version: '1.0'
   tags:
   - CIS
-  - CIS_EKS
+  - EKS
   - CIS 4.2.5
   - Pod Security Policies
   benchmark:

--- a/bundle/compliance/cis_eks/rules/cis_4_2_6/data.yaml
+++ b/bundle/compliance/cis_eks/rules/cis_4_2_6/data.yaml
@@ -38,7 +38,7 @@ metadata:
   version: '1.0'
   tags:
   - CIS
-  - CIS_EKS
+  - EKS
   - CIS 4.2.6
   - Pod Security Policies
   benchmark:

--- a/bundle/compliance/cis_eks/rules/cis_4_2_7/data.yaml
+++ b/bundle/compliance/cis_eks/rules/cis_4_2_7/data.yaml
@@ -41,7 +41,7 @@ metadata:
   version: '1.0'
   tags:
   - CIS
-  - CIS_EKS
+  - EKS
   - CIS 4.2.7
   - Pod Security Policies
   benchmark:

--- a/bundle/compliance/cis_eks/rules/cis_4_2_8/data.yaml
+++ b/bundle/compliance/cis_eks/rules/cis_4_2_8/data.yaml
@@ -33,7 +33,7 @@ metadata:
   version: '1.0'
   tags:
   - CIS
-  - CIS_EKS
+  - EKS
   - CIS 4.2.8
   - Pod Security Policies
   benchmark:

--- a/bundle/compliance/cis_eks/rules/cis_4_2_9/data.yaml
+++ b/bundle/compliance/cis_eks/rules/cis_4_2_9/data.yaml
@@ -34,7 +34,7 @@ metadata:
   version: '1.0'
   tags:
   - CIS
-  - CIS_EKS
+  - EKS
   - CIS 4.2.9
   - Pod Security Policies
   benchmark:

--- a/bundle/compliance/cis_eks/rules/cis_5_1_1/data.yaml
+++ b/bundle/compliance/cis_eks/rules/cis_5_1_1/data.yaml
@@ -53,7 +53,7 @@ metadata:
   version: '1.0'
   tags:
   - CIS
-  - CIS_EKS
+  - EKS
   - CIS 5.1.1
   - Image Registry and Image Scanning
   benchmark:

--- a/bundle/compliance/cis_eks/rules/cis_5_3_1/data.yaml
+++ b/bundle/compliance/cis_eks/rules/cis_5_3_1/data.yaml
@@ -28,7 +28,7 @@ metadata:
     ```
   remediation: |-
     Enable 'Secrets Encryption' during Amazon EKS cluster creation as described in the links within the 'References' section.
-  impact: None
+  impact: ''
   default_value: |
     By default, Application-layer Secrets Encryption is not enabled.
   references: |-
@@ -38,7 +38,7 @@ metadata:
   version: '1.0'
   tags:
   - CIS
-  - CIS_EKS
+  - EKS
   - CIS 5.3.1
   - AWS Key Management Service (KMS)
   benchmark:

--- a/bundle/compliance/cis_eks/rules/cis_5_4_1/data.yaml
+++ b/bundle/compliance/cis_eks/rules/cis_5_4_1/data.yaml
@@ -102,7 +102,7 @@ metadata:
   version: '1.0'
   tags:
   - CIS
-  - CIS_EKS
+  - EKS
   - CIS 5.4.1
   - Cluster Networking
   benchmark:

--- a/bundle/compliance/cis_eks/rules/cis_5_4_2/data.yaml
+++ b/bundle/compliance/cis_eks/rules/cis_5_4_2/data.yaml
@@ -16,8 +16,8 @@ metadata:
     Although Kubernetes API requires an authorized token to perform sensitive actions, a vulnerability could potentially expose the Kubernetes publically with unrestricted access.
     Additionally, an attacker may be able to identify the current cluster and Kubernetes API version and determine whether it is vulnerable to an attack.
     Unless required, disabling public endpoint will help prevent such threats, and require the attacker to be on the master's VPC network to perform any attack on the Kubernetes API.
-  audit: nan
-  remediation: nan
+  audit: ''
+  remediation: ''
   impact: |-
     Configure the EKS cluster endpoint to be private. See [Modifying Cluster Endpoint Access](https://docs.aws.amazon.com/eks/latest/userguide/cluster-endpoint.html) for further information on this topic.
 
@@ -31,7 +31,7 @@ metadata:
   version: '1.0'
   tags:
   - CIS
-  - CIS_EKS
+  - EKS
   - CIS 5.4.2
   - Cluster Networking
   benchmark:

--- a/bundle/compliance/cis_eks/rules/cis_5_4_3/data.yaml
+++ b/bundle/compliance/cis_eks/rules/cis_5_4_3/data.yaml
@@ -8,20 +8,20 @@ metadata:
     Private Nodes are nodes with no public IP addresses.
   rationale: |-
     Disabling public IP addresses on cluster nodes restricts access to only internal networks, forcing attackers to obtain local network access before attempting to compromise the underlying Kubernetes hosts.
-  audit: nan
-  remediation: nan
+  audit: ''
+  remediation: ''
   impact: |-
     To enable Private Nodes, the cluster has to also be configured with a private master IP range and IP Aliasing enabled.
 
     Private Nodes do not have outbound access to the public internet. If you want to provide outbound Internet access for your private nodes, you can use Cloud NAT or you can manage your own NAT gateway.
   default_value: |
     By default, Private Nodes are disabled.
-  references: 1. nan
+  references: ''
   section: Cluster Networking
   version: '1.0'
   tags:
   - CIS
-  - CIS_EKS
+  - EKS
   - CIS 5.4.3
   - Cluster Networking
   benchmark:

--- a/bundle/compliance/cis_eks/rules/cis_5_4_5/data.yaml
+++ b/bundle/compliance/cis_eks/rules/cis_5_4_5/data.yaml
@@ -6,16 +6,16 @@ metadata:
   description: Encrypt traffic to HTTPS load balancers using TLS certificates.
   rationale: |-
     Encrypting traffic between users and your Kubernetes workload is fundamental to protecting data sent over the web.
-  audit: nan
-  remediation: nan
-  impact: None
+  audit: ''
+  remediation: ''
+  impact: ''
   default_value: ''
   references: 1. https://docs.aws.amazon.com/elasticloadbalancing/latest/userguide/data-protection.html
   section: Cluster Networking
   version: '1.0'
   tags:
   - CIS
-  - CIS_EKS
+  - EKS
   - CIS 5.4.5
   - Cluster Networking
   benchmark:

--- a/bundle/compliance/cis_k8s/rules/cis_4_2_10/data.yaml
+++ b/bundle/compliance/cis_k8s/rules/cis_4_2_10/data.yaml
@@ -32,9 +32,9 @@ metadata:
     systemctl daemon-reload
     systemctl restart kubelet.service
     ```
-  impact: None
+  impact: ''
   default_value:
-  references: 1. nan
+  references: ''
   section: Kubelet
   version: '1.0'
   tags:

--- a/bundle/compliance/cis_k8s/rules/cis_4_2_13/data.yaml
+++ b/bundle/compliance/cis_k8s/rules/cis_4_2_13/data.yaml
@@ -52,7 +52,7 @@ metadata:
     Kubelet clients that cannot support modern cryptographic ciphers will not be able to make connections to the Kubelet API.
   default_value: |
     By default the Kubernetes API server supports a wide range of TLS ciphers
-  references: 1. nan
+  references: ''
   section: Kubelet
   version: '1.0'
   tags:

--- a/bundle/compliance/cis_k8s/rules/cis_5_1_3/data.yaml
+++ b/bundle/compliance/cis_k8s/rules/cis_5_1_3/data.yaml
@@ -26,9 +26,9 @@ metadata:
     ```
   remediation: |-
     Where possible replace any use of wildcards in clusterroles and roles with specific objects or actions.
-  impact: None
+  impact: ''
   default_value:
-  references: 1. nan
+  references: ''
   section: RBAC and Service Accounts
   version: '1.0'
   tags:

--- a/bundle/compliance/lib/common/common.rego
+++ b/bundle/compliance/lib/common/common.rego
@@ -1,9 +1,12 @@
 package compliance.lib.common
 
-metadata = {"opa_version": opa_version}
-
 # get OPA version
 opa_version := opa.runtime().version
+
+metadata = {
+	"opa_version": opa_version,
+	"policy_version": "1.0.0",
+}
 
 # set the rule result
 calculate_result(evaluation) = "passed" {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

### Summary of your changes

We missed more nan values in some fields and added a normalization function to replace all `nan` values with empty strings.
I've also added the metadata generator as part of the CI checks to ensure all PRs will have updated metadata (Some of the new rules didn't run the new script).

This is how it looks when there's a mismatch (added `aaaa` to the rule title):
<img width="1042" alt="image" src="https://user-images.githubusercontent.com/85433724/209851359-36eb91e2-056d-41ca-b31a-5e8f442103f2.png">

I've also tested this locally with cloudbeat and got everything as expected:
<img width="1310" alt="image" src="https://user-images.githubusercontent.com/85433724/209851461-92180430-4aee-4486-9b01-02986d46f9ae.png">
<img width="798" alt="image" src="https://user-images.githubusercontent.com/85433724/209851471-ef07bdf1-3a8c-41ad-bdc2-45933a81b172.png">


### Related Issues

- Related: https://github.com/elastic/csp-security-policies/issues/165

