### PR TITLE
Fix evaluation conflict in s3 data adapter

### DIFF
--- a/bundle/compliance/cis_aws/rules/cis_2_1_2/test.rego
+++ b/bundle/compliance/cis_aws/rules/cis_2_1_2/test.rego
@@ -20,7 +20,7 @@ test_not_evaluated {
 	not_eval with input as test_data.not_evaluated_s3_bucket
 }
 
-rule_input(effect, principal, action, is_secure_transport) = test_data.generate_s3_bucket("Bucket", "", test_data.generate_s3_bucket_policy_statement(effect, principal, action, is_secure_transport), null)
+rule_input(effect, principal, action, is_secure_transport) = test_data.generate_s3_bucket("Bucket", "", [test_data.generate_s3_bucket_policy_statement(effect, principal, action, is_secure_transport)], null)
 
 eval_fail {
 	test.assert_fail(finding) with data.benchmark_data_adapter as data_adapter

--- a/bundle/compliance/cis_aws/test_data.rego
+++ b/bundle/compliance/cis_aws/test_data.rego
@@ -122,7 +122,7 @@ generate_s3_bucket(name, sse_algorithm, bucket_policy_statement, bucket_versioni
 		"SSEAlgorithm": sse_algorithm,
 		"BucketPolicy": {
 			"Version": "1",
-			"Statement": [bucket_policy_statement],
+			"Statement": bucket_policy_statement,
 		},
 		"BucketVersioning": bucket_versioning,
 	},

--- a/bundle/compliance/policy/aws_s3/data_adapter.rego
+++ b/bundle/compliance/policy/aws_s3/data_adapter.rego
@@ -8,6 +8,6 @@ sse_algorithm := input.resource.SSEAlgorithm
 
 bucket_policy := input.resource.BucketPolicy
 
-bucket_policy_statement := bucket_policy.Statement[_]
+bucket_policy_statements := object.get(bucket_policy, "Statement", {})
 
 bucket_versioning := input.resource.BucketVersioning

--- a/bundle/compliance/policy/aws_s3/ensure_bucket_policy_deny_http.rego
+++ b/bundle/compliance/policy/aws_s3/ensure_bucket_policy_deny_http.rego
@@ -6,7 +6,7 @@ import data.compliance.policy.aws_s3.data_adapter
 default rule_evaluation = false
 
 rule_evaluation {
-	statement := data_adapter.bucket_policy_statement
+	statement := data_adapter.bucket_policy_statements[_]
 	statement.Condition.Bool["aws:SecureTransport"] == "false"
 	statement.Action == "s3:*"
 	statement.Effect == "Deny"


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

### Summary of your changes
Handle the case in which we are sending s3 buckets with empty policy statements for evaluation causing `eval_conflict_error`.

### Related Issues
- Fixes: https://github.com/elastic/csp-security-policies/issues/198

### Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary README/documentation (if appropriate)

> **Note** Make sure to bump cloudbeat [`version/policy.go`](https://github.com/elastic/cloudbeat/blob/main/version/policy.go#L20) after merging this PR and drafting a new release.
