### PR TITLE
Fix id uniqueness

### DIFF
--- a/bundle/compliance/cis_aws/rules/cis_1_10/data.yaml
+++ b/bundle/compliance/cis_aws/rules/cis_1_10/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 918459ca-19ff-5d1f-9291-d1ba7964a140
+  id: cb57543f-5435-55b5-97cf-bda29ec9094a
   name: Ensure multi-factor authentication (MFA) is enabled for all IAM users that
     have a console password
   profile_applicability: '* Level 1'

--- a/bundle/compliance/cis_aws/rules/cis_1_11/data.yaml
+++ b/bundle/compliance/cis_aws/rules/cis_1_11/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 68d542ca-5524-5f53-b168-4622b51f7568
+  id: 394963fa-63fd-5e81-82eb-ea1b8dfacd53
   name: Do not setup access keys during initial user setup for all IAM users that
     have a console password
   profile_applicability: '* Level 1'

--- a/bundle/compliance/cis_aws/rules/cis_1_12/data.yaml
+++ b/bundle/compliance/cis_aws/rules/cis_1_12/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: c21c1512-65e5-5831-9b94-2e2653ee84a4
+  id: 34a4790c-0214-5eec-b97d-1c11ffa6861e
   name: Ensure credentials unused for 45 days or greater are disabled
   profile_applicability: '* Level 1'
   description: |-

--- a/bundle/compliance/cis_aws/rules/cis_1_13/data.yaml
+++ b/bundle/compliance/cis_aws/rules/cis_1_13/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: ab7e9325-5225-507b-bafc-d6650d216851
+  id: 47ee9344-791e-50e4-a266-ee2ebce093a7
   name: Ensure there is only one active access key available for any single IAM user
   profile_applicability: '* Level 1'
   description: |-

--- a/bundle/compliance/cis_aws/rules/cis_1_14/data.yaml
+++ b/bundle/compliance/cis_aws/rules/cis_1_14/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: fee5a5eb-0e97-5a20-aec0-eda1fd6b3580
+  id: edccbc31-3c4d-5d38-af6a-7fd1d9860bff
   name: Ensure access keys are rotated every 90 days or less
   profile_applicability: '* Level 1'
   description: |-

--- a/bundle/compliance/cis_aws/rules/cis_1_15/data.yaml
+++ b/bundle/compliance/cis_aws/rules/cis_1_15/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: d44d0d65-8a4d-5739-8d9a-c61ad8dbc3d5
+  id: a72cb3ec-36ae-56b0-815f-9f986f0d499f
   name: Ensure IAM Users Receive Permissions Only Through Groups
   profile_applicability: '* Level 1'
   description: |-

--- a/bundle/compliance/cis_aws/rules/cis_1_4/data.yaml
+++ b/bundle/compliance/cis_aws/rules/cis_1_4/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 44f6fd7c-0c0f-55f7-84b3-7fa73b31b7e5
+  id: 7a2ab526-3440-5a0f-804c-c5eea8158053
   name: Ensure no 'root' user account access key exists
   profile_applicability: '* Level 1'
   description: |-

--- a/bundle/compliance/cis_aws/rules/cis_1_5/data.yaml
+++ b/bundle/compliance/cis_aws/rules/cis_1_5/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: c16cebbe-2d1e-5127-8ec0-508428817b02
+  id: 4b1f12b8-5fe6-5cc6-b404-58df727bcd45
   name: Ensure MFA is enabled for the 'root' user account
   profile_applicability: '* Level 1'
   description: |-

--- a/bundle/compliance/cis_aws/rules/cis_1_6/data.yaml
+++ b/bundle/compliance/cis_aws/rules/cis_1_6/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: c3d7eec5-1b67-53ac-aa33-dacb214e4a52
+  id: 741aa940-22a7-5015-95d5-f94b331d774e
   name: Ensure hardware MFA is enabled for the 'root' user account
   profile_applicability: '* Level 2'
   description: |-

--- a/bundle/compliance/cis_aws/rules/cis_1_7/data.yaml
+++ b/bundle/compliance/cis_aws/rules/cis_1_7/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 55723b70-1cc2-5932-ac8f-d7a0574f9d67
+  id: 1054ef6c-8f47-5d20-a922-8df0ac93acfa
   name: Eliminate use of the 'root' user for administrative and daily tasks
   profile_applicability: '* Level 1'
   description: |-

--- a/bundle/compliance/cis_aws/rules/cis_1_8/data.yaml
+++ b/bundle/compliance/cis_aws/rules/cis_1_8/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 328079dd-6af7-5967-97cf-b6db063dd90f
+  id: 89b58088-54f6-55dc-96a3-f08ac4b27ea3
   name: Ensure IAM password policy requires minimum length of 14 or greater
   profile_applicability: '* Level 1'
   description: |-

--- a/bundle/compliance/cis_aws/rules/cis_1_9/data.yaml
+++ b/bundle/compliance/cis_aws/rules/cis_1_9/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: b7a0af34-6b0b-5d6c-ade0-40e78890db00
+  id: 3760ac17-de0b-537d-8e74-455d132d19d2
   name: Ensure IAM password policy prevents password reuse
   profile_applicability: '* Level 1'
   description: |-

--- a/bundle/compliance/cis_aws/rules/cis_2_1_1/data.yaml
+++ b/bundle/compliance/cis_aws/rules/cis_2_1_1/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 8a6fd4b0-1903-5afb-b3f8-0495a4caf49a
+  id: 76be4dd2-a77a-5981-a893-db6770b35911
   name: Ensure all S3 buckets employ encryption-at-rest
   profile_applicability: '* Level 2'
   description: Amazon S3 provides a variety of no, or low, cost encryption options

--- a/bundle/compliance/cis_aws/rules/cis_2_1_2/data.yaml
+++ b/bundle/compliance/cis_aws/rules/cis_2_1_2/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: ece0af5a-5d66-5032-b16e-2c6547079d5a
+  id: 1d6ff20d-4803-574b-80d2-e47031d9baa2
   name: Ensure S3 Bucket Policy is set to deny HTTP requests
   profile_applicability: '* Level 2'
   description: |-

--- a/bundle/compliance/cis_aws/rules/cis_2_1_3/data.yaml
+++ b/bundle/compliance/cis_aws/rules/cis_2_1_3/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 50732c73-5ea9-5cea-af10-7c2cde7b3fa3
+  id: 266ccbf1-813d-529b-b7a6-3d225d3dc1a9
   name: Ensure MFA Delete is enabled on S3 buckets
   profile_applicability: '* Level 1'
   description: |-

--- a/bundle/compliance/cis_aws/rules/cis_2_2_1/data.yaml
+++ b/bundle/compliance/cis_aws/rules/cis_2_2_1/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: ea9c1ce3-40f7-5bee-896f-75ec82c84a1a
+  id: b78aca72-f2c1-5cc2-b481-3f056f91bf4b
   name: Ensure EBS Volume Encryption is Enabled in all Regions
   profile_applicability: '* Level 1'
   description: |-

--- a/bundle/compliance/cis_aws/rules/cis_2_3_1/data.yaml
+++ b/bundle/compliance/cis_aws/rules/cis_2_3_1/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 8f6d16a0-cacc-5dd5-bc22-0e43627f2a14
+  id: 2d0044e3-d235-5703-9c16-729932a0131e
   name: Ensure that encryption is enabled for RDS Instances
   profile_applicability: '* Level 1'
   description: |-

--- a/bundle/compliance/cis_aws/rules/cis_2_3_2/data.yaml
+++ b/bundle/compliance/cis_aws/rules/cis_2_3_2/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: ecfe4f1f-486d-5331-97e4-750ae23920a3
+  id: c52e86bd-55f1-5c6a-8349-918f97963346
   name: Ensure Auto Minor Version Upgrade feature is Enabled for RDS Instances
   profile_applicability: '* Level 1'
   description: |-

--- a/bundle/compliance/cis_aws/rules/cis_3_1/data.yaml
+++ b/bundle/compliance/cis_aws/rules/cis_3_1/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: f53bcf7a-7926-5761-bad2-2ddb5982b2e1
+  id: a501efd2-73b9-5f92-a2c7-fa03ae753140
   name: Ensure CloudTrail is enabled in all regions
   profile_applicability: '* Level 1'
   description: |-

--- a/bundle/compliance/cis_aws/rules/cis_3_10/data.yaml
+++ b/bundle/compliance/cis_aws/rules/cis_3_10/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 4dedc85c-b967-59be-91d6-bfe08905d2b5
+  id: 3ed0b9d8-c5f2-55e2-92a5-2531868e79ca
   name: Ensure that Object-level logging for write events is enabled for S3 bucket
   profile_applicability: '* Level 2'
   description: |-

--- a/bundle/compliance/cis_aws/rules/cis_3_11/data.yaml
+++ b/bundle/compliance/cis_aws/rules/cis_3_11/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: f23d42c5-ca52-5208-83b0-adbf3f942a49
+  id: 15c6f217-2ae2-5bb4-8ebe-f40adf02910d
   name: Ensure that Object-level logging for read events is enabled for S3 bucket
   profile_applicability: '* Level 2'
   description: |-

--- a/bundle/compliance/cis_aws/rules/cis_3_2/data.yaml
+++ b/bundle/compliance/cis_aws/rules/cis_3_2/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 547de8ba-1a23-5dca-88c2-19483b03afc6
+  id: 5411a1e9-a529-5512-b556-93178e544c9e
   name: Ensure CloudTrail log file validation is enabled
   profile_applicability: '* Level 2'
   description: |-

--- a/bundle/compliance/cis_aws/rules/cis_3_3/data.yaml
+++ b/bundle/compliance/cis_aws/rules/cis_3_3/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: f27cc67c-f10f-58bf-aff1-821ebf399b35
+  id: 49c71814-2dbe-5204-ad07-879a80503fbc
   name: Ensure the S3 bucket used to store CloudTrail logs is not publicly accessible
   profile_applicability: '* Level 1'
   description: |-

