### PR TITLE
Fix CIS AWS rule 2.1.5

### DIFF
--- a/bundle/compliance/cis_aws/rules/cis_2_1_1/test.rego
+++ b/bundle/compliance/cis_aws/rules/cis_2_1_1/test.rego
@@ -20,7 +20,7 @@ test_not_evaluated {
 	not_eval with input as rule_input("my bucket", null)
 }
 
-rule_input(name, sse_algorithm) = test_data.generate_s3_bucket(name, sse_algorithm, null, null, null)
+rule_input(name, sse_algorithm) = test_data.generate_s3_bucket(name, sse_algorithm, null, null, null, null)
 
 eval_fail {
 	test.assert_fail(finding) with data.benchmark_data_adapter as data_adapter

--- a/bundle/compliance/cis_aws/rules/cis_2_1_2/test.rego
+++ b/bundle/compliance/cis_aws/rules/cis_2_1_2/test.rego
@@ -5,7 +5,7 @@ import data.compliance.cis_aws.data_adapter
 import data.lib.test
 
 test_violation {
-	eval_fail with input as test_data.generate_s3_bucket("Bucket", "", null, null, null)
+	eval_fail with input as test_data.generate_s3_bucket("Bucket", "", null, null, null, null)
 	eval_fail with input as rule_input("Deny", "*", "s3:*", "true")
 	eval_fail with input as rule_input("Deny", "*", "wrong", "false")
 	eval_fail with input as rule_input("Deny", "wrong", "s3:*", "false")
@@ -15,7 +15,7 @@ test_violation {
 			test_data.generate_s3_bucket_policy_statement("Allow", "*", "s3:*", "false"),
 			test_data.generate_s3_bucket_policy_statement("Allow", "*", "s3:*", "false"),
 		],
-		null, null,
+		null, null, null,
 	)
 }
 
@@ -26,7 +26,7 @@ test_pass {
 			test_data.generate_s3_bucket_policy_statement("Deny", "*", "s3:*", "false"),
 			test_data.generate_s3_bucket_policy_statement("Allow", "*", "s3:*", "false"),
 		],
-		null, null,
+		null, null, null,
 	)
 }
 
@@ -35,7 +35,7 @@ test_not_evaluated {
 	not_eval with input as test_data.s3_bucket_without_policy
 }
 
