### PR TITLE
Implement more AWS CIS S3 rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![CIS K8S](https://img.shields.io/badge/CIS-Kubernetes%20(74%25)-326CE5?logo=Kubernetes)](RULES.md#k8s-cis-benchmark)
 [![CIS EKS](https://img.shields.io/badge/CIS-Amazon%20EKS%20(60%25)-FF9900?logo=Amazon+EKS)](RULES.md#eks-cis-benchmark)
-[![CIS AWS](https://img.shields.io/badge/CIS-AWS%20(25%25)-232F3E?logo=Amazon+AWS)](RULES.md#aws-cis-benchmark)
+[![CIS AWS](https://img.shields.io/badge/CIS-AWS%20(29%25)-232F3E?logo=Amazon+AWS)](RULES.md#aws-cis-benchmark)
 
 ![Coverage Badge](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/oren-zohar/a7160df46e48dff45b24096de9302d38/raw/csp-security-policies_coverage.json)
 

--- a/RULES.md
+++ b/RULES.md
@@ -201,9 +201,9 @@
 
 ## AWS CIS Benchmark
 
-### 16/63 implemented rules (25%)
+### 18/63 implemented rules (29%)
 
-#### Automated rules: 16/55 (29%)
+#### Automated rules: 18/55 (33%)
 
 #### Manual rules: 0/8 (0%)
 
@@ -231,8 +231,8 @@
 |   [1.8](bundle/compliance/cis_aws/rules/cis_1_8)   | Identity and Access Management    | Ensure IAM password policy requires minimum length of 14 or greater                                                | :white_check_mark: | Automated |
 |   [1.9](bundle/compliance/cis_aws/rules/cis_1_9)   | Identity and Access Management    | Ensure IAM password policy prevents password reuse                                                                 | :white_check_mark: | Automated |
 | [2.1.1](bundle/compliance/cis_aws/rules/cis_2_1_1) | Simple Storage Service (S3)       | Ensure all S3 buckets employ encryption-at-rest                                                                    | :white_check_mark: | Automated |
-|                       2.1.2                        | Simple Storage Service (S3)       | Ensure S3 Bucket Policy is set to deny HTTP requests                                                               |        :x:         | Automated |
-|                       2.1.3                        | Simple Storage Service (S3)       | Ensure MFA Delete is enabled on S3 buckets                                                                         |        :x:         | Automated |
+| [2.1.2](bundle/compliance/cis_aws/rules/cis_2_1_2) | Simple Storage Service (S3)       | Ensure S3 Bucket Policy is set to deny HTTP requests                                                               | :white_check_mark: | Automated |
+| [2.1.3](bundle/compliance/cis_aws/rules/cis_2_1_3) | Simple Storage Service (S3)       | Ensure MFA Delete is enabled on S3 buckets                                                                         | :white_check_mark: | Automated |
 |                       2.1.4                        | Simple Storage Service (S3)       | Ensure all data in Amazon S3 has been discovered, classified and secured when required.                            |        :x:         |  Manual   |
 |                       2.1.5                        | Simple Storage Service (S3)       | Ensure that S3 Buckets are configured with 'Block public access (bucket settings)'                                 |        :x:         | Automated |
 |                       2.2.1                        | Elastic Compute Cloud (EC2)       | Ensure EBS Volume Encryption is Enabled in all Regions                                                             |        :x:         | Automated |

--- a/bundle/compliance/cis_aws/rules/cis_2_1_2/data.yaml
+++ b/bundle/compliance/cis_aws/rules/cis_2_1_2/data.yaml
@@ -1,0 +1,135 @@
+metadata:
+  id: ece0af5a-5d66-5032-b16e-2c6547079d5a
+  name: Ensure S3 Bucket Policy is set to deny HTTP requests
+  rule_number: 2.1.2
+  profile_applicability: '* Level 2'
+  description: |-
+    At the Amazon S3 bucket level, you can configure permissions through a bucket policy making the objects accessible only through HTTPS.
+  rationale: |-
+    By default, Amazon S3 allows both HTTP and HTTPS requests.
+    To achieve only allowing access to Amazon S3 objects through HTTPS you also have to explicitly deny access to HTTP requests.
+    Bucket policies that allow HTTPS requests without explicitly denying HTTP requests will not comply with this recommendation.
+  audit: |-
+    To allow access to HTTPS you can use a condition that checks for the key `"aws:SecureTransport: true"`.
+    This means that the request is sent through HTTPS but that HTTP can still be used.
+    So to make sure you do not allow HTTP access confirm that there is a bucket policy that explicitly denies access for HTTP requests and that it contains the key "aws:SecureTransport": "false".
+
+    **From Console:**
+
+    1. Login to AWS Management Console and open the Amazon S3 console using https://console.aws.amazon.com/s3/
+    2. Select the Check box next to the Bucket.
+    3. Click on 'Permissions', then Click on `Bucket Policy`.
+    4. Ensure that a policy is listed that matches:
+    ```
+    '{
+     "Sid": <optional>,
+     "Effect": "Deny",
+     "Principal": "*",
+     "Action": "s3:*",
+     "Resource": "arn:aws:s3:::<bucket_name>/*",
+     "Condition": {
+     "Bool": {
+     "aws:SecureTransport": "false"
+     }'
+    ```
+    `<optional>` and `<bucket_name>` will be specific to your account
+
+    5. Repeat for all the buckets in your AWS account.
+
+    **From Command Line:**
+
+    6. List all of the S3 Buckets 
+    ```
+    aws s3 ls
+    ```
+    7. Using the list of buckets run this command on each of them:
+    ```
+    aws s3api get-bucket-policy --bucket <bucket_name> | grep aws:SecureTransport
+    ```
+    8. Confirm that `aws:SecureTransport` is set to false `aws:SecureTransport:false`
+    9. Confirm that the policy line has Effect set to Deny 'Effect:Deny'
+  remediation: |-
+    **From Console:**
+
+    1. Login to AWS Management Console and open the Amazon S3 console using https://console.aws.amazon.com/s3/
+    2. Select the Check box next to the Bucket.
+    3. Click on 'Permissions'.
+    4. Click 'Bucket Policy'
+    5. Add this to the existing policy filling in the required information
+    ```
+    {
+     "Sid": <optional>",
+     "Effect": "Deny",
+     "Principal": "*",
+     "Action": "s3:*",
+     "Resource": "arn:aws:s3:::<bucket_name>/*",
+     "Condition": {
+     "Bool": {
+     "aws:SecureTransport": "false"
+     }
+     }
+     }
+    ```
+    6. Save
+    7. Repeat for all the buckets in your AWS account that contain sensitive data.
+
+    **From Console** 
+
+    using AWS Policy Generator:
+
+    8. Repeat steps 1-4 above.
+    9. Click on `Policy Generator` at the bottom of the Bucket Policy Editor
+    10. Select Policy Type
+    `S3 Bucket Policy`
+    11. Add Statements
+    - `Effect` = Deny
+    - `Principal` = *
+    - `AWS Service` = Amazon S3
+    - `Actions` = *
+    - `Amazon Resource Name` = <ARN of the S3 Bucket>
+    12. Generate Policy
+    13. Copy the text and add it to the Bucket Policy.
+
+    **From Command Line:**
+
+    14. Export the bucket policy to a json file.
+    ```
+    aws s3api get-bucket-policy --bucket <bucket_name> --query Policy --output text > policy.json
+    ```
+
+    15. Modify the policy.json file by adding in this statement:
+    ```
+    {
+     "Sid": <optional>",
+     "Effect": "Deny",
+     "Principal": "*",
+     "Action": "s3:*",
+     "Resource": "arn:aws:s3:::<bucket_name>/*",
+     "Condition": {
+     "Bool": {
+     "aws:SecureTransport": "false"
+     }
+     }
+     }
+    ```
+    16. Apply this modified policy back to the S3 bucket:
+    ```
+    aws s3api put-bucket-policy --bucket <bucket_name> --policy file://policy.json
+    ```
+  impact: ''
+  default_value: ''
+  references: |-
+    1. https://aws.amazon.com/premiumsupport/knowledge-center/s3-bucket-policy-for-config-rule/
+    2. https://aws.amazon.com/blogs/security/how-to-use-bucket-policies-and-apply-defense-in-depth-to-help-secure-your-amazon-s3-data/
+    3. https://awscli.amazonaws.com/v2/documentation/api/latest/reference/s3api/get-bucket-policy.html
+  section: Simple Storage Service (S3)
+  version: '1.0'
+  tags:
+  - CIS
+  - AWS
+  - CIS 2.1.2
+  - Simple Storage Service (S3)
+  benchmark:
+    name: CIS Amazon Web Services Foundations
+    version: v1.5.0
+    id: cis_aws

--- a/bundle/compliance/cis_aws/rules/cis_2_1_2/rule.rego
+++ b/bundle/compliance/cis_aws/rules/cis_2_1_2/rule.rego
@@ -1,0 +1,5 @@
+package compliance.cis_aws.rules.cis_2_1_2
+
+import data.compliance.policy.aws_s3.ensure_bucket_policy_deny_http as audit
+
+finding = audit.finding

--- a/bundle/compliance/cis_aws/rules/cis_2_1_2/test.rego
+++ b/bundle/compliance/cis_aws/rules/cis_2_1_2/test.rego
@@ -1,0 +1,35 @@
+package compliance.cis_aws.rules.cis_2_1_2
+
+import data.cis_aws.test_data
+import data.compliance.cis_aws.data_adapter
+import data.lib.test
+
+test_violation {
+	eval_fail with input as test_data.generate_s3_bucket("Bucket", "", null, null)
+	eval_fail with input as rule_input("Deny", "*", "s3:*", "true")
+	eval_fail with input as rule_input("Deny", "*", "wrong", "false")
+	eval_fail with input as rule_input("Deny", "wrong", "s3:*", "false")
+	eval_fail with input as rule_input("Allow", "*", "s3:*", "false")
+}
+
+test_pass {
+	eval_pass with input as rule_input("Deny", "*", "s3:*", "false")
+}
+
+test_not_evaluated {
+	not_eval with input as test_data.not_evaluated_s3_bucket
+}
+
+rule_input(effect, principal, action, is_secure_transport) = test_data.generate_s3_bucket("Bucket", "", test_data.generate_s3_bucket_policy_statement(effect, principal, action, is_secure_transport), null)
+
+eval_fail {
+	test.assert_fail(finding) with data.benchmark_data_adapter as data_adapter
+}
+
+eval_pass {
+	test.assert_pass(finding) with data.benchmark_data_adapter as data_adapter
+}
+
+not_eval {
+	not finding with data.benchmark_data_adapter as data_adapter
+}

--- a/bundle/compliance/cis_aws/rules/cis_2_1_3/data.yaml
+++ b/bundle/compliance/cis_aws/rules/cis_2_1_3/data.yaml
@@ -1,0 +1,73 @@
+metadata:
+  id: 50732c73-5ea9-5cea-af10-7c2cde7b3fa3
+  name: Ensure MFA Delete is enabled on S3 buckets
+  rule_number: 2.1.3
+  profile_applicability: '* Level 1'
+  description: |-
+    Once MFA Delete is enabled on your sensitive and classified S3 bucket it requires the user to have two forms of authentication.
+  rationale: |-
+    Adding MFA delete to an S3 bucket, requires additional authentication when you change the version state of your bucket or you delete and object version adding another layer of security in the event your security credentials are compromised or unauthorized access is granted.
+  audit: |-
+    Perform the steps below to confirm MFA delete is configured on an S3 Bucket
+
+    **From Console:**
+
+    1. Login to the S3 console at `https://console.aws.amazon.com/s3/`
+
+    2. Click the `Check` box next to the Bucket name you want to confirm
+
+    3. In the window under `Properties`
+
+    4. Confirm that Versioning is `Enabled`
+
+    5. Confirm that MFA Delete is `Enabled`
+
+    **From Command Line:**
+
+    6. Run the `get-bucket-versioning`
+    ```
+    aws s3api get-bucket-versioning --bucket my-bucket
+    ```
+
+    Output example:
+    ```
+    <VersioningConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"> 
+     <Status>Enabled</Status>
+     <MfaDelete>Enabled</MfaDelete> 
+    </VersioningConfiguration>
+    ```
+
+    If the Console or the CLI output does not show Versioning and MFA Delete `enabled` refer to the remediation below.
+  remediation: |-
+    Perform the steps below to enable MFA delete on an S3 bucket.
+
+    Note:
+    -You cannot enable MFA Delete using the AWS Management Console.
+    You must use the AWS CLI or API.
+    -You must use your 'root' account to enable MFA Delete on S3 buckets.
+
+    **From Command line:**
+
+    1. Run the s3api put-bucket-versioning command
+
+    ```
+    aws s3api put-bucket-versioning --profile my-root-profile --bucket Bucket_Name --versioning-configuration Status=Enabled,MFADelete=Enabled --mfa “arn:aws:iam::aws_account_id:mfa/root-account-mfa-device passcode”
+    ```
+  impact: ''
+  default_value: ''
+  references: |-
+    1. https://docs.aws.amazon.com/AmazonS3/latest/dev/Versioning.html#MultiFactorAuthenticationDelete
+    2. https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingMFADelete.html
+    3. https://aws.amazon.com/blogs/security/securing-access-to-aws-using-mfa-part-3/
+    4. https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_mfa_lost-or-broken.html
+  section: Simple Storage Service (S3)
+  version: '1.0'
+  tags:
+  - CIS
+  - AWS
+  - CIS 2.1.3
+  - Simple Storage Service (S3)
+  benchmark:
+    name: CIS Amazon Web Services Foundations
+    version: v1.5.0
+    id: cis_aws

--- a/bundle/compliance/cis_aws/rules/cis_2_1_3/rule.rego
+++ b/bundle/compliance/cis_aws/rules/cis_2_1_3/rule.rego
@@ -1,0 +1,5 @@
+package compliance.cis_aws.rules.cis_2_1_3
+
+import data.compliance.policy.aws_s3.ensure_mfa_delete_enabled as audit
+
+finding = audit.finding

--- a/bundle/compliance/cis_aws/rules/cis_2_1_3/test.rego
+++ b/bundle/compliance/cis_aws/rules/cis_2_1_3/test.rego
@@ -1,24 +1,24 @@
-package compliance.cis_aws.rules.cis_2_1_1
+package compliance.cis_aws.rules.cis_2_1_3
 
 import data.cis_aws.test_data
 import data.compliance.cis_aws.data_adapter
 import data.lib.test
 
 test_violation {
-	eval_fail with input as rule_input("my bucket", "")
-	eval_fail with input as rule_input("my bucket", "FakeAlgorithm")
+	eval_fail with input as rule_input(false, false)
+	eval_fail with input as rule_input(false, true)
+	eval_fail with input as rule_input(true, false)
 }
 
 test_pass {
-	eval_pass with input as rule_input("my bucket", "AES256")
-	eval_pass with input as rule_input("my bucket", "aws:kms")
+	eval_pass with input as rule_input(true, true)
 }
 
 test_not_evaluated {
 	not_eval with input as test_data.not_evaluated_s3_bucket
 }
 
-rule_input(name, sse_algorithm) = test_data.generate_s3_bucket(name, sse_algorithm, null, null)
+rule_input(enabled, mfa_delete) = test_data.generate_s3_bucket("Bucket", "", null, test_data.generate_s3_bucket_versioning(enabled, mfa_delete))
 
 eval_fail {
 	test.assert_fail(finding) with data.benchmark_data_adapter as data_adapter

--- a/bundle/compliance/cis_aws/test_data.rego
+++ b/bundle/compliance/cis_aws/test_data.rego
@@ -96,18 +96,42 @@ not_evaluated_s3_bucket = {
 	"resource": {
 		"Name": "my-bucket",
 		"SSEAlgorithm": "AES256",
+		"BucketPolicy": {
+			"Version": "2012-10-17",
+			"Statement": [generate_s3_bucket_policy_statement("Deny", "*", "s3:*", "true")],
+		},
+		"BucketVersioning": generate_s3_bucket_versioning(true, true),
 	},
 	"type": "wrong type",
 	"subType": "wrong sub type",
 }
 
-generate_s3_bucket(name, sse_algorithm) = {
+generate_s3_bucket(name, sse_algorithm, bucket_policy_statement, bucket_versioning) = {
 	"resource": {
 		"Name": name,
 		"SSEAlgorithm": sse_algorithm,
+		"BucketPolicy": {
+			"Version": "1",
+			"Statement": [bucket_policy_statement],
+		},
+		"BucketVersioning": bucket_versioning,
 	},
 	"type": "cloud-storage",
 	"subType": "aws-s3",
+}
+
+generate_s3_bucket_policy_statement(effect, principal, action, is_secure_transport) = {
+	"Sid": "Statement1",
+	"Effect": effect,
+	"Principal": principal,
+	"Action": action,
+	"Resource": "arn:aws:s3:::test-bucket/*",
+	"Condition": {"Bool": {"aws:SecureTransport": is_secure_transport}},
+}
+
+generate_s3_bucket_versioning(enabled, mfa_delete) = {
+	"Enabled": enabled,
+	"MfaDelete": mfa_delete,
 }
 
 generate_security_group(entry) = {

--- a/bundle/compliance/policy/aws_s3/data_adapter.rego
+++ b/bundle/compliance/policy/aws_s3/data_adapter.rego
@@ -5,3 +5,9 @@ is_s3 {
 }
 
 sse_algorithm := input.resource.SSEAlgorithm
+
+bucket_policy := input.resource.BucketPolicy
+
+bucket_policy_statement := bucket_policy.Statement[_]
+
+bucket_versioning := input.resource.BucketVersioning

--- a/bundle/compliance/policy/aws_s3/ensure_bucket_policy_deny_http.rego
+++ b/bundle/compliance/policy/aws_s3/ensure_bucket_policy_deny_http.rego
@@ -1,0 +1,23 @@
+package compliance.policy.aws_s3.ensure_bucket_policy_deny_http
+
+import data.compliance.lib.common as lib_common
+import data.compliance.policy.aws_s3.data_adapter
+
+default rule_evaluation = false
+
+rule_evaluation {
+	statement := data_adapter.bucket_policy_statement
+	statement.Condition.Bool["aws:SecureTransport"] == "false"
+	statement.Action == "s3:*"
+	statement.Effect == "Deny"
+	statement.Principal == "*"
+}
+
+finding = result {
+	data_adapter.is_s3
+
+	result := lib_common.generate_result_without_expected(
+		lib_common.calculate_result(rule_evaluation),
+		{"BucketPolicy": data_adapter.bucket_policy},
+	)
+}

--- a/bundle/compliance/policy/aws_s3/ensure_mfa_delete_enabled.rego
+++ b/bundle/compliance/policy/aws_s3/ensure_mfa_delete_enabled.rego
@@ -1,0 +1,21 @@
+package compliance.policy.aws_s3.ensure_mfa_delete_enabled
+
+import data.compliance.lib.common as lib_common
+import data.compliance.policy.aws_s3.data_adapter
+
+default rule_evaluation = false
+
+rule_evaluation {
+	bucket_versioning := data_adapter.bucket_versioning
+	bucket_versioning.Enabled = true
+	bucket_versioning.MfaDelete = true
+}
+
+finding = result {
+	data_adapter.is_s3
+
+	result := lib_common.generate_result_without_expected(
+		lib_common.calculate_result(rule_evaluation),
+		{"BucketVersioning": data_adapter.bucket_versioning},
+	)
+}


### PR DESCRIPTION
### Summary of your changes
Implement two additional rules for AWS CIS S3 section:
- 2.1.2 Ensure S3 Bucket Policy is set to deny HTTP requests
- 2.1.3 Ensure MFA Delete is enabled on S3 buckets

### Related Issues
Resolves https://github.com/elastic/csp-security-policies/issues/144

`cloudbeat` PR: https://github.com/elastic/cloudbeat/pull/661

### Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary README/documentation (if appropriate)