--- a/bundle/compliance/cis_aws/rules/cis_3_4/data.yaml
+++ b/bundle/compliance/cis_aws/rules/cis_3_4/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 63413a69-d879-5b0e-8f9e-d70cd4fc49fa
+  id: c1581c69-3e5c-5ab2-bdde-3619955a1dcf
   name: Ensure CloudTrail trails are integrated with CloudWatch Logs
   profile_applicability: '* Level 1'
   description: |-

--- a/bundle/compliance/cis_aws/rules/cis_3_6/data.yaml
+++ b/bundle/compliance/cis_aws/rules/cis_3_6/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 1ec2536b-6215-5b0b-b48e-0e272c4873e3
+  id: 91d52d43-da61-5ba2-a4d4-1018fee84559
   name: Ensure S3 bucket access logging is enabled on the CloudTrail S3 bucket
   profile_applicability: '* Level 1'
   description: |-

--- a/bundle/compliance/cis_aws/rules/cis_3_7/data.yaml
+++ b/bundle/compliance/cis_aws/rules/cis_3_7/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: ce0e1284-a518-5fcc-99b6-9d9d1b532679
+  id: eda32e5d-3684-5205-b3a4-bbddacddc60f
   name: Ensure CloudTrail logs are encrypted at rest using KMS CMKs
   profile_applicability: '* Level 2'
   description: |-

--- a/bundle/compliance/cis_aws/rules/cis_3_9/data.yaml
+++ b/bundle/compliance/cis_aws/rules/cis_3_9/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 0bb44109-6890-5b9e-aa23-2a14531ac78f
+  id: fcc4b1b4-13e6-5908-be80-7ed36211de90
   name: Ensure VPC flow logging is enabled in all VPCs
   profile_applicability: '* Level 2'
   description: |-

--- a/bundle/compliance/cis_aws/rules/cis_4_1/data.yaml
+++ b/bundle/compliance/cis_aws/rules/cis_4_1/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 1d47812f-b34c-5870-817b-1a2f457f1c0c
+  id: fb8759d0-8564-572c-9042-d395b7e0b74d
   name: Ensure a log metric filter and alarm exist for unauthorized API calls
   profile_applicability: '* Level 1'
   description: |-

--- a/bundle/compliance/cis_aws/rules/cis_4_10/data.yaml
+++ b/bundle/compliance/cis_aws/rules/cis_4_10/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: cdddcc3c-e6af-5c4e-a1f1-250782e5fa4e
+  id: a6074b1d-e115-5416-bdc5-6e1940effd09
   name: Ensure a log metric filter and alarm exist for security group changes
   profile_applicability: '* Level 2'
   description: |-

--- a/bundle/compliance/cis_aws/rules/cis_4_11/data.yaml
+++ b/bundle/compliance/cis_aws/rules/cis_4_11/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 573de90d-647b-542f-bbc9-e7f81cb262b2
+  id: a52c1d16-d925-545d-bbd9-4257c2485eea
   name: Ensure a log metric filter and alarm exist for changes to Network Access Control
     Lists (NACL)
   profile_applicability: '* Level 2'

--- a/bundle/compliance/cis_aws/rules/cis_4_12/data.yaml
+++ b/bundle/compliance/cis_aws/rules/cis_4_12/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 7cd7a607-fa45-546d-b2a2-670b7716211f
+  id: 71cd1aed-48f7-5490-a63d-e22436549822
   name: Ensure a log metric filter and alarm exist for changes to network gateways
   profile_applicability: '* Level 1'
   description: |-

--- a/bundle/compliance/cis_aws/rules/cis_4_13/data.yaml
+++ b/bundle/compliance/cis_aws/rules/cis_4_13/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 43c3bcb5-83cb-56b4-88a9-4a1fa3912c29
+  id: 06161f41-c17a-586f-b08e-c45ea5157da0
   name: Ensure a log metric filter and alarm exist for route table changes
   profile_applicability: '* Level 1'
   description: |-

--- a/bundle/compliance/cis_aws/rules/cis_4_14/data.yaml
+++ b/bundle/compliance/cis_aws/rules/cis_4_14/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 209bbabc-22c4-5578-8304-98a6397e7aaa
+  id: 6e46620d-cf63-55f9-b025-01889df276fd
   name: Ensure a log metric filter and alarm exist for VPC changes
   profile_applicability: '* Level 1'
   description: |-

--- a/bundle/compliance/cis_aws/rules/cis_4_15/data.yaml
+++ b/bundle/compliance/cis_aws/rules/cis_4_15/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 61ef788d-74f2-5273-b19a-1318b9543fc2
+  id: a2447c19-a799-5270-9e03-ac322c2396d5
   name: Ensure a log metric filter and alarm exists for AWS Organizations changes
   profile_applicability: '* Level 1'
   description: |-

--- a/bundle/compliance/cis_aws/rules/cis_4_16/data.yaml
+++ b/bundle/compliance/cis_aws/rules/cis_4_16/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: b937047b-2cf4-5438-9f0c-8b14347b51fe
+  id: 3851b212-b300-545d-8d6b-54ef71c86661
   name: Ensure AWS Security Hub is enabled
   profile_applicability: '* Level 2'
   description: |-

--- a/bundle/compliance/cis_aws/rules/cis_4_2/data.yaml
+++ b/bundle/compliance/cis_aws/rules/cis_4_2/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 3ca4608a-c9b7-5731-bf83-6594c6682027
+  id: c40bebb5-5403-59d8-b960-00d6946931ce
   name: Ensure a log metric filter and alarm exist for Management Console sign-in
     without MFA
   profile_applicability: '* Level 1'

--- a/bundle/compliance/cis_aws/rules/cis_4_3/data.yaml
+++ b/bundle/compliance/cis_aws/rules/cis_4_3/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: dc31ee20-6472-51a9-bb41-4e46059b31b6
+  id: c9e64bdb-9225-5f60-b31c-a2d62f5427f9
   name: Ensure a log metric filter and alarm exist for usage of 'root' account
   profile_applicability: '* Level 1'
   description: |-

--- a/bundle/compliance/cis_aws/rules/cis_4_4/data.yaml
+++ b/bundle/compliance/cis_aws/rules/cis_4_4/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 708ca63c-90f3-561b-a2bd-6e315224138c
+  id: 0bdfe13d-7bc8-5415-8517-65114d344798
   name: Ensure a log metric filter and alarm exist for IAM policy changes
   profile_applicability: '* Level 1'
   description: |-

--- a/bundle/compliance/cis_aws/rules/cis_4_5/data.yaml
+++ b/bundle/compliance/cis_aws/rules/cis_4_5/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 97715f58-2692-5308-8a72-92e56a03259f
+  id: dfc4b9b5-43dc-5ec2-97b4-76a71621fa40
   name: Ensure a log metric filter and alarm exist for CloudTrail configuration changes
   profile_applicability: '* Level 1'
   description: |-

--- a/bundle/compliance/cis_aws/rules/cis_4_6/data.yaml
+++ b/bundle/compliance/cis_aws/rules/cis_4_6/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: da9222ec-d622-58fe-bb38-7b3538d48b1d
+  id: af0e7adc-2f70-5bf5-bce4-abf418bee40b
   name: Ensure a log metric filter and alarm exist for AWS Management Console authentication
     failures
   profile_applicability: '* Level 2'

--- a/bundle/compliance/cis_aws/rules/cis_4_7/data.yaml
+++ b/bundle/compliance/cis_aws/rules/cis_4_7/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: c7d9481c-97c8-58c3-8dfc-2578626eb8d5
+  id: e073f962-74d9-585b-ae5a-e37c461e9b7c
   name: |-
     Ensure a log metric filter and alarm exist for disabling or scheduled deletion of customer created CMKs
   profile_applicability: '* Level 2'

--- a/bundle/compliance/cis_aws/rules/cis_4_8/data.yaml
+++ b/bundle/compliance/cis_aws/rules/cis_4_8/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: a1cd4943-fb10-5e9d-b500-32ce7a6042ef
+  id: 5ee4897d-808b-5ad6-877b-a276f8e65076
   name: Ensure a log metric filter and alarm exist for S3 bucket policy changes
   profile_applicability: '* Level 1'
   description: |-

--- a/bundle/compliance/cis_aws/rules/cis_4_9/data.yaml
+++ b/bundle/compliance/cis_aws/rules/cis_4_9/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 243c6ac0-d5b5-5e56-85c7-c264a5243489
+  id: d498d11f-6c2a-5593-b6c6-6960b28da84e
   name: Ensure a log metric filter and alarm exist for AWS Config configuration changes
   profile_applicability: '* Level 2'
   description: |-

--- a/bundle/compliance/cis_aws/rules/cis_5_1/data.yaml
+++ b/bundle/compliance/cis_aws/rules/cis_5_1/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 5dc677bc-80c7-5043-80a2-5c99667cdb90
+  id: 3d701761-f9b6-5c2d-ab99-928161d2ebbd
   name: Ensure no Network ACLs allow ingress from 0.0.0.0/0 to remote server administration
     ports
   profile_applicability: '* Level 1'

--- a/bundle/compliance/cis_aws/rules/cis_5_2/data.yaml
+++ b/bundle/compliance/cis_aws/rules/cis_5_2/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 100d2822-9a4c-5b86-9f57-5152f64e23fb
+  id: 9209df46-e7e2-5d4b-b1b6-b54a196e7e5d
   name: Ensure no security groups allow ingress from 0.0.0.0/0 to remote server administration
     ports
   profile_applicability: '* Level 1'

--- a/bundle/compliance/cis_aws/rules/cis_5_3/data.yaml
+++ b/bundle/compliance/cis_aws/rules/cis_5_3/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 27b3ecb4-fb3b-50f3-bac5-d44521fde9af
+  id: f9dfc7e7-d067-5be5-8fc1-5d9043a4cd06
   name: Ensure no security groups allow ingress from ::/0 to remote server administration
     ports
   profile_applicability: '* Level 1'

--- a/bundle/compliance/cis_aws/rules/cis_5_4/data.yaml
+++ b/bundle/compliance/cis_aws/rules/cis_5_4/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 131caf34-f2a8-52a2-ae39-95c47e407186
+  id: bbc219e5-75d8-55d6-bccb-7d1acef796bf
   name: Ensure the default security group of every VPC restricts all traffic
   profile_applicability: '* Level 2'
   description: |-

