### PR TITLE
Update minimize_certain_capability audit function

### DIFF
--- a/bundle/compliance/cis_eks/rules/cis_4_2_7/test.rego
+++ b/bundle/compliance/cis_eks/rules/cis_4_2_7/test.rego
@@ -18,7 +18,7 @@ test_pass {
 }
 
 test_not_evaluated {
-	not finding with input as {"type": "no-kube-api"}
+	not finding with input as {"type": "k8s_object", "resource": {"kind": "Node"}}
 }
 
 rule_input(resource) = test_data.kube_api_input(resource)

--- a/bundle/compliance/cis_k8s/rules/cis_5_2_8/test.rego
+++ b/bundle/compliance/cis_k8s/rules/cis_5_2_8/test.rego
@@ -17,7 +17,7 @@ test_pass {
 }
 
 test_not_evaluated {
-	not finding with input as {"type": "no-kube-api"}
+	not finding with input as {"type": "k8s_object", "resource": {"kind": "Node"}}
 }
 
 rule_input(resource) = test_data.kube_api_input(resource)

--- a/bundle/compliance/policy/kube_api/data_adapter.rego
+++ b/bundle/compliance/policy/kube_api/data_adapter.rego
@@ -32,7 +32,7 @@ is_kube_pod {
 }
 
 pod = p {
-	input.resource.kind == "Pod"
+	is_kube_pod
 	p := input.resource
 }
 
@@ -41,7 +41,7 @@ is_service_account_or_pod = pod
 is_service_account_or_pod = service_account
 
 containers := c {
-	input.resource.kind == "Pod"
+	is_kube_pod
 	c := {
 		"app_containers": object.get(pod.spec, "containers", {}),
 		"init_containers": object.get(pod.spec, "initContainers", {}),

--- a/bundle/compliance/policy/kube_api/data_adapter.rego
+++ b/bundle/compliance/policy/kube_api/data_adapter.rego
@@ -26,6 +26,11 @@ is_kube_node {
 	input.resource.kind == "Node"
 }
 
+is_kube_pod {
+	is_kube_api
+	input.resource.kind == "Pod"
+}
+
 pod = p {
 	input.resource.kind == "Pod"
 	p := input.resource

--- a/bundle/compliance/policy/kube_api/minimize_certain_capability.rego
+++ b/bundle/compliance/policy/kube_api/minimize_certain_capability.rego
@@ -17,7 +17,7 @@ rule_evaluation {
 }
 
 finding := result {
-	data_adapter.is_kube_api
+	data_adapter.is_kube_pod
 
 	# set result
 	result := common.generate_result_without_expected(


### PR DESCRIPTION
### Summary of your changes
Update the audit function's filter to apply only to pod resources.
The previous implementation accidentally filtered events the right way by the evidence section.
Affected rules: 
- CIS EKS 4.2.7
- CIS K8s 5.2.8

### Related Issues
- https://github.com/elastic/csp-security-policies/pull/184

### Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary README/documentation (if appropriate)

### Screenshot
![Screenshot 2023-02-21 at 12 36 47](https://user-images.githubusercontent.com/68195305/220322049-fc48c3c3-9b95-4808-a1b4-32696e9ea731.png)


> **Note** Make sure to bump cloudbeat [`version/policy.go`](https://github.com/elastic/cloudbeat/blob/main/version/policy.go#L20) after merging this PR and drafting a new release.
