### PR TITLE
Fix CIS AWS rule 3.6

### DIFF
--- a/bundle/compliance/cis_aws/rules/cis_3_6/rule.rego
+++ b/bundle/compliance/cis_aws/rules/cis_3_6/rule.rego
@@ -5,6 +5,10 @@ import data.compliance.policy.aws_cloudtrail.data_adapter
 
 default rule_evaluation = false
 
+rule_evaluation {
+	data_adapter.trail_bucket_info.logging.Enabled == true
+}
+
 # Ensure S3 bucket access logging is enabled on the CloudTrail S3 bucket
 finding = result {
 	# filter
@@ -15,8 +19,4 @@ finding = result {
 		common.calculate_result(rule_evaluation),
 		input.resource,
 	)
-}
-
-rule_evaluation {
-	data_adapter.trail_bucket_info.logging.enabled == true
 }

--- a/bundle/compliance/cis_aws/test_data.rego
+++ b/bundle/compliance/cis_aws/test_data.rego
@@ -186,7 +186,7 @@ generate_enriched_trail(is_log_validation_enabled, cloudwatch_log_group_arn, log
 			"KmsKeyId": kms_key_id,
 		},
 		"Status": {"LatestcloudwatchLogdDeliveryTime": log_delivery_time},
-		"bucket_info": {"logging": {"enabled": is_bucket_logging_enabled}},
+		"bucket_info": {"logging": {"Enabled": is_bucket_logging_enabled}},
 	},
 }
 


### PR DESCRIPTION
### Summary of your changes
Fix CIS AWS rule 3.6 - Ensure S3 bucket access logging is enabled on the CloudTrail S3 bucket

### Related Issues
Resolves https://github.com/elastic/cloudbeat/issues/810

### Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary README/documentation (if appropriate)