--- a/bundle/compliance/cis_eks/rules/cis_2_1_1/data.yaml
+++ b/bundle/compliance/cis_eks/rules/cis_2_1_1/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 5b3b7bd3-eff9-5f9b-8456-2c880cbdb0b0
+  id: 66cd0518-cfa3-5917-a399-a7dfde4e19db
   name: Enable audit Logs
   profile_applicability: '* Level 1'
   description: |-

--- a/bundle/compliance/cis_eks/rules/cis_3_1_1/data.yaml
+++ b/bundle/compliance/cis_eks/rules/cis_3_1_1/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 8f843abe-1720-5ee5-a3ae-a1fd773d2bec
+  id: 90b8ae5e-df30-5ba6-9fe9-03aab2b7a1c3
   name: Ensure that the kubeconfig file permissions are set to 644 or more restrictive
   profile_applicability: '* Level 1'
   description: |-

--- a/bundle/compliance/cis_eks/rules/cis_3_1_2/data.yaml
+++ b/bundle/compliance/cis_eks/rules/cis_3_1_2/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: be9d43ae-4355-51ed-8ea7-dfd9b30e9d07
+  id: 9a0d57ac-a54d-5652-bf07-982d542bf296
   name: Ensure that the kubelet kubeconfig file ownership is set to root:root
   profile_applicability: '* Level 1'
   description: |-

--- a/bundle/compliance/cis_eks/rules/cis_3_1_3/data.yaml
+++ b/bundle/compliance/cis_eks/rules/cis_3_1_3/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: e11693e6-8f19-5ddb-b1d3-4adcb5595adf
+  id: c8f24be5-fd7d-510f-ab93-2440bb826750
   name: Ensure that the kubelet configuration file has permissions set to 644 or more
     restrictive
   profile_applicability: '* Level 1'

--- a/bundle/compliance/cis_eks/rules/cis_3_1_4/data.yaml
+++ b/bundle/compliance/cis_eks/rules/cis_3_1_4/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 7dd9fde2-7160-5313-be4c-a26f9d705808
+  id: ab555e6d-b77e-5c85-b6a8-333f7e567b6b
   name: Ensure that the kubelet configuration file ownership is set to root:root
   profile_applicability: '* Level 1'
   description: |-

--- a/bundle/compliance/cis_eks/rules/cis_3_2_1/data.yaml
+++ b/bundle/compliance/cis_eks/rules/cis_3_2_1/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 340b6012-9394-569d-ac5a-74745dae70cb
+  id: 06635c87-1e11-59c3-9eba-b4d8a08ba899
   name: Ensure that the --anonymous-auth argument is set to false
   profile_applicability: '* Level 1'
   description: Disable anonymous requests to the Kubelet server.

--- a/bundle/compliance/cis_eks/rules/cis_3_2_10/data.yaml
+++ b/bundle/compliance/cis_eks/rules/cis_3_2_10/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 4dda78b5-7d6e-52fb-8faa-998ac97fa4ef
+  id: 9482a2bf-7e11-59eb-9d09-1e0c06cc1d8e
   name: Ensure that the --rotate-certificates argument is not set to false
   profile_applicability: '* Level 2'
   description: Enable kubelet client certificate rotation.

--- a/bundle/compliance/cis_eks/rules/cis_3_2_11/data.yaml
+++ b/bundle/compliance/cis_eks/rules/cis_3_2_11/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 3be81f29-6e8b-5393-bb91-425a2b2a388e
+  id: d248e880-7d96-5559-a25c-0f56c289a2e7
   name: Ensure that the RotateKubeletServerCertificate argument is set to true
   profile_applicability: '* Level 1'
   description: Enable kubelet server certificate rotation.

--- a/bundle/compliance/cis_eks/rules/cis_3_2_2/data.yaml
+++ b/bundle/compliance/cis_eks/rules/cis_3_2_2/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 78ba925d-bea7-5b17-b0db-9ee592faf10c
+  id: 1706a986-39d7-5900-93eb-f191f6a40892
   name: Ensure that the --authorization-mode argument is not set to AlwaysAllow
   profile_applicability: '* Level 1'
   description: "Do not allow all requests.\nEnable explicit authorization."

--- a/bundle/compliance/cis_eks/rules/cis_3_2_3/data.yaml
+++ b/bundle/compliance/cis_eks/rules/cis_3_2_3/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 789d5b9b-b96f-5bc0-8e37-dd12530eae65
+  id: 9e87e9e4-2701-5c8e-8dc3-4ccb712afa4b
   name: Ensure that the --client-ca-file argument is set as appropriate
   profile_applicability: '* Level 1'
   description: Enable Kubelet authentication using certificates.

--- a/bundle/compliance/cis_eks/rules/cis_3_2_4/data.yaml
+++ b/bundle/compliance/cis_eks/rules/cis_3_2_4/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 4fc4a2f3-bd99-517f-abca-2a35540432d0
+  id: db28165f-6f7c-5450-b9f3-61c7b897d833
   name: Ensure that the --read-only-port is secured
   profile_applicability: '* Level 1'
   description: Disable the read-only port.

--- a/bundle/compliance/cis_eks/rules/cis_3_2_5/data.yaml
+++ b/bundle/compliance/cis_eks/rules/cis_3_2_5/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 863f315d-739a-5995-843c-1ab6f9e2bac4
+  id: e1c469c1-89d2-5cbd-a1f1-fe8f636b151f
   name: Ensure that the --streaming-connection-idle-timeout argument is not set to
     0
   profile_applicability: '* Level 1'

--- a/bundle/compliance/cis_eks/rules/cis_3_2_6/data.yaml
+++ b/bundle/compliance/cis_eks/rules/cis_3_2_6/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: bce28b5e-2f2c-5c57-960e-5385341b2f2b
+  id: d1d73385-2909-598a-acf7-bf1d8130f314
   name: Ensure that the --protect-kernel-defaults argument is set to true
   profile_applicability: '* Level 1'
   description: Protect tuned kernel parameters from overriding kubelet default kernel

--- a/bundle/compliance/cis_eks/rules/cis_3_2_7/data.yaml
+++ b/bundle/compliance/cis_eks/rules/cis_3_2_7/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: bfe7e23b-0a7f-5530-a986-0b06fab6f274
+  id: d416ff74-0e84-56cc-a577-0cdeb6a220f6
   name: Ensure that the --make-iptables-util-chains argument is set to true
   profile_applicability: '* Level 1'
   description: Allow Kubelet to manage iptables.

--- a/bundle/compliance/cis_eks/rules/cis_3_2_8/data.yaml
+++ b/bundle/compliance/cis_eks/rules/cis_3_2_8/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 06ee416f-aadc-5ac5-807e-39c16c52e985
+  id: 9fcbc87c-0963-58ba-8e21-87e22b80fc27
   name: Ensure that the --hostname-override argument is not set
   profile_applicability: '* Level 1'
   description: Do not override node hostnames.

--- a/bundle/compliance/cis_eks/rules/cis_3_2_9/data.yaml
+++ b/bundle/compliance/cis_eks/rules/cis_3_2_9/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 7b8b0bbb-e4ca-5279-a60a-7e1957f1c0ee
+  id: 1a8ee966-458a-5ff9-a6e9-436aba157ebd
   name: |-
     Ensure that the --eventRecordQPS argument is set to 0 or a level which ensures appropriate event capture
   profile_applicability: '* Level 2'

--- a/bundle/compliance/cis_eks/rules/cis_4_2_1/data.yaml
+++ b/bundle/compliance/cis_eks/rules/cis_4_2_1/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 9be37569-9f32-51b7-978c-556a2d7d207a
+  id: cd05adf8-d0fe-54b6-b1a0-93cf02bcec72
   name: Minimize the admission of privileged containers
   profile_applicability: '* Level 1'
   description: |-

--- a/bundle/compliance/cis_eks/rules/cis_4_2_2/data.yaml
+++ b/bundle/compliance/cis_eks/rules/cis_4_2_2/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: f7c69dc3-fbdd-5a04-b4fe-38550e586f7e
+  id: d117cea4-376b-5cb7-ad81-58a2f4efb47e
   name: Minimize the admission of containers wishing to share the host process ID
     namespace
   profile_applicability: '* Level 1'

--- a/bundle/compliance/cis_eks/rules/cis_4_2_3/data.yaml
+++ b/bundle/compliance/cis_eks/rules/cis_4_2_3/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: c44797fd-3b88-51d4-b4e7-164695073447
+  id: 934583bd-306a-51d9-a730-020bd45f7f01
   name: Minimize the admission of containers wishing to share the host IPC namespace
   profile_applicability: '* Level 1'
   description: Do not generally permit containers to be run with the `hostIPC` flag

--- a/bundle/compliance/cis_eks/rules/cis_4_2_4/data.yaml
+++ b/bundle/compliance/cis_eks/rules/cis_4_2_4/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: fca03b1c-e00c-5552-84f7-5be94cbfc600
+  id: 4d0a1c5a-27b5-5429-895d-e90878fcce1d
   name: Minimize the admission of containers wishing to share the host network namespace
   profile_applicability: '* Level 1'
   description: Do not generally permit containers to be run with the `hostNetwork`

--- a/bundle/compliance/cis_eks/rules/cis_4_2_5/data.yaml
+++ b/bundle/compliance/cis_eks/rules/cis_4_2_5/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: d6fa5f41-3671-563a-ba35-a7494223273a
+  id: 882ffc80-73e9-56aa-ae72-73b39af6702f
   name: Minimize the admission of containers with allowPrivilegeEscalation
   profile_applicability: '* Level 1'
   description: Do not generally permit containers to be run with the `allowPrivilegeEscalation`

--- a/bundle/compliance/cis_eks/rules/cis_4_2_6/data.yaml
+++ b/bundle/compliance/cis_eks/rules/cis_4_2_6/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 77bc9d3b-7f54-5149-8430-9c0222184f32
+  id: 668cee84-c115-5166-a422-05c4d3e88c2c
   name: Minimize the admission of root containers
   profile_applicability: '* Level 2'
   description: Do not generally permit containers to be run as the root user.

