### PR TITLE
Fix bug of Object-level logging for S3 buckets

### DIFF
--- a/bundle/compliance/cis_aws/rules/cis_3_10/test.rego
+++ b/bundle/compliance/cis_aws/rules/cis_3_10/test.rego
@@ -21,6 +21,7 @@ test_violation {
 test_pass {
 	eval_pass with input as rule_input([{"ReadWriteType": "WriteOnly", "DataResources": [{"Type": s3_object_type, "Values": ["arn:aws:s3"]}]}], true)
 	eval_pass with input as rule_input([{"ReadWriteType": "All", "DataResources": [{"Type": s3_object_type, "Values": ["arn:aws:s3"]}]}], true)
+	eval_pass with input as rule_input([{"ReadWriteType": "All", "DataResources": [{"Type": s3_object_type, "Values": ["arn:aws:s3:::aws-cloudtrail-logs-abc"]}]}], true)
 	eval_pass with input as rule_input([{"ReadWriteType": "All", "DataResources": [{"Type": not_s3_object_type, "Values": ["arn:aws:s3"]}, {"Type": s3_object_type, "Values": ["arn:aws:s3"]}]}], true)
 }
 

--- a/bundle/compliance/cis_aws/rules/cis_3_10/test.rego
+++ b/bundle/compliance/cis_aws/rules/cis_3_10/test.rego
@@ -21,7 +21,7 @@ test_violation {
 test_pass {
 	eval_pass with input as rule_input([{"ReadWriteType": "WriteOnly", "DataResources": [{"Type": s3_object_type, "Values": ["arn:aws:s3"]}]}], true)
 	eval_pass with input as rule_input([{"ReadWriteType": "All", "DataResources": [{"Type": s3_object_type, "Values": ["arn:aws:s3"]}]}], true)
-	eval_pass with input as rule_input([{"ReadWriteType": "All", "DataResources": [{"Type": s3_object_type, "Values": ["arn:aws:s3:::aws-cloudtrail-logs-abc"]}]}], true)
+	eval_pass with input as rule_input([{"ReadWriteType": "All", "DataResources": [{"Type": s3_object_type, "Values": ["arn:aws:s3:::some-bucket"]}]}], true)
 	eval_pass with input as rule_input([{"ReadWriteType": "All", "DataResources": [{"Type": not_s3_object_type, "Values": ["arn:aws:s3"]}, {"Type": s3_object_type, "Values": ["arn:aws:s3"]}]}], true)
 }
 

--- a/bundle/compliance/cis_aws/rules/cis_3_11/test.rego
+++ b/bundle/compliance/cis_aws/rules/cis_3_11/test.rego
@@ -21,6 +21,7 @@ test_violation {
 test_pass {
 	eval_pass with input as rule_input([{"ReadWriteType": "ReadOnly", "DataResources": [{"Type": s3_object_type, "Values": ["arn:aws:s3"]}]}], true)
 	eval_pass with input as rule_input([{"ReadWriteType": "All", "DataResources": [{"Type": s3_object_type, "Values": ["arn:aws:s3"]}]}], true)
+	eval_pass with input as rule_input([{"ReadWriteType": "All", "DataResources": [{"Type": s3_object_type, "Values": ["arn:aws:s3:::aws-cloudtrail-logs-abc"]}]}], true)
 	eval_pass with input as rule_input([{"ReadWriteType": "All", "DataResources": [{"Type": not_s3_object_type, "Values": ["arn:aws:s3"]}, {"Type": s3_object_type, "Values": ["arn:aws:s3"]}]}], true)
 }
 

--- a/bundle/compliance/cis_aws/rules/cis_3_11/test.rego
+++ b/bundle/compliance/cis_aws/rules/cis_3_11/test.rego
@@ -21,7 +21,7 @@ test_violation {
 test_pass {
 	eval_pass with input as rule_input([{"ReadWriteType": "ReadOnly", "DataResources": [{"Type": s3_object_type, "Values": ["arn:aws:s3"]}]}], true)
 	eval_pass with input as rule_input([{"ReadWriteType": "All", "DataResources": [{"Type": s3_object_type, "Values": ["arn:aws:s3"]}]}], true)
-	eval_pass with input as rule_input([{"ReadWriteType": "All", "DataResources": [{"Type": s3_object_type, "Values": ["arn:aws:s3:::aws-cloudtrail-logs-abc"]}]}], true)
+	eval_pass with input as rule_input([{"ReadWriteType": "All", "DataResources": [{"Type": s3_object_type, "Values": ["arn:aws:s3:::some-bucket"]}]}], true)
 	eval_pass with input as rule_input([{"ReadWriteType": "All", "DataResources": [{"Type": not_s3_object_type, "Values": ["arn:aws:s3"]}, {"Type": s3_object_type, "Values": ["arn:aws:s3"]}]}], true)
 }
 

--- a/bundle/compliance/policy/aws_cloudtrail/verify_s3_object_logging.rego
+++ b/bundle/compliance/policy/aws_cloudtrail/verify_s3_object_logging.rego
@@ -18,5 +18,5 @@ ensure_s3_object_logging(allowed_types) {
 	dataResource.Type == "AWS::S3::Object"
 
 	partialARN := dataResource.Values[k]
-	partialARN == "arn:aws:s3"
+	startswith(partialARN, "arn:aws:s3")
 } else = false


### PR DESCRIPTION
### Summary of your changes
Fixing CSPM rules 3.10, 3.11.
When object-level logging for write / read events is enabled for S3 bucket the evaluation should pass.

### Related Issues
Resolves: https://github.com/elastic/cloudbeat/issues/811

### Checklist
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary README/documentation (if appropriate)

> **Note** Make sure to bump cloudbeat [`version/policy.go`](https://github.com/elastic/cloudbeat/blob/main/version/policy.go#L20) after merging this PR and drafting a new release.
