### PR TITLE
Fixing security group non default evaluations

### DIFF
--- a/bundle/compliance/cis_aws/rules/cis_5_4/test.rego
+++ b/bundle/compliance/cis_aws/rules/cis_5_4/test.rego
@@ -15,9 +15,12 @@ test_violation {
 test_pass {
 	# default security group with restricted inbound/outbound rules
 	eval_pass with input as rule_input({"GroupName": "default", "IpPermissions": [], "IpPermissionsEgress": []})
+}
 
-	# non default security groups can have any rule
-	eval_pass with input as rule_input({"GroupName": "custom", "IpPermissions": [{}], "IpPermissionsEgress": [{}]})
+test_not_evaluated {
+	not_eval with input as rule_input({"GroupName": "custom", "IpPermissions": [{}], "IpPermissionsEgress": [{}]})
+	not_eval with input as rule_input({"GroupName": "custom", "IpPermissions": [{}]})
+	not_eval with input as rule_input({"GroupName": "custom", "IpPermissionsEgress": [{}]})
 }
 
 rule_input(entry) = test_data.generate_security_group(entry)
@@ -28,4 +31,8 @@ eval_fail {
 
 eval_pass {
 	test.assert_pass(finding) with data.benchmark_data_adapter as data_adapter
+}
+
+not_eval {
+	not finding with data.benchmark_data_adapter as data_adapter
 }

--- a/bundle/compliance/policy/aws_ec2/data_adapter.rego
+++ b/bundle/compliance/policy/aws_ec2/data_adapter.rego
@@ -26,7 +26,7 @@ security_groups_ip_permissions = entries {
 
 is_default_security_group {
 	input.resource.GroupName == "default"
-} else = false
+}
 
 # Filter all the entries that 
 # 1. have ingres (egress == false)

--- a/bundle/compliance/policy/aws_ec2/ensure_default_security_group_restricted.rego
+++ b/bundle/compliance/policy/aws_ec2/ensure_default_security_group_restricted.rego
@@ -9,6 +9,7 @@ default rule_evaluation = false
 finding = result {
 	# filter 
 	data_adapter.is_security_group_policy
+	data_adapter.is_default_security_group
 
 	# set result
 	result := common.generate_result_without_expected(
@@ -21,10 +22,7 @@ finding = result {
 # non default security group can have any rules
 rule_evaluation {
 	assert.all_true([
-		data_adapter.is_default_security_group,
 		count(data_adapter.security_group_inbound_rules) == 0,
 		count(data_adapter.security_group_outbound_rules) == 0,
 	])
-} else {
-	not data_adapter.is_default_security_group
 }


### PR DESCRIPTION
### Summary of your changes
Making sure that AWS CIS rule 5.4 doesn't evaluate non-default resources.

Ran evaluation comand:
```bash
opa eval -b ./bundle -i input_securitygroup.json data.main
```

With input:
```json
{
  "subType": "aws-security-group",
  "resource": {
    "GroupName": "jenia",
    "IpPermissions": [
      {
        "FromPort": 22,
        "IpProtocol": "tcp",
        "IpRanges": [
          {
            "CidrIp": ""
          }
        ]
      }
    ],
    "IpPermissionsEgress": [
      {
        "IpProtocol": "-1",
        "IpRanges": [
          {
            "CidrIp": ""
          }
        ]
      }
    ]
  }
}
```

Got response:
```json
{
  "result": [
    {
      "expressions": [
        {
          "value": {
            "findings": [
              {
                "result": {
                  "evaluation": "passed",
                  "evidence": {
                    "GroupName": "jenia",
                    "IpPermissions": [
                      {
                        "FromPort": 22,
                        "IpProtocol": "tcp",
                        "IpRanges": [
                          {
                            "CidrIp": ""
                          }
                        ]
                      }
                    ],
                    "IpPermissionsEgress": [
                      {
                        "IpProtocol": "-1",
                        "IpRanges": [
                          {
                            "CidrIp": ""
                          }
                        ]
                      }
                    ]
                  }
                },
                "rule": {
                  "audit": "Perform the following to determine if the account is configured as prescribed:\n\n1. Login to the AWS Management Console at [https://console.aws.amazon.com/vpc/home](https://console.aws.amazon.com/vpc/home)\n2. In the left pane, click `Security Groups` \n3. For each security group, perform the following:\n4. Select the security group\n5. Click the `Inbound Rules` tab\n6. Ensure no rule exists that has a port range that includes port `22`, `3389`, or other remote server administration ports for your environment and has a `Source` of `0.0.0.0/0` \n\n**Note:** A Port value of `ALL` or a port range such as `0-1024` are inclusive of port `22`, `3389`, and other remote server administration ports.",
                  "benchmark": {
                    "id": "cis_aws",
                    "name": "CIS Amazon Web Services Foundations",
                    "posture_type": "cspm",
                    "rule_number": "5.2",
                    "version": "v1.5.0"
                  },
                  "default_value": "",
                  "description": "Security groups provide stateful filtering of ingress and egress network traffic to AWS resources.\nIt is recommended that no security group allows unrestricted ingress access to remote server administration ports, such as SSH to port `22` and RDP to port `3389`.",
                  "id": "9209df46-e7e2-5d4b-b1b6-b54a196e7e5d",
                  "impact": "When updating an existing environment, ensure that administrators have access to remote server administration ports through another mechanism before removing access by deleting the 0.0.0.0/0 inbound rule.",
                  "name": "Ensure no security groups allow ingress from 0.0.0.0/0 to remote server administration ports",
                  "profile_applicability": "* Level 1",
                  "rationale": "Public access to remote server administration ports, such as 22 and 3389, increases resource attack surface and unnecessarily raises the risk of resource compromise.",
                  "references": "1. https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-security-groups.html#deleting-security-group-rule",
                  "remediation": "Perform the following to implement the prescribed state:\n\n1. Login to the AWS Management Console at [https://console.aws.amazon.com/vpc/home](https://console.aws.amazon.com/vpc/home)\n2. In the left pane, click `Security Groups` \n3. For each security group, perform the following:\n4. Select the security group\n5. Click the `Inbound Rules` tab\n6. Click the `Edit inbound rules` button\n7. Identify the rules to be edited or removed\n8. Either A) update the Source field to a range other than 0.0.0.0/0, or, B) Click `Delete` to remove the offending inbound rule\n9. Click `Save rules`",
                  "section": "Networking",
                  "tags": [
                    "CIS",
                    "AWS",
                    "CIS 5.2",
                    "Networking"
                  ],
                  "version": "1.0"
                }
              },
              {
                "result": {
                  "evaluation": "passed",
                  "evidence": {
                    "GroupName": "jenia",
                    "IpPermissions": [
                      {
                        "FromPort": 22,
                        "IpProtocol": "tcp",
                        "IpRanges": [
                          {
                            "CidrIp": ""
                          }
                        ]
                      }
                    ],
                    "IpPermissionsEgress": [
                      {
                        "IpProtocol": "-1",
                        "IpRanges": [
                          {
                            "CidrIp": ""
                          }
                        ]
                      }
                    ]
                  }
                },
                "rule": {
                  "audit": "Perform the following to determine if the account is configured as prescribed:\n\n1. Login to the AWS Management Console at [https://console.aws.amazon.com/vpc/home](https://console.aws.amazon.com/vpc/home)\n2. In the left pane, click `Security Groups` \n3. For each security group, perform the following:\n4. Select the security group\n5. Click the `Inbound Rules` tab\n6. Ensure no rule exists that has a port range that includes port `22`, `3389`, or other remote server administration ports for your environment and has a `Source` of `::/0` \n\n**Note:** A Port value of `ALL` or a port range such as `0-1024` are inclusive of port `22`, `3389`, and other remote server administration ports.",
                  "benchmark": {
                    "id": "cis_aws",
                    "name": "CIS Amazon Web Services Foundations",
                    "posture_type": "cspm",
                    "rule_number": "5.3",
                    "version": "v1.5.0"
                  },
                  "default_value": "",
                  "description": "Security groups provide stateful filtering of ingress and egress network traffic to AWS resources.\nIt is recommended that no security group allows unrestricted ingress access to remote server administration ports, such as SSH to port `22` and RDP to port `3389`.",
                  "id": "f9dfc7e7-d067-5be5-8fc1-5d9043a4cd06",
                  "impact": "When updating an existing environment, ensure that administrators have access to remote server administration ports through another mechanism before removing access by deleting the ::/0 inbound rule.",
                  "name": "Ensure no security groups allow ingress from ::/0 to remote server administration ports",
                  "profile_applicability": "* Level 1",
                  "rationale": "Public access to remote server administration ports, such as 22 and 3389, increases resource attack surface and unnecessarily raises the risk of resource compromise.",
                  "references": "1. https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-security-groups.html#deleting-security-group-rule",
                  "remediation": "Perform the following to implement the prescribed state:\n\n1. Login to the AWS Management Console at [https://console.aws.amazon.com/vpc/home](https://console.aws.amazon.com/vpc/home)\n2. In the left pane, click `Security Groups` \n3. For each security group, perform the following:\n4. Select the security group\n5. Click the `Inbound Rules` tab\n6. Click the `Edit inbound rules` button\n7. Identify the rules to be edited or removed\n8. Either A) update the Source field to a range other than ::/0, or, B) Click `Delete` to remove the offending inbound rule\n9. Click `Save rules`",
                  "section": "Networking",
                  "tags": [
                    "CIS",
                    "AWS",
                    "CIS 5.3",
                    "Networking"
                  ],
                  "version": "1.0"
                }
              }
            ],
            "metadata": {
              "opa_version": "0.42.0-dev",
              "policy_version": "1.0.0"
            },
            "resource": {
              "GroupName": "jenia",
              "IpPermissions": [
                {
                  "FromPort": 22,
                  "IpProtocol": "tcp",
                  "IpRanges": [
                    {
                      "CidrIp": ""
                    }
                  ]
                }
              ],
              "IpPermissionsEgress": [
                {
                  "IpProtocol": "-1",
                  "IpRanges": [
                    {
                      "CidrIp": ""
                    }
                  ]
                }
              ]
            }
          },
          "text": "data.main",
          "location": {
            "row": 1,
            "col": 1
          }
        }
      ]
    }
  ]
}
```

You can see that there are no findings for the resource from the 5.4 rule.

When changing the resource name to `default`, I get findings from 5.4 rule:
```json
{
  "result": [
    {
      "expressions": [
        {
          "value": {
            "findings": [
              {
                "result": {
                  "evaluation": "failed",
                  "evidence": {
                    "GroupName": "default",
                    "IpPermissions": [
                      {
                        "FromPort": 22,
                        "IpProtocol": "tcp",
                        "IpRanges": [
                          {
                            "CidrIp": ""
                          }
                        ]
                      }
                    ],
                    "IpPermissionsEgress": [
                      {
                        "IpProtocol": "-1",
                        "IpRanges": [
                          {
                            "CidrIp": ""
                          }
                        ]
                      }
                    ]
                  }
                },
                "rule": {
                  "audit": "Perform the following to determine if the account is configured as prescribed:\n\nSecurity Group State\n\n1. Login to the AWS Management Console at [https://console.aws.amazon.com/vpc/home](https://console.aws.amazon.com/vpc/home)\n2. Repeat the next steps for all VPCs - including the default VPC in each AWS region:\n3. In the left pane, click `Security Groups` \n4. For each default security group, perform the following:\n5. Select the `default` security group\n6. Click the `Inbound Rules` tab\n7. Ensure no rule exist\n8. Click the `Outbound Rules` tab\n9. Ensure no rules exist\n\nSecurity Group Members\n\n10. Login to the AWS Management Console at [https://console.aws.amazon.com/vpc/home](https://console.aws.amazon.com/vpc/home)\n11. Repeat the next steps for all default groups in all VPCs - including the default VPC in each AWS region:\n12. In the left pane, click `Security Groups` \n13. Copy the id of the default security group.\n14. Change to the EC2 Management Console at https://console.aws.amazon.com/ec2/v2/home\n15. In the filter column type 'Security Group ID : \u003c security group id from #4 \u003e'",
                  "benchmark": {
                    "id": "cis_aws",
                    "name": "CIS Amazon Web Services Foundations",
                    "posture_type": "cspm",
                    "rule_number": "5.4",
                    "version": "v1.5.0"
                  },
                  "default_value": "",
                  "description": "A VPC comes with a default security group whose initial settings deny all inbound traffic, allow all outbound traffic, and allow all traffic between instances assigned to the security group.\nIf you don't specify a security group when you launch an instance, the instance is automatically assigned to this default security group.\nSecurity groups provide stateful filtering of ingress/egress network traffic to AWS resources.\nIt is recommended that the default security group restrict all traffic.\n\nThe default VPC in every region should have its default security group updated to comply.\nAny newly created VPCs will automatically contain a default security group that will need remediation to comply with this recommendation.\n\n**NOTE:** When implementing this recommendation, VPC flow logging is invaluable in determining the least privilege port access required by systems to work properly because it can log all packet acceptances and rejections occurring under the current security groups.\nThis dramatically reduces the primary barrier to least privilege engineering - discovering the minimum ports required by systems in the environment.\nEven if the VPC flow logging recommendation in this benchmark is not adopted as a permanent security measure, it should be used during any period of discovery and engineering for least privileged security groups.",
                  "id": "bbc219e5-75d8-55d6-bccb-7d1acef796bf",
                  "impact": "Implementing this recommendation in an existing VPC containing operating resources requires extremely careful migration planning as the default security groups are likely to be enabling many ports that are unknown. Enabling VPC flow logging (of accepts) in an existing environment that is known to be breach free will reveal the current pattern of ports being used for each instance to communicate successfully.",
                  "name": "Ensure the default security group of every VPC restricts all traffic",
                  "profile_applicability": "* Level 2",
                  "rationale": "Configuring all VPC default security groups to restrict all traffic will encourage least privilege security group development and mindful placement of AWS resources into security groups which will in-turn reduce the exposure of those resources.",
                  "references": "1. https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-network-security.html\n2. https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-security-groups.html#default-security-group",
                  "remediation": "Security Group Members\n\nPerform the following to implement the prescribed state:\n\n1. Identify AWS resources that exist within the default security group\n2. Create a set of least privilege security groups for those resources\n3. Place the resources in those security groups\n4. Remove the resources noted in #1 from the default security group\n\nSecurity Group State\n\n5. Login to the AWS Management Console at [https://console.aws.amazon.com/vpc/home](https://console.aws.amazon.com/vpc/home)\n6. Repeat the next steps for all VPCs - including the default VPC in each AWS region:\n7. In the left pane, click `Security Groups` \n8. For each default security group, perform the following:\n9. Select the `default` security group\n10. Click the `Inbound Rules` tab\n11. Remove any inbound rules\n12. Click the `Outbound Rules` tab\n13. Remove any Outbound rules\n\nRecommended:\n\nIAM groups allow you to edit the \"name\" field.\nAfter remediating default groups rules for all VPCs in all regions, edit this field to add text similar to \"DO NOT USE.\nDO NOT ADD RULES\"",
                  "section": "Networking",
                  "tags": [
                    "CIS",
                    "AWS",
                    "CIS 5.4",
                    "Networking"
                  ],
                  "version": "1.0"
                }
              },
              {
                "result": {
                  "evaluation": "passed",
                  "evidence": {
                    "GroupName": "default",
                    "IpPermissions": [
                      {
                        "FromPort": 22,
                        "IpProtocol": "tcp",
                        "IpRanges": [
                          {
                            "CidrIp": ""
                          }
                        ]
                      }
                    ],
                    "IpPermissionsEgress": [
                      {
                        "IpProtocol": "-1",
                        "IpRanges": [
                          {
                            "CidrIp": ""
                          }
                        ]
                      }
                    ]
                  }
                },
                "rule": {
                  "audit": "Perform the following to determine if the account is configured as prescribed:\n\n1. Login to the AWS Management Console at [https://console.aws.amazon.com/vpc/home](https://console.aws.amazon.com/vpc/home)\n2. In the left pane, click `Security Groups` \n3. For each security group, perform the following:\n4. Select the security group\n5. Click the `Inbound Rules` tab\n6. Ensure no rule exists that has a port range that includes port `22`, `3389`, or other remote server administration ports for your environment and has a `Source` of `0.0.0.0/0` \n\n**Note:** A Port value of `ALL` or a port range such as `0-1024` are inclusive of port `22`, `3389`, and other remote server administration ports.",
                  "benchmark": {
                    "id": "cis_aws",
                    "name": "CIS Amazon Web Services Foundations",
                    "posture_type": "cspm",
                    "rule_number": "5.2",
                    "version": "v1.5.0"
                  },
                  "default_value": "",
                  "description": "Security groups provide stateful filtering of ingress and egress network traffic to AWS resources.\nIt is recommended that no security group allows unrestricted ingress access to remote server administration ports, such as SSH to port `22` and RDP to port `3389`.",
                  "id": "9209df46-e7e2-5d4b-b1b6-b54a196e7e5d",
                  "impact": "When updating an existing environment, ensure that administrators have access to remote server administration ports through another mechanism before removing access by deleting the 0.0.0.0/0 inbound rule.",
                  "name": "Ensure no security groups allow ingress from 0.0.0.0/0 to remote server administration ports",
                  "profile_applicability": "* Level 1",
                  "rationale": "Public access to remote server administration ports, such as 22 and 3389, increases resource attack surface and unnecessarily raises the risk of resource compromise.",
                  "references": "1. https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-security-groups.html#deleting-security-group-rule",
                  "remediation": "Perform the following to implement the prescribed state:\n\n1. Login to the AWS Management Console at [https://console.aws.amazon.com/vpc/home](https://console.aws.amazon.com/vpc/home)\n2. In the left pane, click `Security Groups` \n3. For each security group, perform the following:\n4. Select the security group\n5. Click the `Inbound Rules` tab\n6. Click the `Edit inbound rules` button\n7. Identify the rules to be edited or removed\n8. Either A) update the Source field to a range other than 0.0.0.0/0, or, B) Click `Delete` to remove the offending inbound rule\n9. Click `Save rules`",
                  "section": "Networking",
                  "tags": [
                    "CIS",
                    "AWS",
                    "CIS 5.2",
                    "Networking"
                  ],
                  "version": "1.0"
                }
              },
              {
                "result": {
                  "evaluation": "passed",
                  "evidence": {
                    "GroupName": "default",
                    "IpPermissions": [
                      {
                        "FromPort": 22,
                        "IpProtocol": "tcp",
                        "IpRanges": [
                          {
                            "CidrIp": ""
                          }
                        ]
                      }
                    ],
                    "IpPermissionsEgress": [
                      {
                        "IpProtocol": "-1",
                        "IpRanges": [
                          {
                            "CidrIp": ""
                          }
                        ]
                      }
                    ]
                  }
                },
                "rule": {
                  "audit": "Perform the following to determine if the account is configured as prescribed:\n\n1. Login to the AWS Management Console at [https://console.aws.amazon.com/vpc/home](https://console.aws.amazon.com/vpc/home)\n2. In the left pane, click `Security Groups` \n3. For each security group, perform the following:\n4. Select the security group\n5. Click the `Inbound Rules` tab\n6. Ensure no rule exists that has a port range that includes port `22`, `3389`, or other remote server administration ports for your environment and has a `Source` of `::/0` \n\n**Note:** A Port value of `ALL` or a port range such as `0-1024` are inclusive of port `22`, `3389`, and other remote server administration ports.",
                  "benchmark": {
                    "id": "cis_aws",
                    "name": "CIS Amazon Web Services Foundations",
                    "posture_type": "cspm",
                    "rule_number": "5.3",
                    "version": "v1.5.0"
                  },
                  "default_value": "",
                  "description": "Security groups provide stateful filtering of ingress and egress network traffic to AWS resources.\nIt is recommended that no security group allows unrestricted ingress access to remote server administration ports, such as SSH to port `22` and RDP to port `3389`.",
                  "id": "f9dfc7e7-d067-5be5-8fc1-5d9043a4cd06",
                  "impact": "When updating an existing environment, ensure that administrators have access to remote server administration ports through another mechanism before removing access by deleting the ::/0 inbound rule.",
                  "name": "Ensure no security groups allow ingress from ::/0 to remote server administration ports",
                  "profile_applicability": "* Level 1",
                  "rationale": "Public access to remote server administration ports, such as 22 and 3389, increases resource attack surface and unnecessarily raises the risk of resource compromise.",
                  "references": "1. https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-security-groups.html#deleting-security-group-rule",
                  "remediation": "Perform the following to implement the prescribed state:\n\n1. Login to the AWS Management Console at [https://console.aws.amazon.com/vpc/home](https://console.aws.amazon.com/vpc/home)\n2. In the left pane, click `Security Groups` \n3. For each security group, perform the following:\n4. Select the security group\n5. Click the `Inbound Rules` tab\n6. Click the `Edit inbound rules` button\n7. Identify the rules to be edited or removed\n8. Either A) update the Source field to a range other than ::/0, or, B) Click `Delete` to remove the offending inbound rule\n9. Click `Save rules`",
                  "section": "Networking",
                  "tags": [
                    "CIS",
                    "AWS",
                    "CIS 5.3",
                    "Networking"
                  ],
                  "version": "1.0"
                }
              }
            ],
            "metadata": {
              "opa_version": "0.42.0-dev",
              "policy_version": "1.0.0"
            },
            "resource": {
              "GroupName": "default",
              "IpPermissions": [
                {
                  "FromPort": 22,
                  "IpProtocol": "tcp",
                  "IpRanges": [
                    {
                      "CidrIp": ""
                    }
                  ]
                }
              ],
              "IpPermissionsEgress": [
                {
                  "IpProtocol": "-1",
                  "IpRanges": [
                    {
                      "CidrIp": ""
                    }
                  ]
                }
              ]
            }
          },
          "text": "data.main",
          "location": {
            "row": 1,
            "col": 1
          }
        }
      ]
    }
  ]
}
```

### Related Issues
- Fixes: https://github.com/elastic/cloudbeat/issues/815

### Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary README/documentation (if appropriate)

> **Note** Make sure to bump cloudbeat [`version/policy.go`](https://github.com/elastic/cloudbeat/blob/main/version/policy.go#L20) after merging this PR and drafting a new release.