--- a/bundle/compliance/cis_eks/rules/cis_4_2_7/data.yaml
+++ b/bundle/compliance/cis_eks/rules/cis_4_2_7/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 13c821af-7d0a-5269-855d-2a87134ed4ee
+  id: 95e17dc2-ef2f-50d0-b1a8-84d2ae523c4b
   name: Minimize the admission of containers with the NET_RAW capability
   profile_applicability: '* Level 1'
   description: Do not generally permit containers with the potentially dangerous NET_RAW

--- a/bundle/compliance/cis_eks/rules/cis_4_2_8/data.yaml
+++ b/bundle/compliance/cis_eks/rules/cis_4_2_8/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 9870ae7a-8c40-5f47-a482-355a720b01db
+  id: 551d3a0b-36f6-51c6-ba8b-0a83926b1864
   name: Minimize the admission of containers with added capabilities
   profile_applicability: '* Level 1'
   description: Do not generally permit containers with capabilities assigned beyond

--- a/bundle/compliance/cis_eks/rules/cis_4_2_9/data.yaml
+++ b/bundle/compliance/cis_eks/rules/cis_4_2_9/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: b28f5d7c-3db2-58cf-8704-b8e922e236b7
+  id: db58a1e4-de58-5899-bee8-f6ced89d6f80
   name: Minimize the admission of containers with capabilities assigned
   profile_applicability: '* Level 2'
   description: Do not generally permit containers with capabilities

--- a/bundle/compliance/cis_eks/rules/cis_5_1_1/data.yaml
+++ b/bundle/compliance/cis_eks/rules/cis_5_1_1/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: d062432b-6804-5626-9953-1de08c4f8ccb
+  id: b42eb917-8a4e-5cb7-93b1-886dbf2751bc
   name: Ensure Image Vulnerability Scanning using Amazon ECR image scanning or a third
     party provider
   profile_applicability: '* Level 1'

--- a/bundle/compliance/cis_eks/rules/cis_5_3_1/data.yaml
+++ b/bundle/compliance/cis_eks/rules/cis_5_3_1/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 8b6bfb52-9051-5863-baef-2c4eaa6a5eb1
+  id: b449135c-8747-58fe-9d46-218728745520
   name: Ensure Kubernetes Secrets are encrypted using Customer Master Keys (CMKs)
     managed in AWS KMS
   profile_applicability: '* Level 1'

--- a/bundle/compliance/cis_eks/rules/cis_5_4_1/data.yaml
+++ b/bundle/compliance/cis_eks/rules/cis_5_4_1/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: ef45d674-b20a-509a-8d95-15142c89c3d0
+  id: c28e606d-f6a7-58b2-820f-e2fb702bf956
   name: Restrict Access to the Control Plane Endpoint
   profile_applicability: '* Level 1'
   description: |-

--- a/bundle/compliance/cis_eks/rules/cis_5_4_2/data.yaml
+++ b/bundle/compliance/cis_eks/rules/cis_5_4_2/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 4c198b47-5e4f-559d-be67-cbd5b8c3ebcd
+  id: 1b112bf6-61ad-5b08-888b-7b6c86b3526c
   name: Ensure clusters are created with Private Endpoint Enabled and Public Access
     Disabled
   profile_applicability: '* Level 2'

--- a/bundle/compliance/cis_eks/rules/cis_5_4_3/data.yaml
+++ b/bundle/compliance/cis_eks/rules/cis_5_4_3/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 76565652-57f3-586c-b702-379e39b65fb5
+  id: 3afddcd1-b745-5b3c-8623-ce4abe6878b5
   name: Ensure clusters are created with Private Nodes
   profile_applicability: '* Level 1'
   description: |-

--- a/bundle/compliance/cis_eks/rules/cis_5_4_5/data.yaml
+++ b/bundle/compliance/cis_eks/rules/cis_5_4_5/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 2b7f6d8c-48fc-58a8-9f38-0ea23b4477ca
+  id: 4cfe4df4-4157-53bb-820f-278fe02ec960
   name: Encrypt traffic to HTTPS load balancers with TLS certificates
   profile_applicability: '* Level 2'
   description: Encrypt traffic to HTTPS load balancers using TLS certificates.

--- a/bundle/compliance/cis_k8s/rules/cis_1_1_1/data.yaml
+++ b/bundle/compliance/cis_k8s/rules/cis_1_1_1/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 56f66a4d-0bec-5ec5-bc6d-2d0ae33a0635
+  id: c444d9e3-d3de-5598-90e7-95a922b51664
   name: Ensure that the API server pod specification file permissions are set to 644
     or more restrictive
   profile_applicability: '* Level 1 - Master Node'

--- a/bundle/compliance/cis_k8s/rules/cis_1_1_11/data.yaml
+++ b/bundle/compliance/cis_k8s/rules/cis_1_1_11/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: a1bfd354-721a-5038-a7f3-0a38e9232304
+  id: 4f7354df-2e3b-5acf-9ba7-d6b5cfd12e35
   name: Ensure that the etcd data directory permissions are set to 700 or more restrictive
   profile_applicability: '* Level 1 - Master Node'
   description: Ensure that the etcd data directory has permissions of `700` or more

--- a/bundle/compliance/cis_k8s/rules/cis_1_1_12/data.yaml
+++ b/bundle/compliance/cis_k8s/rules/cis_1_1_12/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 29b0f497-6bbf-5991-8173-279b97004fd6
+  id: f512a987-4f86-5fb3-b202-6b5de22a739f
   name: Ensure that the etcd data directory ownership is set to etcd:etcd
   profile_applicability: '* Level 1 - Master Node'
   description: Ensure that the etcd data directory ownership is set to `etcd:etcd`.

--- a/bundle/compliance/cis_k8s/rules/cis_1_1_13/data.yaml
+++ b/bundle/compliance/cis_k8s/rules/cis_1_1_13/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 33d1b3cc-7d61-5940-9b67-bd3bdf1372c0
+  id: ed797ade-c473-5b6a-b1e2-1fd4410f7156
   name: Ensure that the admin.conf file permissions are set to 600
   profile_applicability: '* Level 1 - Master Node'
   description: Ensure that the `admin.conf` file has permissions of `600`.

--- a/bundle/compliance/cis_k8s/rules/cis_1_1_14/data.yaml
+++ b/bundle/compliance/cis_k8s/rules/cis_1_1_14/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: e3b1c434-02ca-5c23-83c7-767e692545f9
+  id: e24bf247-bfdc-5bbf-9813-165b905b52e6
   name: Ensure that the admin.conf file ownership is set to root:root
   profile_applicability: '* Level 1 - Master Node'
   description: Ensure that the `admin.conf` file ownership is set to `root:root`.

--- a/bundle/compliance/cis_k8s/rules/cis_1_1_15/data.yaml
+++ b/bundle/compliance/cis_k8s/rules/cis_1_1_15/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 84c66732-9c11-5a66-9bf9-e65f06e08171
+  id: 6b3b122f-ac19-5a57-b6d0-131daf3fbf6d
   name: Ensure that the scheduler.conf file permissions are set to 644 or more restrictive
   profile_applicability: '* Level 1 - Master Node'
   description: Ensure that the `scheduler.conf` file has permissions of `644` or more

--- a/bundle/compliance/cis_k8s/rules/cis_1_1_16/data.yaml
+++ b/bundle/compliance/cis_k8s/rules/cis_1_1_16/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 6a676e26-ad2f-53a2-9968-1a075a70a84b
+  id: c1e1ca12-c0e2-543e-819d-22249927d241
   name: Ensure that the scheduler.conf file ownership is set to root:root
   profile_applicability: '* Level 1 - Master Node'
   description: Ensure that the `scheduler.conf` file ownership is set to `root:root`.

--- a/bundle/compliance/cis_k8s/rules/cis_1_1_17/data.yaml
+++ b/bundle/compliance/cis_k8s/rules/cis_1_1_17/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 73926a71-4298-505a-a3d4-6131ab97a9f4
+  id: b5493b70-e25f-54e6-9931-36138c33f775
   name: Ensure that the controller-manager.conf file permissions are set to 644 or
     more restrictive
   profile_applicability: '* Level 1 - Master Node'

--- a/bundle/compliance/cis_k8s/rules/cis_1_1_18/data.yaml
+++ b/bundle/compliance/cis_k8s/rules/cis_1_1_18/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 76c4a120-d350-5958-a585-0f8b9d581652
+  id: 9b3242a1-51a5-5b5e-8d29-70b9dd7ae7eb
   name: Ensure that the controller-manager.conf file ownership is set to root:root
   profile_applicability: '* Level 1 - Master Node'
   description: Ensure that the `controller-manager.conf` file ownership is set to

--- a/bundle/compliance/cis_k8s/rules/cis_1_1_19/data.yaml
+++ b/bundle/compliance/cis_k8s/rules/cis_1_1_19/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: a6f7e4ca-4a24-58df-9807-2ed19b164cd2
+  id: d98f24a9-e788-55d2-8b70-e9fe88311f9c
   name: Ensure that the Kubernetes PKI directory and file ownership is set to root:root
   profile_applicability: '* Level 1 - Master Node'
   description: Ensure that the Kubernetes PKI directory and file ownership is set

--- a/bundle/compliance/cis_k8s/rules/cis_1_1_2/data.yaml
+++ b/bundle/compliance/cis_k8s/rules/cis_1_1_2/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: ffcb9161-0ec8-5c29-9856-9626556e8f12
+  id: c0ef1e12-b201-5736-8475-4b62978084e8
   name: Ensure that the API server pod specification file ownership is set to root:root
   profile_applicability: '* Level 1 - Master Node'
   description: Ensure that the API server pod specification file ownership is set

--- a/bundle/compliance/cis_k8s/rules/cis_1_1_20/data.yaml
+++ b/bundle/compliance/cis_k8s/rules/cis_1_1_20/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 5a666423-ae65-502b-a256-938bfc55bc43
+  id: 93808f1f-f05e-5e48-b130-5527795e6158
   name: Ensure that the Kubernetes PKI certificate file permissions are set to 644
     or more restrictive
   profile_applicability: '* Level 1 - Master Node'