-rule_input(effect, principal, action, is_secure_transport) = test_data.generate_s3_bucket("Bucket", "", [test_data.generate_s3_bucket_policy_statement(effect, principal, action, is_secure_transport)], null, null)
+rule_input(effect, principal, action, is_secure_transport) = test_data.generate_s3_bucket("Bucket", "", [test_data.generate_s3_bucket_policy_statement(effect, principal, action, is_secure_transport)], null, null, null)
 
 eval_fail {
 	test.assert_fail(finding) with data.benchmark_data_adapter as data_adapter

--- a/bundle/compliance/cis_aws/rules/cis_2_1_3/test.rego
+++ b/bundle/compliance/cis_aws/rules/cis_2_1_3/test.rego
@@ -16,10 +16,10 @@ test_pass {
 
 test_not_evaluated {
 	not_eval with input as test_data.not_evaluated_s3_bucket
-	not_eval with input as test_data.generate_s3_bucket("Bucket", "", null, null, null)
+	not_eval with input as test_data.generate_s3_bucket("Bucket", "", null, null, null, null)
 }
 
-rule_input(enabled, mfa_delete) = test_data.generate_s3_bucket("Bucket", "", null, test_data.generate_s3_bucket_versioning(enabled, mfa_delete), null)
+rule_input(enabled, mfa_delete) = test_data.generate_s3_bucket("Bucket", "", null, test_data.generate_s3_bucket_versioning(enabled, mfa_delete), null, null)
 
 eval_fail {
 	test.assert_fail(finding) with data.benchmark_data_adapter as data_adapter

--- a/bundle/compliance/cis_aws/test_data.rego
+++ b/bundle/compliance/cis_aws/test_data.rego
@@ -112,12 +112,13 @@ not_evaluated_s3_bucket = {
 		},
 		"bucket_versioning": generate_s3_bucket_versioning(true, true),
 		"public_access_block_configuration": generate_s3_public_access_block_configuration(true, true, true, true),
+		"account_public_access_block_configuration": generate_s3_public_access_block_configuration(true, true, true, true),
 	},
 	"type": "wrong type",
 	"subType": "wrong sub type",
 }
 
-generate_s3_bucket(name, sse_algorithm, bucket_policy_statement, bucket_versioning, public_access_block_configuration) = {
+generate_s3_bucket(name, sse_algorithm, bucket_policy_statement, bucket_versioning, public_access_block_configuration, account_public_access_block_configuration) = {
 	"resource": {
 		"name": name,
 		"sse_algorithm": sse_algorithm,
@@ -127,6 +128,7 @@ generate_s3_bucket(name, sse_algorithm, bucket_policy_statement, bucket_versioni
 		},
 		"bucket_versioning": bucket_versioning,
 		"public_access_block_configuration": public_access_block_configuration,
+		"account_public_access_block_configuration": account_public_access_block_configuration,
 	},
 	"type": "cloud-storage",
 	"subType": "aws-s3",

--- a/bundle/compliance/policy/aws_s3/data_adapter.rego
+++ b/bundle/compliance/policy/aws_s3/data_adapter.rego
@@ -13,3 +13,5 @@ bucket_policy_statements := object.get(bucket_policy, "Statement", [])
 bucket_versioning := input.resource.bucket_versioning
 
 public_access_block_configuration := input.resource.public_access_block_configuration
+
+account_public_access_block_configuration := input.resource.account_public_access_block_configuration

--- a/bundle/compliance/policy/aws_s3/ensure_block_public_access.rego
+++ b/bundle/compliance/policy/aws_s3/ensure_block_public_access.rego
@@ -1,5 +1,6 @@
 package compliance.policy.aws_s3.ensure_block_public_access
 
+import data.compliance.lib.assert
 import data.compliance.lib.common as lib_common
 import data.compliance.policy.aws_s3.data_adapter
 import future.keywords.in
@@ -7,18 +8,19 @@ import future.keywords.in
 default rule_evaluation = false
 
 rule_evaluation {
-	data_adapter.public_access_block_configuration.BlockPublicAcls == true
-	data_adapter.public_access_block_configuration.BlockPublicPolicy == true
-	data_adapter.public_access_block_configuration.IgnorePublicAcls == true
-	data_adapter.public_access_block_configuration.RestrictPublicBuckets == true
+	assert.some_true([data_adapter.public_access_block_configuration.BlockPublicAcls, data_adapter.account_public_access_block_configuration.BlockPublicAcls])
+	assert.some_true([data_adapter.public_access_block_configuration.BlockPublicPolicy, data_adapter.account_public_access_block_configuration.BlockPublicPolicy])
+	assert.some_true([data_adapter.public_access_block_configuration.IgnorePublicAcls, data_adapter.account_public_access_block_configuration.IgnorePublicAcls])
+	assert.some_true([data_adapter.public_access_block_configuration.RestrictPublicBuckets, data_adapter.account_public_access_block_configuration.RestrictPublicBuckets])
 }
 
 finding = result {
 	data_adapter.is_s3
 	not data_adapter.public_access_block_configuration == null
+	not data_adapter.account_public_access_block_configuration == null
 
 	result := lib_common.generate_result_without_expected(
 		lib_common.calculate_result(rule_evaluation),
-		{"PublicAccessBlockConfiguration": data_adapter.public_access_block_configuration},
+		{"PublicAccessBlockConfiguration": data_adapter.public_access_block_configuration, "AccountPublicAccessBlockConfiguration": data_adapter.account_public_access_block_configuration},
 	)
 }


### PR DESCRIPTION
### Summary of your changes
Fix the implementation of CIS AWS rule 2.1.5 - Ensure that S3 Buckets are configured with 'Block public access (bucket settings)'

### Related Issues
Related https://github.com/elastic/csp-security-policies/issues/194

### Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary README/documentation (if appropriate)