### PR TITLE
Fix arg parser

### DIFF
--- a/bundle/compliance/cis_eks/data_adapter.rego
+++ b/bundle/compliance/cis_eks/data_adapter.rego
@@ -2,4 +2,4 @@ package compliance.cis_eks.data_adapter
 
 import data.compliance.policy.process.data_adapter as process_data_adapter
 
-process_args := process_data_adapter.process_args(" ")
+process_args := process_data_adapter.process_args

--- a/bundle/compliance/cis_eks/rules/cis_3_2_4/test.rego
+++ b/bundle/compliance/cis_eks/rules/cis_3_2_4/test.rego
@@ -8,6 +8,7 @@ test_violation {
 	eval_fail with input as rule_input("")
 	eval_fail with input as rule_input("--read-only-port 10")
 	eval_fail with input as rule_input_with_external("--read-only-port 10", create_process_config(0))
+	eval_fail with input as rule_input_with_external("--read-only-port=10", create_process_config(0))
 	eval_fail with input as rule_input_with_external("", create_process_config(10))
 }
 
@@ -15,6 +16,7 @@ test_pass {
 	eval_pass with input as rule_input("--read-only-port 0")
 	eval_pass with input as rule_input_with_external("--read-only-port 0", create_process_config(10))
 	eval_pass with input as rule_input_with_external("--read-only-port 0", create_process_config(0))
+	eval_pass with input as rule_input_with_external("--read-only-port=0", create_process_config(0))
 	eval_pass with input as rule_input_with_external("", create_process_config(0))
 }
 

--- a/bundle/compliance/cis_eks/rules/cis_3_2_5/test.rego
+++ b/bundle/compliance/cis_eks/rules/cis_3_2_5/test.rego
@@ -8,6 +8,7 @@ test_violation {
 	eval_fail with input as rule_input("--streaming-connection-idle-timeout 0")
 	eval_fail with input as rule_input_with_external("--streaming-connection-idle-timeout 0", create_process_config(0))
 	eval_fail with input as rule_input_with_external("--streaming-connection-idle-timeout 0", create_process_config(10))
+	eval_fail with input as rule_input_with_external("--streaming-connection-idle-timeout=0", create_process_config(10))
 	eval_fail with input as rule_input_with_external("", create_process_config(0))
 }
 
@@ -16,6 +17,7 @@ test_pass {
 	eval_pass with input as rule_input("--streaming-connection-idle-timeout 10")
 	eval_pass with input as rule_input_with_external("--streaming-connection-idle-timeout 10", create_process_config(0))
 	eval_pass with input as rule_input_with_external("--streaming-connection-idle-timeout 10", create_process_config(10))
+	eval_pass with input as rule_input_with_external("--streaming-connection-idle-timeout=10", create_process_config(10))
 	eval_pass with input as rule_input_with_external("", create_process_config(10))
 }
 

--- a/bundle/compliance/cis_eks/rules/cis_3_2_7/test.rego
+++ b/bundle/compliance/cis_eks/rules/cis_3_2_7/test.rego
@@ -8,6 +8,7 @@ test_violation {
 	eval_fail with input as rule_input("--make-iptables-util-chains false")
 	eval_fail with input as rule_input_with_external("", create_process_config(false))
 	eval_fail with input as rule_input_with_external("--make-iptables-util-chains false", create_process_config(true))
+	eval_fail with input as rule_input_with_external("--make-iptables-util-chains=false", create_process_config(true))
 }
 
 test_pass {
@@ -15,6 +16,7 @@ test_pass {
 	eval_pass with input as rule_input("--make-iptables-util-chains true")
 	eval_pass with input as rule_input_with_external("--make-iptables-util-chains true", create_process_config(false))
 	eval_pass with input as rule_input_with_external("--make-iptables-util-chains true", create_process_config(true))
+	eval_pass with input as rule_input_with_external("--make-iptables-util-chains=true", create_process_config(true))
 	eval_pass with input as rule_input_with_external("", create_process_config(true))
 }
 

--- a/bundle/compliance/cis_k8s/data_adapter.rego
+++ b/bundle/compliance/cis_k8s/data_adapter.rego
@@ -2,4 +2,4 @@ package compliance.cis_k8s.data_adapter
 
 import data.compliance.policy.process.data_adapter as process_data_adapter
 
-process_args := process_data_adapter.process_args("=")
+process_args := process_data_adapter.process_args

--- a/bundle/compliance/policy/process/data_adapter.rego
+++ b/bundle/compliance/policy/process/data_adapter.rego
@@ -20,6 +20,8 @@ process_args_list = args_list {
 
 # Parses a single argument and returns a tuple of the flag and the value
 parse_argument(argument) = [flag, value] {
+    # We would like to split the argument by the first delimiter
+    # The dilimiter can be either a space or an equal sign
 	splitted_argument := regex.split("\\s|\\=", argument)
 	flag = concat("", ["--", splitted_argument[0]])
 

--- a/bundle/compliance/policy/process/data_adapter.rego
+++ b/bundle/compliance/policy/process/data_adapter.rego
@@ -20,8 +20,8 @@ process_args_list = args_list {
 
 # Parses a single argument and returns a tuple of the flag and the value
 parse_argument(argument) = [flag, value] {
-    # We would like to split the argument by the first delimiter
-    # The dilimiter can be either a space or an equal sign
+	# We would like to split the argument by the first delimiter
+	# The dilimiter can be either a space or an equal sign
 	splitted_argument := regex.split("\\s|\\=", argument)
 	flag = concat("", ["--", splitted_argument[0]])
 

--- a/bundle/compliance/policy/process/data_adapter.rego
+++ b/bundle/compliance/policy/process/data_adapter.rego
@@ -18,16 +18,13 @@ process_args_list = args_list {
 	args_list := split(input.resource.command, " --")
 }
 
-# # This method creates a process args object
-# # The object will contain all the process `flags` and their matching values as object key,value accordingly
-# process_args(delimiter) = {flag: value | [flag, value] = parse_argument(process_args_list[_], delimiter)}
-
-parse_argument(argument, delimiter) = [flag, value] {
-	splitted_argument = split(argument, delimiter)
+# Parses a single argument and returns a tuple of the flag and the value
+parse_argument(argument) = [flag, value] {
+	splitted_argument := regex.split("\\s|\\=", argument)
 	flag = concat("", ["--", splitted_argument[0]])
 
 	# We would like to take the entire string after the first delimiter
-	value = concat(delimiter, array.slice(splitted_argument, 1, count(splitted_argument) + 1))
+	value = concat("=", array.slice(splitted_argument, 1, count(splitted_argument) + 1))
 }
 
 process_config = config {
@@ -55,4 +52,4 @@ is_kubelet {
 	process_name == "kubelet"
 }
 
-process_args(seperator) = {flag: value | [flag, value] = parse_argument(process_args_list[_], seperator)}
+process_args = {flag: value | [flag, value] = parse_argument(process_args_list[_])}


### PR DESCRIPTION
### Summary of your changes
arg parser will now support both `=` and space diameter 

### Related Issues
- Fixes: https://github.com/elastic/cloudbeat/issues/632
- Fixes: https://github.com/elastic/cloudbeat/issues/633
- Fixes: https://github.com/elastic/cloudbeat/issues/631

### Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary README/documentation (if appropriate)

> **Note** Make sure to bump cloudbeat [`version/policy.go`](https://github.com/elastic/cloudbeat/blob/main/version/policy.go#L20) after merging this PR and drafting a new release.