--- a/bundle/compliance/cis_k8s/rules/cis_1_1_21/data.yaml
+++ b/bundle/compliance/cis_k8s/rules/cis_1_1_21/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 58a8587b-2c3a-5bd0-9097-42fdfa2801aa
+  id: 1e180f0d-3419-5681-838b-9247927eb0f6
   name: Ensure that the Kubernetes PKI key file permissions are set to 600
   profile_applicability: '* Level 1 - Master Node'
   description: Ensure that Kubernetes PKI key files have permissions of `600`.

--- a/bundle/compliance/cis_k8s/rules/cis_1_1_3/data.yaml
+++ b/bundle/compliance/cis_k8s/rules/cis_1_1_3/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: b7a17fac-ac87-5dbe-8b1e-f2565cd2427d
+  id: 04e01d1a-d7d4-5020-a398-8aadd3fe32ae
   name: |-
     Ensure that the controller manager pod specification file permissions are set to 644 or more restrictive
   profile_applicability: '* Level 1 - Master Node'

--- a/bundle/compliance/cis_k8s/rules/cis_1_1_4/data.yaml
+++ b/bundle/compliance/cis_k8s/rules/cis_1_1_4/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: c4978061-8644-5d22-a5d5-16f63af61c09
+  id: 151312c8-7e97-5420-ac05-5a916b3c1feb
   name: Ensure that the controller manager pod specification file ownership is set
     to root:root
   profile_applicability: '* Level 1 - Master Node'

--- a/bundle/compliance/cis_k8s/rules/cis_1_1_5/data.yaml
+++ b/bundle/compliance/cis_k8s/rules/cis_1_1_5/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: c08aac61-22f2-5c36-ade5-7c41ccf67fea
+  id: b1b40df2-f562-564a-9d43-94774e1698d1
   name: Ensure that the scheduler pod specification file permissions are set to 644
     or more restrictive
   profile_applicability: '* Level 1 - Master Node'

--- a/bundle/compliance/cis_k8s/rules/cis_1_1_6/data.yaml
+++ b/bundle/compliance/cis_k8s/rules/cis_1_1_6/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 7dcb6273-247f-5398-9732-1c3f2ce0b98b
+  id: 3fb6051e-31f8-5fb5-bd45-4f140fa4442e
   name: Ensure that the scheduler pod specification file ownership is set to root:root
   profile_applicability: '* Level 1 - Master Node'
   description: Ensure that the scheduler pod specification file ownership is set to

--- a/bundle/compliance/cis_k8s/rules/cis_1_1_7/data.yaml
+++ b/bundle/compliance/cis_k8s/rules/cis_1_1_7/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: bec347e5-b056-5104-9199-eca9e264983a
+  id: 3ef4430e-2829-576a-a813-edc766625ea9
   name: Ensure that the etcd pod specification file permissions are set to 644 or
     more restrictive
   profile_applicability: '* Level 1 - Master Node'

--- a/bundle/compliance/cis_k8s/rules/cis_1_1_8/data.yaml
+++ b/bundle/compliance/cis_k8s/rules/cis_1_1_8/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: d023f3a1-548d-5fb8-a664-31c1d9113d47
+  id: 129b07b7-4470-5224-8246-6ae975d6304b
   name: Ensure that the etcd pod specification file ownership is set to root:root
   profile_applicability: '* Level 1 - Master Node'
   description: Ensure that the `/etc/kubernetes/manifests/etcd.yaml` file ownership

--- a/bundle/compliance/cis_k8s/rules/cis_1_2_10/data.yaml
+++ b/bundle/compliance/cis_k8s/rules/cis_1_2_10/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: ca5b005f-9922-5cdc-a664-7b8f33e20f00
+  id: 29cefccd-77fe-5428-8bea-3fc1390d5d1e
   name: Ensure that the admission control plugin EventRateLimit is set
   profile_applicability: '* Level 1 - Master Node'
   description: Limit the rate at which the API server accepts requests.

--- a/bundle/compliance/cis_k8s/rules/cis_1_2_11/data.yaml
+++ b/bundle/compliance/cis_k8s/rules/cis_1_2_11/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 848c3124-9dd0-5590-9338-82de21c1df9f
+  id: a6a43181-3a24-5ead-b845-1f1b56c95ad5
   name: Ensure that the admission control plugin AlwaysAdmit is not set
   profile_applicability: '* Level 1 - Master Node'
   description: Do not allow all requests.

--- a/bundle/compliance/cis_k8s/rules/cis_1_2_12/data.yaml
+++ b/bundle/compliance/cis_k8s/rules/cis_1_2_12/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 73fa944c-a62c-5371-a011-0e17bf85f79f
+  id: 9718b528-8327-5eef-ad21-c8bed5532429
   name: Ensure that the admission control plugin AlwaysPullImages is set
   profile_applicability: '* Level 1 - Master Node'
   description: Always pull images.

--- a/bundle/compliance/cis_k8s/rules/cis_1_2_13/data.yaml
+++ b/bundle/compliance/cis_k8s/rules/cis_1_2_13/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: ee7b40c4-abf3-53f1-b938-aa982a416ad4
+  id: 1b89acc6-978c-57c3-b319-680e5251d6f6
   name: Ensure that the admission control plugin SecurityContextDeny is set if PodSecurityPolicy
     is not used
   profile_applicability: '* Level 1 - Master Node'

--- a/bundle/compliance/cis_k8s/rules/cis_1_2_14/data.yaml
+++ b/bundle/compliance/cis_k8s/rules/cis_1_2_14/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 145d13e1-a792-5070-bf34-68d90fcd90dd
+  id: d57d6506-a519-5a29-a816-b1204ebfef21
   name: Ensure that the admission control plugin ServiceAccount is set
   profile_applicability: '* Level 1 - Master Node'
   description: Automate service accounts management.

--- a/bundle/compliance/cis_k8s/rules/cis_1_2_15/data.yaml
+++ b/bundle/compliance/cis_k8s/rules/cis_1_2_15/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: c2cd82d0-2ded-593d-8231-9c643c40ed73
+  id: c53dab24-a23f-53c6-8d36-f64cc03ab277
   name: Ensure that the admission control plugin NamespaceLifecycle is set
   profile_applicability: '* Level 1 - Master Node'
   description: Reject creating objects in a namespace that is undergoing termination.

--- a/bundle/compliance/cis_k8s/rules/cis_1_2_16/data.yaml
+++ b/bundle/compliance/cis_k8s/rules/cis_1_2_16/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 0a9250ba-0634-567c-bd6d-63dbab03d83b
+  id: 7eebf1d9-7a68-54fd-89b7-0f8b1441a179
   name: Ensure that the admission control plugin NodeRestriction is set
   profile_applicability: '* Level 1 - Master Node'
   description: Limit the `Node` and `Pod` objects that a kubelet could modify.

--- a/bundle/compliance/cis_k8s/rules/cis_1_2_17/data.yaml
+++ b/bundle/compliance/cis_k8s/rules/cis_1_2_17/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: b38efe94-7174-5e1d-8f32-14ec97aa9d47
+  id: fd42f0d0-6e1d-53e5-b322-9a0eaa56948b
   name: Ensure that the --secure-port argument is not set to 0
   profile_applicability: '* Level 1 - Master Node'
   description: Do not disable the secure port.

--- a/bundle/compliance/cis_k8s/rules/cis_1_2_18/data.yaml
+++ b/bundle/compliance/cis_k8s/rules/cis_1_2_18/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 75faeb95-6d19-5205-85b9-4bb1471292c4
+  id: b0a70444-c719-5772-a8c1-2cd72578f8ee
   name: Ensure that the --profiling argument is set to false
   profile_applicability: '* Level 1 - Master Node'
   description: Disable profiling, if not needed.

--- a/bundle/compliance/cis_k8s/rules/cis_1_2_19/data.yaml
+++ b/bundle/compliance/cis_k8s/rules/cis_1_2_19/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 50ebf148-b0a8-5d12-a761-a4e79cb68b37
+  id: 9ef34b4f-b9e1-566b-8a2b-69f8933fa852
   name: Ensure that the --audit-log-path argument is set
   profile_applicability: '* Level 1 - Master Node'
   description: Enable auditing on the Kubernetes API Server and set the desired audit

--- a/bundle/compliance/cis_k8s/rules/cis_1_2_2/data.yaml
+++ b/bundle/compliance/cis_k8s/rules/cis_1_2_2/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 6d342ec7-132b-5764-92df-89d4018f632d
+  id: eeb00e89-7125-58e8-9248-b9f429583277
   name: Ensure that the --token-auth-file parameter is not set
   profile_applicability: '* Level 1 - Master Node'
   description: Do not use token based authentication.

--- a/bundle/compliance/cis_k8s/rules/cis_1_2_20/data.yaml
+++ b/bundle/compliance/cis_k8s/rules/cis_1_2_20/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: b7515b92-10ec-5218-94b4-b10de05fd90f
+  id: b3b3c352-fc81-5874-8bbc-31e2f58e884e
   name: Ensure that the --audit-log-maxage argument is set to 30 or as appropriate
   profile_applicability: '* Level 1 - Master Node'
   description: Retain the logs for at least 30 days or as appropriate.

--- a/bundle/compliance/cis_k8s/rules/cis_1_2_21/data.yaml
+++ b/bundle/compliance/cis_k8s/rules/cis_1_2_21/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 5bf4df2b-2758-5dfc-b670-74faf135e437
+  id: 5dd8b281-9a80-50a7-a03d-fe462a5a2ba0
   name: Ensure that the --audit-log-maxbackup argument is set to 10 or as appropriate
   profile_applicability: '* Level 1 - Master Node'
   description: Retain 10 or an appropriate number of old log files.

--- a/bundle/compliance/cis_k8s/rules/cis_1_2_22/data.yaml
+++ b/bundle/compliance/cis_k8s/rules/cis_1_2_22/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 9629f363-8475-5939-8432-ae72e223a892
+  id: c455dba0-a768-5c76-8509-3484ec33102f
   name: Ensure that the --audit-log-maxsize argument is set to 100 or as appropriate
   profile_applicability: '* Level 1 - Master Node'
   description: Rotate log files on reaching 100 MB or as appropriate.

