### PR TITLE
Fix CIS AWS rule 3.3

### DIFF
--- a/bundle/compliance/cis_aws/rules/cis_3_3/rule.rego
+++ b/bundle/compliance/cis_aws/rules/cis_3_3/rule.rego
@@ -11,7 +11,7 @@ finding = result {
 
 	# set result
 	result := common.generate_result_without_expected(
-		common.calculate_result(audit.no_public_log_access),
+		common.calculate_result(audit.bucket_is_public == false),
 		input.resource,
 	)
 }

--- a/bundle/compliance/policy/aws_cloudtrail/esure_no_public_accessibility.rego
+++ b/bundle/compliance/policy/aws_cloudtrail/esure_no_public_accessibility.rego
@@ -1,18 +1,33 @@
 package compliance.policy.aws_cloudtrail.no_public_bucket_access
 
-import data.compliance.lib.common
 import data.compliance.policy.aws_cloudtrail.data_adapter
-import future.keywords.every
+import future.keywords.if
+import future.keywords.in
 
-default no_public_log_access = false
+default bucket_is_public = false
 
-no_public_log_access {
-	grant := data_adapter.trail_bucket_info.acl.Grants[_]
-	not grant.Grantee.URI == "https://acs.amazonaws.com/groups/global/AllUsers"
-	not grant.Grantee.URI == "https://acs.amazonaws.com/groups/global/AuthenticatedUsers"
+# Bucket is public if any ACL grant grantee is `AllUsers`
+bucket_is_public if {
+	some grant in data_adapter.trail_bucket_info.acl.Grants
+	grant.Grantee.URI == "http://acs.amazonaws.com/groups/global/AllUsers"
+}
 
-	every statement in data_adapter.trail_bucket_info.policy.Statement {
-		not statement.Effect == "Allow"
-		not common.array_contains(["*", {"AWS": "*"}], statement.Principal)
-	}
+# Bucket is public if any ACL grant grantee is `AuthenticatedUsers`
+bucket_is_public if {
+	some grant in data_adapter.trail_bucket_info.acl.Grants
+	grant.Grantee.URI == "http://acs.amazonaws.com/groups/global/AuthenticatedUsers"
+}
+
+# Bucket is public if any policy statement has effect "Allow" and principal "*"
+bucket_is_public if {
+	some statement in data_adapter.trail_bucket_info.policy.Statement
+	statement.Effect == "Allow"
+	statement.Principal == "*"
+}
+
+# Bucket is public if any policy statement has effect "Allow" and principal {"AWS": "*"}
+bucket_is_public if {
+	some statement in data_adapter.trail_bucket_info.policy.Statement
+	statement.Effect == "Allow"
+	statement.Principal == {"AWS": "*"}
 }


### PR DESCRIPTION
### Summary of your changes
Fix logic for CIS AWS rule 3.3 - Ensure the S3 bucket used to store CloudTrail logs is not publicly accessible

### Related Issues
Resolves https://github.com/elastic/csp-security-policies/issues/203

### Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary README/documentation (if appropriate)
