### PR TITLE
Add CIS AWS S3 rule 2.1.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![CIS K8S](https://img.shields.io/badge/CIS-Kubernetes%20(74%25)-326CE5?logo=Kubernetes)](RULES.md#k8s-cis-benchmark)
 [![CIS EKS](https://img.shields.io/badge/CIS-Amazon%20EKS%20(60%25)-FF9900?logo=Amazon+EKS)](RULES.md#eks-cis-benchmark)
-[![CIS AWS](https://img.shields.io/badge/CIS-AWS%20(75%25)-232F3E?logo=Amazon+AWS)](RULES.md#aws-cis-benchmark)
+[![CIS AWS](https://img.shields.io/badge/CIS-AWS%20(76%25)-232F3E?logo=Amazon+AWS)](RULES.md#aws-cis-benchmark)
 
 ![Coverage Badge](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/oren-zohar/a7160df46e48dff45b24096de9302d38/raw/csp-security-policies_coverage.json)
 

--- a/RULES.md
+++ b/RULES.md
@@ -201,9 +201,9 @@
 
 ## AWS CIS Benchmark
 
-### 47/63 implemented rules (75%)
+### 48/63 implemented rules (76%)
 
-#### Automated rules: 47/55 (85%)
+#### Automated rules: 48/55 (87%)
 
 #### Manual rules: 0/8 (0%)
 
@@ -234,7 +234,7 @@
 | [2.1.2](bundle/compliance/cis_aws/rules/cis_2_1_2) | Simple Storage Service (S3)       | Ensure S3 Bucket Policy is set to deny HTTP requests                                                               | :white_check_mark: | Automated |
 | [2.1.3](bundle/compliance/cis_aws/rules/cis_2_1_3) | Simple Storage Service (S3)       | Ensure MFA Delete is enabled on S3 buckets                                                                         | :white_check_mark: | Automated |
 |                       2.1.4                        | Simple Storage Service (S3)       | Ensure all data in Amazon S3 has been discovered, classified and secured when required.                            |        :x:         |  Manual   |
-|                       2.1.5                        | Simple Storage Service (S3)       | Ensure that S3 Buckets are configured with 'Block public access (bucket settings)'                                 |        :x:         | Automated |
+| [2.1.5](bundle/compliance/cis_aws/rules/cis_2_1_5) | Simple Storage Service (S3)       | Ensure that S3 Buckets are configured with 'Block public access (bucket settings)'                                 | :white_check_mark: | Automated |
 | [2.2.1](bundle/compliance/cis_aws/rules/cis_2_2_1) | Elastic Compute Cloud (EC2)       | Ensure EBS Volume Encryption is Enabled in all Regions                                                             | :white_check_mark: | Automated |
 | [2.3.1](bundle/compliance/cis_aws/rules/cis_2_3_1) | Relational Database Service (RDS) | Ensure that encryption is enabled for RDS Instances                                                                | :white_check_mark: | Automated |
 | [2.3.2](bundle/compliance/cis_aws/rules/cis_2_3_2) | Relational Database Service (RDS) | Ensure Auto Minor Version Upgrade feature is Enabled for RDS Instances                                             | :white_check_mark: | Automated |

--- a/bundle/compliance/cis_aws/rules/cis_2_1_1/test.rego
+++ b/bundle/compliance/cis_aws/rules/cis_2_1_1/test.rego
@@ -20,7 +20,7 @@ test_not_evaluated {
 	not_eval with input as rule_input("my bucket", null)
 }
 
-rule_input(name, sse_algorithm) = test_data.generate_s3_bucket(name, sse_algorithm, null, null)
+rule_input(name, sse_algorithm) = test_data.generate_s3_bucket(name, sse_algorithm, null, null, null)
 
 eval_fail {
 	test.assert_fail(finding) with data.benchmark_data_adapter as data_adapter

--- a/bundle/compliance/cis_aws/rules/cis_2_1_2/test.rego
+++ b/bundle/compliance/cis_aws/rules/cis_2_1_2/test.rego
@@ -5,7 +5,7 @@ import data.compliance.cis_aws.data_adapter
 import data.lib.test
 
 test_violation {
-	eval_fail with input as test_data.generate_s3_bucket("Bucket", "", null, null)
+	eval_fail with input as test_data.generate_s3_bucket("Bucket", "", null, null, null)
 	eval_fail with input as rule_input("Deny", "*", "s3:*", "true")
 	eval_fail with input as rule_input("Deny", "*", "wrong", "false")
 	eval_fail with input as rule_input("Deny", "wrong", "s3:*", "false")
@@ -15,7 +15,7 @@ test_violation {
 			test_data.generate_s3_bucket_policy_statement("Allow", "*", "s3:*", "false"),
 			test_data.generate_s3_bucket_policy_statement("Allow", "*", "s3:*", "false"),
 		],
-		null,
+		null, null,
 	)
 }
 
@@ -26,7 +26,7 @@ test_pass {
 			test_data.generate_s3_bucket_policy_statement("Deny", "*", "s3:*", "false"),
 			test_data.generate_s3_bucket_policy_statement("Allow", "*", "s3:*", "false"),
 		],
-		null,
+		null, null,
 	)
 }
 
@@ -35,7 +35,7 @@ test_not_evaluated {
 	not_eval with input as test_data.s3_bucket_without_policy
 }
 
-rule_input(effect, principal, action, is_secure_transport) = test_data.generate_s3_bucket("Bucket", "", [test_data.generate_s3_bucket_policy_statement(effect, principal, action, is_secure_transport)], null)
+rule_input(effect, principal, action, is_secure_transport) = test_data.generate_s3_bucket("Bucket", "", [test_data.generate_s3_bucket_policy_statement(effect, principal, action, is_secure_transport)], null, null)
 
 eval_fail {
 	test.assert_fail(finding) with data.benchmark_data_adapter as data_adapter

--- a/bundle/compliance/cis_aws/rules/cis_2_1_3/test.rego
+++ b/bundle/compliance/cis_aws/rules/cis_2_1_3/test.rego
@@ -16,10 +16,10 @@ test_pass {
 
 test_not_evaluated {
 	not_eval with input as test_data.not_evaluated_s3_bucket
-	not_eval with input as test_data.generate_s3_bucket("Bucket", "", null, null)
+	not_eval with input as test_data.generate_s3_bucket("Bucket", "", null, null, null)
 }
 
-rule_input(enabled, mfa_delete) = test_data.generate_s3_bucket("Bucket", "", null, test_data.generate_s3_bucket_versioning(enabled, mfa_delete))
+rule_input(enabled, mfa_delete) = test_data.generate_s3_bucket("Bucket", "", null, test_data.generate_s3_bucket_versioning(enabled, mfa_delete), null)
 
 eval_fail {
 	test.assert_fail(finding) with data.benchmark_data_adapter as data_adapter

--- a/bundle/compliance/cis_aws/rules/cis_2_1_5/data.yaml
+++ b/bundle/compliance/cis_aws/rules/cis_2_1_5/data.yaml
@@ -1,0 +1,139 @@
+metadata:
+  id: 34b16c08-cf25-5f0d-afed-98f75b5513de
+  name: Ensure that S3 Buckets are configured with 'Block public access (bucket settings)'
+  profile_applicability: '* Level 1'
+  description: |-
+    Amazon S3 provides `Block public access (bucket settings)` and `Block public access (account settings)` to help you manage public access to Amazon S3 resources.
+    By default, S3 buckets and objects are created with public access disabled.
+    However, an IAM principal with sufficient S3 permissions can enable public access at the bucket and/or object level.
+    While enabled, `Block public access (bucket settings)` prevents an individual bucket, and its contained objects, from becoming publicly accessible.
+    Similarly, `Block public access (account settings)` prevents all buckets, and contained objects, from becoming publicly accessible across the entire account.
+  rationale: |-
+    Amazon S3 `Block public access (bucket settings)` prevents the accidental or malicious public exposure of data contained within the respective bucket(s).
+
+
+    Amazon S3 `Block public access (account settings)` prevents the accidental or malicious public exposure of data contained within all buckets of the respective AWS account.
+
+    Whether blocking public access to all or some buckets is an organizational decision that should be based on data sensitivity, least privilege, and use case.
+  audit: |-
+    **If utilizing Block Public Access (bucket settings)**
+
+    **From Console:**
+
+    1. Login to AWS Management Console and open the Amazon S3 console using https://console.aws.amazon.com/s3/ 
+    2. Select the Check box next to the Bucket.
+    3. Click on 'Edit public access settings'.
+    4. Ensure that block public access settings are set appropriately for this bucket
+    5. Repeat for all the buckets in your AWS account.
+
+    **From Command Line:**
+
+    6. List all of the S3 Buckets
+    ```
+    aws s3 ls
+    ```
+    7. Find the public access setting on that bucket
+    ```
+    aws s3api get-public-access-block --bucket <name-of-the-bucket>
+    ```
+    Output if Block Public access is enabled:
+
+    ```
+    {
+     "PublicAccessBlockConfiguration": {
+     "BlockPublicAcls": true,
+     "IgnorePublicAcls": true,
+     "BlockPublicPolicy": true,
+     "RestrictPublicBuckets": true
+     }
+    }
+    ```
+
+    If the output reads `false` for the separate configuration settings then proceed to the remediation.
+
+    **If utilizing Block Public Access (account settings)**
+
+    **From Console:**
+
+    8. Login to AWS Management Console and open the Amazon S3 console using https://console.aws.amazon.com/s3/ 
+    9. Choose `Block public access (account settings)`
+    10. Ensure that block public access settings are set appropriately for your AWS account.
+
+    **From Command Line:**
+
+    To check Public access settings for this account status, run the following command,
+    `aws s3control get-public-access-block --account-id <ACCT_ID> --region <REGION_NAME>`
+
+    Output if Block Public access is enabled:
+
+    ```
+    {
+     "PublicAccessBlockConfiguration": {
+     "IgnorePublicAcls": true, 
+     "BlockPublicPolicy": true, 
+     "BlockPublicAcls": true, 
+     "RestrictPublicBuckets": true
+     }
+    }
+    ```
+
+    If the output reads `false` for the separate configuration settings then proceed to the remediation.
+  remediation: |-
+    **If utilizing Block Public Access (bucket settings)**
+
+    **From Console:**
+
+    1. Login to AWS Management Console and open the Amazon S3 console using https://console.aws.amazon.com/s3/ 
+    2. Select the Check box next to the Bucket.
+    3. Click on 'Edit public access settings'.
+    4. Click 'Block all public access'
+    5. Repeat for all the buckets in your AWS account that contain sensitive data.
+
+    **From Command Line:**
+
+    6. List all of the S3 Buckets
+    ```
+    aws s3 ls
+    ```
+    7. Set the Block Public Access to true on that bucket
+    ```
+    aws s3api put-public-access-block --bucket <name-of-bucket> --public-access-block-configuration "BlockPublicAcls=true,IgnorePublicAcls=true,BlockPublicPolicy=true,RestrictPublicBuckets=true"
+    ```
+
+    **If utilizing Block Public Access (account settings)**
+
+    **From Console:**
+
+    If the output reads `true` for the separate configuration settings then it is set on the account.
+
+    8. Login to AWS Management Console and open the Amazon S3 console using https://console.aws.amazon.com/s3/ 
+    9. Choose `Block Public Access (account settings)`
+    10. Choose `Edit` to change the block public access settings for all the buckets in your AWS account
+    11. Choose the settings you want to change, and then choose `Save`. For details about each setting, pause on the `i` icons.
+    12. When you're asked for confirmation, enter `confirm`. Then Click `Confirm` to save your changes.
+
+    **From Command Line:**
+
+    To set Block Public access settings for this account, run the following command:
+    ```
+    aws s3control put-public-access-block
+    --public-access-block-configuration BlockPublicAcls=true, IgnorePublicAcls=true, BlockPublicPolicy=true, RestrictPublicBuckets=true
+    --account-id <value>
+    ```
+  impact: |-
+    When you apply Block Public Access settings to an account, the settings apply to all AWS Regions globally. The settings might not take effect in all Regions immediately or simultaneously, but they eventually propagate to all Regions.
+  default_value: ''
+  references: 1. https://docs.aws.amazon.com/AmazonS3/latest/user-guide/block-public-access-account.html
+  section: Simple Storage Service (S3)
+  version: '1.0'
+  tags:
+  - CIS
+  - AWS
+  - CIS 2.1.5
+  - Simple Storage Service (S3)
+  benchmark:
+    name: CIS Amazon Web Services Foundations
+    version: v1.5.0
+    id: cis_aws
+    rule_number: 2.1.5
+    posture_type: cspm

--- a/bundle/compliance/cis_aws/rules/cis_2_1_5/rule.rego
+++ b/bundle/compliance/cis_aws/rules/cis_2_1_5/rule.rego
@@ -1,0 +1,5 @@
+package compliance.cis_aws.rules.cis_2_1_5
+
+import data.compliance.policy.aws_s3.ensure_block_public_access as audit
+
+finding = audit.finding

--- a/bundle/compliance/cis_aws/rules/cis_2_1_5/test.rego
+++ b/bundle/compliance/cis_aws/rules/cis_2_1_5/test.rego
@@ -1,0 +1,53 @@
+package compliance.cis_aws.rules.cis_2_1_5
+
+import data.cis_aws.test_data
+import data.compliance.cis_aws.data_adapter
+import data.lib.test
+
+test_violation {
+	# All properties false
+	eval_fail with input as rule_input(false, false, false, false)
+
+	# 3 properties false
+	eval_fail with input as rule_input(true, false, false, false)
+	eval_fail with input as rule_input(false, true, false, false)
+	eval_fail with input as rule_input(false, false, true, false)
+	eval_fail with input as rule_input(false, false, false, true)
+
+	# 2 properties false
+	eval_fail with input as rule_input(true, true, false, false)
+	eval_fail with input as rule_input(true, false, true, false)
+	eval_fail with input as rule_input(true, false, false, true)
+	eval_fail with input as rule_input(false, true, true, false)
+	eval_fail with input as rule_input(false, true, false, true)
+	eval_fail with input as rule_input(false, false, true, true)
+
+	# 1 property false
+	eval_fail with input as rule_input(false, true, true, true)
+	eval_fail with input as rule_input(true, false, true, true)
+	eval_fail with input as rule_input(true, true, false, true)
+	eval_fail with input as rule_input(true, true, true, false)
+}
+
+test_pass {
+	eval_pass with input as rule_input(true, true, true, true)
+}
+
+test_not_evaluated {
+	not_eval with input as test_data.not_evaluated_s3_bucket
+	not_eval with input as test_data.generate_s3_bucket("Bucket", "", null, null, null)
+}
+
+rule_input(block_public_acls, block_public_policy, ignore_public_acls, restrict_public_buckets) = test_data.generate_s3_bucket("Bucket", "", null, null, test_data.generate_s3_public_access_block_configuration(block_public_acls, block_public_policy, ignore_public_acls, restrict_public_buckets))
+
+eval_fail {
+	test.assert_fail(finding) with data.benchmark_data_adapter as data_adapter
+}
+
+eval_pass {
+	test.assert_pass(finding) with data.benchmark_data_adapter as data_adapter
+}
+
+not_eval {
+	not finding with data.benchmark_data_adapter as data_adapter
+}

--- a/bundle/compliance/cis_aws/test_data.rego
+++ b/bundle/compliance/cis_aws/test_data.rego
@@ -111,12 +111,13 @@ not_evaluated_s3_bucket = {
 			"Statement": [generate_s3_bucket_policy_statement("Deny", "*", "s3:*", "true")],
 		},
 		"bucket_versioning": generate_s3_bucket_versioning(true, true),
+		"public_access_block_configuration": generate_s3_public_access_block_configuration(true, true, true, true),
 	},
 	"type": "wrong type",
 	"subType": "wrong sub type",
 }
 
-generate_s3_bucket(name, sse_algorithm, bucket_policy_statement, bucket_versioning) = {
+generate_s3_bucket(name, sse_algorithm, bucket_policy_statement, bucket_versioning, public_access_block_configuration) = {
 	"resource": {
 		"name": name,
 		"sse_algorithm": sse_algorithm,
@@ -125,6 +126,7 @@ generate_s3_bucket(name, sse_algorithm, bucket_policy_statement, bucket_versioni
 			"Statement": bucket_policy_statement,
 		},
 		"bucket_versioning": bucket_versioning,
+		"public_access_block_configuration": public_access_block_configuration,
 	},
 	"type": "cloud-storage",
 	"subType": "aws-s3",
@@ -262,4 +264,11 @@ generate_rds_db_instance(encryption_enabled, auto_minor_version_upgrade_enabled)
 	},
 	"type": "cloud-database",
 	"subType": "aws-rds",
+}
+
+generate_s3_public_access_block_configuration(block_public_acls, block_public_policy, ignore_public_acls, restrict_public_buckets) = {
+	"BlockPublicAcls": block_public_acls,
+	"BlockPublicPolicy": block_public_policy,
+	"IgnorePublicAcls": ignore_public_acls,
+	"RestrictPublicBuckets": restrict_public_buckets,
 }

--- a/bundle/compliance/policy/aws_s3/data_adapter.rego
+++ b/bundle/compliance/policy/aws_s3/data_adapter.rego
@@ -11,3 +11,5 @@ bucket_policy := input.resource.bucket_policy
 bucket_policy_statements := object.get(bucket_policy, "Statement", [])
 
 bucket_versioning := input.resource.bucket_versioning
+
+public_access_block_configuration := input.resource.public_access_block_configuration

--- a/bundle/compliance/policy/aws_s3/ensure_block_public_access.rego
+++ b/bundle/compliance/policy/aws_s3/ensure_block_public_access.rego
@@ -1,0 +1,24 @@
+package compliance.policy.aws_s3.ensure_block_public_access
+
+import data.compliance.lib.common as lib_common
+import data.compliance.policy.aws_s3.data_adapter
+import future.keywords.in
+
+default rule_evaluation = false
+
+rule_evaluation {
+	data_adapter.public_access_block_configuration.BlockPublicAcls == true
+	data_adapter.public_access_block_configuration.BlockPublicPolicy == true
+	data_adapter.public_access_block_configuration.IgnorePublicAcls == true
+	data_adapter.public_access_block_configuration.RestrictPublicBuckets == true
+}
+
+finding = result {
+	data_adapter.is_s3
+	not data_adapter.public_access_block_configuration == null
+
+	result := lib_common.generate_result_without_expected(
+		lib_common.calculate_result(rule_evaluation),
+		{"PublicAccessBlockConfiguration": data_adapter.public_access_block_configuration},
+	)
+}


### PR DESCRIPTION
### Summary of your changes
Add CIS AWS S3 rule 2.1.5 - Ensure that S3 Buckets are configured with 'Block public access (bucket settings)'

### Related Issues
Resolves https://github.com/elastic/csp-security-policies/issues/194

### Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary README/documentation (if appropriate)