--- a/bundle/compliance/cis_k8s/rules/cis_1_2_23/data.yaml
+++ b/bundle/compliance/cis_k8s/rules/cis_1_2_23/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 21ef8d8e-ac0d-57e4-805f-30817ec1500b
+  id: 17282e92-075f-593d-99eb-99346e4288ed
   name: Ensure that the --request-timeout argument is set as appropriate
   profile_applicability: '* Level 1 - Master Node'
   description: Set global request timeout for API server requests as appropriate.

--- a/bundle/compliance/cis_k8s/rules/cis_1_2_24/data.yaml
+++ b/bundle/compliance/cis_k8s/rules/cis_1_2_24/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 98547a10-464e-5b9f-9a80-6b254cb621a3
+  id: e92ddce9-3cba-5e3d-adac-53df0350eca0
   name: Ensure that the --service-account-lookup argument is set to true
   profile_applicability: '* Level 1 - Master Node'
   description: Validate service account before validating token.

--- a/bundle/compliance/cis_k8s/rules/cis_1_2_25/data.yaml
+++ b/bundle/compliance/cis_k8s/rules/cis_1_2_25/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 645144dd-f578-5e76-9251-1679bc027910
+  id: c8a8f827-fba6-58ee-80b8-e64a605a4902
   name: Ensure that the --service-account-key-file argument is set as appropriate
   profile_applicability: '* Level 1 - Master Node'
   description: Explicitly set a service account public key file for service accounts

--- a/bundle/compliance/cis_k8s/rules/cis_1_2_26/data.yaml
+++ b/bundle/compliance/cis_k8s/rules/cis_1_2_26/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 1635eab6-ee81-5075-a0bc-8e56a9f16a88
+  id: dafb527b-9869-5062-8d38-c9dced4a27c2
   name: Ensure that the --etcd-certfile and --etcd-keyfile arguments are set as appropriate
   profile_applicability: '* Level 1 - Master Node'
   description: etcd should be configured to make use of TLS encryption for client

--- a/bundle/compliance/cis_k8s/rules/cis_1_2_27/data.yaml
+++ b/bundle/compliance/cis_k8s/rules/cis_1_2_27/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 719ccb48-0106-5c2a-a563-b31620da736a
+  id: ef3852ff-b0f9-51d5-af6d-b1b1fed72005
   name: Ensure that the --tls-cert-file and --tls-private-key-file arguments are set
     as appropriate
   profile_applicability: '* Level 1 - Master Node'

--- a/bundle/compliance/cis_k8s/rules/cis_1_2_28/data.yaml
+++ b/bundle/compliance/cis_k8s/rules/cis_1_2_28/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 5097a7f7-be0e-57f1-81d7-665334381426
+  id: 328a73c3-011d-5827-ae86-4e323739e4e1
   name: Ensure that the --client-ca-file argument is set as appropriate
   profile_applicability: '* Level 1 - Master Node'
   description: Setup TLS connection on the API server.

--- a/bundle/compliance/cis_k8s/rules/cis_1_2_29/data.yaml
+++ b/bundle/compliance/cis_k8s/rules/cis_1_2_29/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 174c9892-d459-584c-9407-b69e848bdd2c
+  id: 08d850ca-c1be-57e2-ac39-5e38f8750cf6
   name: Ensure that the --etcd-cafile argument is set as appropriate
   profile_applicability: '* Level 1 - Master Node'
   description: etcd should be configured to make use of TLS encryption for client

--- a/bundle/compliance/cis_k8s/rules/cis_1_2_32/data.yaml
+++ b/bundle/compliance/cis_k8s/rules/cis_1_2_32/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 1b0fb4c0-9ee1-51df-9b7b-d261950ecc07
+  id: c67fb159-cec6-5114-bbfe-f9a1e57fdcd4
   name: Ensure that the API Server only makes use of Strong Cryptographic Ciphers
   profile_applicability: '* Level 1 - Master Node'
   description: Ensure that the API server is configured to only use strong cryptographic

--- a/bundle/compliance/cis_k8s/rules/cis_1_2_4/data.yaml
+++ b/bundle/compliance/cis_k8s/rules/cis_1_2_4/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 697cc9f6-28dd-51a5-934c-b6cc3922a6db
+  id: 88634421-e47c-59fb-9466-a86023f20dd5
   name: Ensure that the --kubelet-https argument is set to true
   profile_applicability: '* Level 1 - Master Node'
   description: Use https for kubelet connections.

--- a/bundle/compliance/cis_k8s/rules/cis_1_2_5/data.yaml
+++ b/bundle/compliance/cis_k8s/rules/cis_1_2_5/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 6f90e227-03d9-5a1b-bf87-b13c45b23182
+  id: 64feecfc-7166-5d77-b830-bf4a8dd2e05d
   name: |-
     Ensure that the --kubelet-client-certificate and --kubelet-client-key arguments are set as appropriate
   profile_applicability: '* Level 1 - Master Node'

--- a/bundle/compliance/cis_k8s/rules/cis_1_2_6/data.yaml
+++ b/bundle/compliance/cis_k8s/rules/cis_1_2_6/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 53095c31-20ab-5659-a8e6-3e1b505c6984
+  id: 5cdc703f-54ea-5de6-97c4-9fdb495725ef
   name: Ensure that the --kubelet-certificate-authority argument is set as appropriate
   profile_applicability: '* Level 1 - Master Node'
   description: Verify kubelet's certificate before establishing connection.

--- a/bundle/compliance/cis_k8s/rules/cis_1_2_7/data.yaml
+++ b/bundle/compliance/cis_k8s/rules/cis_1_2_7/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 3781a71f-54e5-5987-9da2-d72a7d139af7
+  id: c006dbcb-dbaf-5bf5-886a-e05d7e5e6e1b
   name: Ensure that the --authorization-mode argument is not set to AlwaysAllow
   profile_applicability: '* Level 1 - Master Node'
   description: Do not always authorize all requests.

--- a/bundle/compliance/cis_k8s/rules/cis_1_2_8/data.yaml
+++ b/bundle/compliance/cis_k8s/rules/cis_1_2_8/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: bc294f39-513a-528c-8207-72ddd221054d
+  id: c43a57db-5248-5855-a613-2a05d0a42768
   name: Ensure that the --authorization-mode argument includes Node
   profile_applicability: '* Level 1 - Master Node'
   description: Restrict kubelet nodes to reading only objects associated with them.

--- a/bundle/compliance/cis_k8s/rules/cis_1_2_9/data.yaml
+++ b/bundle/compliance/cis_k8s/rules/cis_1_2_9/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: b10e1f96-660c-501e-81e4-9ceac82a9907
+  id: 555cf8d5-f963-5574-a856-e06614cf9341
   name: Ensure that the --authorization-mode argument includes RBAC
   profile_applicability: '* Level 1 - Master Node'
   description: Turn on Role Based Access Control.

--- a/bundle/compliance/cis_k8s/rules/cis_1_3_2/data.yaml
+++ b/bundle/compliance/cis_k8s/rules/cis_1_3_2/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 75faeb95-6d19-5205-85b9-4bb1471292c4
+  id: 9c2d1c63-7bf3-584d-b87a-043853dad7a4
   name: Ensure that the --profiling argument is set to false
   profile_applicability: '* Level 1 - Master Node'
   description: Disable profiling, if not needed.

--- a/bundle/compliance/cis_k8s/rules/cis_1_3_3/data.yaml
+++ b/bundle/compliance/cis_k8s/rules/cis_1_3_3/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: e103a398-f4ee-55cb-8b5c-88772e226b17
+  id: 84b8b7be-d917-50f3-beab-c076d0098d83
   name: Ensure that the --use-service-account-credentials argument is set to true
   profile_applicability: '* Level 1 - Master Node'
   description: Use individual service account credentials for each controller.

--- a/bundle/compliance/cis_k8s/rules/cis_1_3_4/data.yaml
+++ b/bundle/compliance/cis_k8s/rules/cis_1_3_4/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: fb88f47c-1309-5fa3-af23-499c217cb70a
+  id: 6de73498-23d7-537f-83f3-08c660217e7e
   name: Ensure that the --service-account-private-key-file  argument is set as appropriate
   profile_applicability: '* Level 1 - Master Node'
   description: Explicitly set a service account private key file for service accounts

--- a/bundle/compliance/cis_k8s/rules/cis_1_3_5/data.yaml
+++ b/bundle/compliance/cis_k8s/rules/cis_1_3_5/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 2cb45802-52cb-582a-a6f2-0d19e1903cf1
+  id: d303c4f1-489c-56ca-add9-29820c2214af
   name: Ensure that the --root-ca-file argument is set as appropriate
   profile_applicability: '* Level 1 - Master Node'
   description: Allow pods to verify the API server's serving certificate before establishing

--- a/bundle/compliance/cis_k8s/rules/cis_1_3_6/data.yaml
+++ b/bundle/compliance/cis_k8s/rules/cis_1_3_6/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 2b5d962b-52a6-558f-beed-6da38c4af362
+  id: 8d3f2919-da46-5502-b48b-9ba41d03281b
   name: Ensure that the RotateKubeletServerCertificate argument is set to true
   profile_applicability: '* Level 2 - Master Node'
   description: Enable kubelet server certificate rotation on controller-manager.

--- a/bundle/compliance/cis_k8s/rules/cis_1_3_7/data.yaml
+++ b/bundle/compliance/cis_k8s/rules/cis_1_3_7/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 091b1308-4f72-59ef-9103-4b548386ae27
+  id: 89a294ae-d736-51ca-99d4-0ea4782caed0
   name: Ensure that the --bind-address argument is set to 127.0.0.1
   profile_applicability: '* Level 1 - Master Node'
   description: Do not bind the Controller Manager service to non-loopback insecure

--- a/bundle/compliance/cis_k8s/rules/cis_1_4_1/data.yaml
+++ b/bundle/compliance/cis_k8s/rules/cis_1_4_1/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 75faeb95-6d19-5205-85b9-4bb1471292c4
+  id: 9fc74adb-6ddd-5838-be72-cfd17fbfb74b
   name: Ensure that the --profiling argument is set to false
   profile_applicability: '* Level 1 - Master Node'
   description: Disable profiling, if not needed.

--- a/bundle/compliance/cis_k8s/rules/cis_1_4_2/data.yaml
+++ b/bundle/compliance/cis_k8s/rules/cis_1_4_2/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 091b1308-4f72-59ef-9103-4b548386ae27
+  id: abc6f4b4-3add-57c4-973d-c678df60804c
   name: Ensure that the --bind-address argument is set to 127.0.0.1
   profile_applicability: '* Level 1 - Master Node'
   description: Do not bind the scheduler service to non-loopback insecure addresses.

--- a/bundle/compliance/cis_k8s/rules/cis_2_1/data.yaml
+++ b/bundle/compliance/cis_k8s/rules/cis_2_1/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 15413809-b667-59d0-a54a-972ba4826eb4
+  id: 067385c5-d3a0-536a-bd4f-ed7c1f4033ce
   name: Ensure that the --cert-file and --key-file arguments are set as appropriate
   profile_applicability: '* Level 1 - Master Node'
   description: Configure TLS encryption for the etcd service.

--- a/bundle/compliance/cis_k8s/rules/cis_2_2/data.yaml
+++ b/bundle/compliance/cis_k8s/rules/cis_2_2/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 8e4b745a-d2db-5fe5-9a60-7c5029599d27
+  id: 1ea2df8f-a973-561b-a1f9-a0bea9cfba36
   name: Ensure that the --client-cert-auth argument is set to true
   profile_applicability: '* Level 1 - Master Node'
   description: Enable client authentication on etcd service.

--- a/bundle/compliance/cis_k8s/rules/cis_2_3/data.yaml
+++ b/bundle/compliance/cis_k8s/rules/cis_2_3/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 0c11cba6-a115-5485-bf50-f7f57a7deffa
+  id: f507bb23-1a9d-55dd-8edc-19a33e64d646
   name: Ensure that the --auto-tls argument is not set to true
   profile_applicability: '* Level 1 - Master Node'
   description: Do not use self-signed certificates for TLS.

--- a/bundle/compliance/cis_k8s/rules/cis_2_4/data.yaml
+++ b/bundle/compliance/cis_k8s/rules/cis_2_4/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 16d8e9bd-f09c-5195-b474-7d0861150d44
+  id: fe219241-4b9c-585f-b982-bb248852baa1
   name: Ensure that the --peer-cert-file and --peer-key-file arguments are set as
     appropriate
   profile_applicability: '* Level 1 - Master Node'

--- a/bundle/compliance/cis_k8s/rules/cis_2_5/data.yaml
+++ b/bundle/compliance/cis_k8s/rules/cis_2_5/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: be86166d-d578-5af3-a36c-fabca73ff99c
+  id: 900567f0-4c2f-543a-b5cf-d11223a772a2
   name: Ensure that the --peer-client-cert-auth argument is set to true
   profile_applicability: '* Level 1 - Master Node'
   description: etcd should be configured for peer authentication.

--- a/bundle/compliance/cis_k8s/rules/cis_2_6/data.yaml
+++ b/bundle/compliance/cis_k8s/rules/cis_2_6/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 6fa22113-1614-5998-94c8-7fba2c6d151f
+  id: 506b205e-9b6a-5d6e-b136-3e5d7101b1bc
   name: Ensure that the --peer-auto-tls argument is not set to true
   profile_applicability: '* Level 1 - Master Node'
   description: Do not use automatically generated self-signed certificates for TLS

--- a/bundle/compliance/cis_k8s/rules/cis_4_1_1/data.yaml
+++ b/bundle/compliance/cis_k8s/rules/cis_4_1_1/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 46c54b14-2a9f-5a4c-9c9e-4a71280422ee
+  id: cda5f949-378c-5ef6-a65e-47187af983e4
   name: Ensure that the kubelet service file permissions are set to 644 or more restrictive
   profile_applicability: '* Level 1 - Worker Node'
   description: Ensure that the `kubelet` service file has permissions of `644` or

--- a/bundle/compliance/cis_k8s/rules/cis_4_1_10/data.yaml
+++ b/bundle/compliance/cis_k8s/rules/cis_4_1_10/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 4ee863b2-fde3-583c-83e4-0b809bf4389e
+  id: 1915b785-942d-5613-9a24-b40394ef745f
   name: Ensure that the kubelet --config configuration file ownership is set to root:root
   profile_applicability: '* Level 1 - Worker Node'
   description: |-

--- a/bundle/compliance/cis_k8s/rules/cis_4_1_2/data.yaml
+++ b/bundle/compliance/cis_k8s/rules/cis_4_1_2/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 5316a432-8098-500b-ab01-f13d37e2d66e
+  id: 919ef7a7-126c-517e-aa35-fb251b1ad587
   name: Ensure that the kubelet service file ownership is set to root:root
   profile_applicability: '* Level 1 - Worker Node'
   description: Ensure that the `kubelet` service file ownership is set to `root:root`.

--- a/bundle/compliance/cis_k8s/rules/cis_4_1_5/data.yaml
+++ b/bundle/compliance/cis_k8s/rules/cis_4_1_5/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 406fd115-6c53-5bed-b8d6-b5def651b284
+  id: ee5ea7e5-dcb4-5abc-ab8c-58b3223669ce
   name: Ensure that the --kubeconfig kubelet.conf file permissions are set to 644
     or more restrictive
   profile_applicability: '* Level 1 - Worker Node'

--- a/bundle/compliance/cis_k8s/rules/cis_4_1_6/data.yaml
+++ b/bundle/compliance/cis_k8s/rules/cis_4_1_6/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 37ad604b-0db6-5227-bd00-9bfde1253a82
+  id: 49fe9df5-e86f-5981-ac24-dcaadadc2790
   name: Ensure that the --kubeconfig kubelet.conf file ownership is set to root:root
   profile_applicability: '* Level 1 - Worker Node'
   description: Ensure that the `kubelet.conf` file ownership is set to `root:root`.

--- a/bundle/compliance/cis_k8s/rules/cis_4_1_9/data.yaml
+++ b/bundle/compliance/cis_k8s/rules/cis_4_1_9/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: f13be1cb-5ce3-50d5-937e-2b64b1b769fd
+  id: f9344da7-b640-5587-98b8-9d9066000883
   name: Ensure that the kubelet --config configuration file has permissions set to
     644 or more restrictive
   profile_applicability: '* Level 1 - Worker Node'

--- a/bundle/compliance/cis_k8s/rules/cis_4_2_1/data.yaml
+++ b/bundle/compliance/cis_k8s/rules/cis_4_2_1/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 7ead9422-3286-5a8a-9b3e-9fa9af02607c
+  id: d1f8d730-5ee2-56bb-8065-78e8c8ae668c
   name: Ensure that the --anonymous-auth argument is set to false
   profile_applicability: '* Level 1 - Worker Node'
   description: Disable anonymous requests to the Kubelet server.

--- a/bundle/compliance/cis_k8s/rules/cis_4_2_10/data.yaml
+++ b/bundle/compliance/cis_k8s/rules/cis_4_2_10/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 719ccb48-0106-5c2a-a563-b31620da736a
+  id: f78dad83-1fe2-5aba-8507-64ea9efb53d6
   name: Ensure that the --tls-cert-file and --tls-private-key-file arguments are set
     as appropriate
   profile_applicability: '* Level 1 - Worker Node'

--- a/bundle/compliance/cis_k8s/rules/cis_4_2_11/data.yaml
+++ b/bundle/compliance/cis_k8s/rules/cis_4_2_11/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: bc4855e5-8921-5622-9784-5723c6d56091
+  id: 05f0c324-5c11-576f-b7a2-35ebf66f084b
   name: Ensure that the --rotate-certificates argument is not set to false
   profile_applicability: '* Level 1 - Worker Node'
   description: Enable kubelet client certificate rotation.

--- a/bundle/compliance/cis_k8s/rules/cis_4_2_12/data.yaml
+++ b/bundle/compliance/cis_k8s/rules/cis_4_2_12/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: ba803c66-9d80-5c30-b951-35b54a3bde31
+  id: ba545cc3-f447-5d14-8841-d3d3c05024e8
   name: Verify that the RotateKubeletServerCertificate argument is set to true
   profile_applicability: '* Level 1 - Worker Node'
   description: Enable kubelet server certificate rotation.

--- a/bundle/compliance/cis_k8s/rules/cis_4_2_13/data.yaml
+++ b/bundle/compliance/cis_k8s/rules/cis_4_2_13/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 05afb6ee-e198-5d85-97e4-05d86c73b1e4
+  id: 94fb43f8-90da-5089-b503-66a04faa2630
   name: Ensure that the Kubelet only makes use of Strong Cryptographic Ciphers
   profile_applicability: '* Level 1 - Worker Node'
   description: Ensure that the Kubelet is configured to only use strong cryptographic

--- a/bundle/compliance/cis_k8s/rules/cis_4_2_2/data.yaml
+++ b/bundle/compliance/cis_k8s/rules/cis_4_2_2/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 3781a71f-54e5-5987-9da2-d72a7d139af7
+  id: 9c02cf2c-a61d-5ac4-bf6f-78d4ddfc265f
   name: Ensure that the --authorization-mode argument is not set to AlwaysAllow
   profile_applicability: '* Level 1 - Worker Node'
   description: "Do not allow all requests.\nEnable explicit authorization."

--- a/bundle/compliance/cis_k8s/rules/cis_4_2_3/data.yaml
+++ b/bundle/compliance/cis_k8s/rules/cis_4_2_3/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 5097a7f7-be0e-57f1-81d7-665334381426
+  id: 551e7bcf-b231-500d-a193-d0a98163a680
   name: Ensure that the --client-ca-file argument is set as appropriate
   profile_applicability: '* Level 1 - Worker Node'
   description: Enable Kubelet authentication using certificates.

--- a/bundle/compliance/cis_k8s/rules/cis_4_2_4/data.yaml
+++ b/bundle/compliance/cis_k8s/rules/cis_4_2_4/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: c29d500e-8baf-5dad-b985-935be71d042f
+  id: 95e368ec-eebe-5aa1-bc86-9fa532a82d3a
   name: Verify that the --read-only-port argument is set to 0
   profile_applicability: '* Level 1 - Worker Node'
   description: Disable the read-only port.

--- a/bundle/compliance/cis_k8s/rules/cis_4_2_5/data.yaml
+++ b/bundle/compliance/cis_k8s/rules/cis_4_2_5/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 5f80fd5e-772e-5562-a310-be9b33d1f9d3
+  id: 374309b1-b87a-58bd-b795-1067d2e8ee9f
   name: Ensure that the --streaming-connection-idle-timeout argument is not set to
     0
   profile_applicability: '* Level 1 - Worker Node'

--- a/bundle/compliance/cis_k8s/rules/cis_4_2_6/data.yaml
+++ b/bundle/compliance/cis_k8s/rules/cis_4_2_6/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 0a2bee94-296f-56da-b5a5-308e81517990
+  id: c2b36f84-34b5-57fd-b9b0-f225be981497
   name: Ensure that the --protect-kernel-defaults argument is set to true
   profile_applicability: '* Level 1 - Worker Node'
   description: Protect tuned kernel parameters from overriding kubelet default kernel

--- a/bundle/compliance/cis_k8s/rules/cis_4_2_7/data.yaml
+++ b/bundle/compliance/cis_k8s/rules/cis_4_2_7/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: d649c9bf-85a8-5247-9ac0-53635680af10
+  id: 5382994d-59e0-54d9-a32b-dd860c467813
   name: Ensure that the --make-iptables-util-chains argument is set to true
   profile_applicability: '* Level 1 - Worker Node'
   description: Allow Kubelet to manage iptables.

--- a/bundle/compliance/cis_k8s/rules/cis_4_2_8/data.yaml
+++ b/bundle/compliance/cis_k8s/rules/cis_4_2_8/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 6f2e9eb5-d55f-5eaa-9f8d-472f246d1343
+  id: f6d0110b-51c5-54db-a531-29b0cb58d0f2
   name: Ensure that the --hostname-override argument is not set
   profile_applicability: '* Level 1 - Worker Node'
   description: Do not override node hostnames.

--- a/bundle/compliance/cis_k8s/rules/cis_4_2_9/data.yaml
+++ b/bundle/compliance/cis_k8s/rules/cis_4_2_9/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: ec063233-fc31-5f50-8ecd-ada8cba33192
+  id: b2909440-5ad0-522e-8db0-9439d573b7d5
   name: Ensure that the --event-qps argument is set to 0 or a level which ensures
     appropriate event capture
   profile_applicability: '* Level 2 - Worker Node'

--- a/bundle/compliance/cis_k8s/rules/cis_5_1_3/data.yaml
+++ b/bundle/compliance/cis_k8s/rules/cis_5_1_3/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: c1467bb9-fc01-5264-81e9-8a6b4f85b03d
+  id: fdd3f5ce-cbfb-5abf-8b4e-988168d5e5a4
   name: Minimize wildcard use in Roles and ClusterRoles
   profile_applicability: '* Level 1 - Worker Node'
   description: |-

--- a/bundle/compliance/cis_k8s/rules/cis_5_1_5/data.yaml
+++ b/bundle/compliance/cis_k8s/rules/cis_5_1_5/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 29ab476c-31fc-51a5-b24d-6842c1e27ba4
+  id: a97eb244-d583-528c-a49a-17b0aa14decd
   name: Ensure that default service accounts are not actively used.
   profile_applicability: '* Level 1 - Master Node'
   description: |-

--- a/bundle/compliance/cis_k8s/rules/cis_5_1_6/data.yaml
+++ b/bundle/compliance/cis_k8s/rules/cis_5_1_6/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 06f347db-c8b9-52bb-8e44-8f4af01d2a4f
+  id: b6189255-e8a5-5a01-87a6-a1b408a0d92a
   name: Ensure that Service Account Tokens are only mounted where necessary
   profile_applicability: '* Level 1 - Master Node'
   description: |-

--- a/bundle/compliance/cis_k8s/rules/cis_5_2_10/data.yaml
+++ b/bundle/compliance/cis_k8s/rules/cis_5_2_10/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: b193abe9-297a-5650-8740-939e9fd3bd8f
+  id: b96194c6-8eb7-5835-852d-47b84db83697
   name: Minimize the admission of containers with capabilities assigned
   profile_applicability: '* Level 2 - Master Node'
   description: Do not generally permit containers with capabilities

--- a/bundle/compliance/cis_k8s/rules/cis_5_2_2/data.yaml
+++ b/bundle/compliance/cis_k8s/rules/cis_5_2_2/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 2ebc00e8-2e43-5828-a5bb-b56c81733ec6
+  id: 875c1196-b6c7-5bc9-b255-e052853c3d08
   name: Minimize the admission of privileged containers
   profile_applicability: '* Level 1 - Master Node'
   description: |-

--- a/bundle/compliance/cis_k8s/rules/cis_5_2_3/data.yaml
+++ b/bundle/compliance/cis_k8s/rules/cis_5_2_3/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 9e2858f0-3e6b-571e-b675-3de189ef13e9
+  id: 38535c6f-a478-5cbb-82de-9417a3968bd6
   name: Minimize the admission of containers wishing to share the host process ID
     namespace
   profile_applicability: '* Level 1 - Master Node'

--- a/bundle/compliance/cis_k8s/rules/cis_5_2_4/data.yaml
+++ b/bundle/compliance/cis_k8s/rules/cis_5_2_4/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 8bc174f7-9a5b-5599-bc64-22f8ea0b28f5
+  id: 429ada1f-ad8f-5c2d-97fd-31485ace8a0c
   name: Minimize the admission of containers wishing to share the host IPC namespace
   profile_applicability: '* Level 1 - Master Node'
   description: Do not generally permit containers to be run with the `hostIPC` flag

--- a/bundle/compliance/cis_k8s/rules/cis_5_2_5/data.yaml
+++ b/bundle/compliance/cis_k8s/rules/cis_5_2_5/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 03b75f04-40a0-5b43-becb-8227b24eea5d
+  id: 28f96eda-c94e-597c-aef0-0bceee085540
   name: Minimize the admission of containers wishing to share the host network namespace
   profile_applicability: '* Level 1 - Master Node'
   description: Do not generally permit containers to be run with the `hostNetwork`

--- a/bundle/compliance/cis_k8s/rules/cis_5_2_6/data.yaml
+++ b/bundle/compliance/cis_k8s/rules/cis_5_2_6/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 48c203ce-2a1f-5b64-8b46-ef8d0de4f801
+  id: 94fbdc26-aa6f-52e6-9277-094174c46e29
   name: Minimize the admission of containers with allowPrivilegeEscalation
   profile_applicability: '* Level 1 - Master Node'
   description: |-

--- a/bundle/compliance/cis_k8s/rules/cis_5_2_7/data.yaml
+++ b/bundle/compliance/cis_k8s/rules/cis_5_2_7/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: 847fd97a-ec24-556d-b7d6-ceaa3dd27106
+  id: aa4374f0-adab-580c-ac9d-907fd2783219
   name: Minimize the admission of root containers
   profile_applicability: '* Level 2 - Master Node'
   description: Do not generally permit containers to be run as the root user.

--- a/bundle/compliance/cis_k8s/rules/cis_5_2_8/data.yaml
+++ b/bundle/compliance/cis_k8s/rules/cis_5_2_8/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: cef6324e-75cf-522f-b527-92c29bdc8986
+  id: 05c4bd94-162d-53e8-b112-e617ce74f8f6
   name: Minimize the admission of containers with the NET_RAW capability
   profile_applicability: '* Level 1 - Master Node'
   description: Do not generally permit containers with the potentially dangerous NET_RAW

--- a/bundle/compliance/cis_k8s/rules/cis_5_2_9/data.yaml
+++ b/bundle/compliance/cis_k8s/rules/cis_5_2_9/data.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: a7192e59-24c4-552f-a93e-12dff2f881c1
+  id: 23941040-0aae-5afd-bc8d-793742133647
   name: Minimize the admission of containers with added capabilities
   profile_applicability: '* Level 1 - Master Node'
   description: Do not generally permit containers with capabilities assigned beyond

--- a/dev/generate_rule_metadata.py
+++ b/dev/generate_rule_metadata.py
@@ -175,7 +175,7 @@ def generate_metadata(benchmark_id: str, raw_data: pd.DataFrame, sections: dict)
 
         benchmark_metadata = generate_rule_benchmark_metadata(benchmark_id, rule["Rule Number"])
         r = Rule(
-            id=str(uuid.uuid5(uuid.NAMESPACE_DNS, f"{benchmark_metadata.name} {rule['Title']}")),
+            id=str(uuid.uuid5(uuid.NAMESPACE_DNS, f"{benchmark_metadata.name} {rule['Title']} {rule['Rule Number']}")),
             name=rule["Title"],
             profile_applicability=f"* {rule['profile_applicability']}",
             description=common.fix_code_blocks(rule["description"]),

--- a/dev/generate_rule_templates.py
+++ b/dev/generate_rule_templates.py
@@ -41,6 +41,7 @@ def generate_rule_templates(benchmark: str, selected_rules: list, rule_template_
             rules_templates.append(rule_template)
 
     # Write templates into file
+    print(f"Processed {len(rules_templates)} rules for {benchmark} benchmark")
     save_rule_templates(rules_templates, rule_template_dir)
 
 
@@ -64,7 +65,7 @@ def migrate_csp_rule_metadata(doc: dict) -> dict:
     Migrate rule metadata to integration format
     """
     attributes = doc["attributes"]
-    print(attributes.get("rule_number"))
+    print(f"Processing {attributes['benchmark']['rule_number']}")
     metadata = {
         "impact": attributes.pop("impact", None),
         "default_value": attributes.pop("default_value", None),


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

### Summary of your changes
Rule ID was based on the rule name + benchmark id. I found out that in some benchmarks they have rules which share the same name, which led to duplicate rule ID. this will change the way. we calculate the rule id based on the benchmark + rule name + rule number.

### Related Issues
<!--
- Related: https://github.com/elastic/security-team/issues/
- Fixes: https://github.com/elastic/security-team/issues/
-->

### Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary README/documentation (if appropriate)

> **Note** Make sure to bump cloudbeat [`version/policy.go`](https://github.com/elastic/cloudbeat/blob/main/version/policy.go#L20) after merging this PR and drafting a new release.
