### PR TITLE
fix: validate required filter pattern having topic

### DIFF
--- a/bundle/compliance/cis_aws/rules/cis_4_1/test.rego
+++ b/bundle/compliance/cis_aws/rules/cis_4_1/test.rego
@@ -15,8 +15,8 @@ test_violation {
 			"Status": {"IsLogging": true},
 			"EventSelectors": [{"IncludeManagementEvents": true}],
 		},
-		"Topics": ["arn:aws:...sns"],
-		"MetricFilters": [{"FilterPattern": "{ ($.errorCode = \"*UnauthorizedOperation\") || ($.errorCode = \"AccessDenied*\") || ($.sourceIPAddress!=\"delivery.logs.amazonaws.com\") || ($.eventName!=\"HeadBucket\") }"}],
+		"MetricTopicBinding": {"filter_1": ["arn:aws:...sns"]},
+		"MetricFilters": [{"FilterName": "filter_1", "FilterPattern": "{ ($.errorCode = \"*UnauthorizedOperation\") || ($.errorCode = \"AccessDenied*\") || ($.sourceIPAddress!=\"delivery.logs.amazonaws.com\") || ($.eventName!=\"HeadBucket\") }"}],
 	}])
 
 	# No topics
@@ -26,8 +26,8 @@ test_violation {
 			"Status": {"IsLogging": true},
 			"EventSelectors": [{"IncludeManagementEvents": true}],
 		},
-		"Topics": [],
-		"MetricFilters": [{"FilterPattern": "{ ($.errorCode = \"*UnauthorizedOperation\") || ($.errorCode = \"AccessDenied*\") || ($.sourceIPAddress!=\"delivery.logs.amazonaws.com\") || ($.eventName!=\"HeadBucket\") }"}],
+		"MetricTopicBinding": {},
+		"MetricFilters": [{"FilterName": "filter_1", "FilterPattern": "{ ($.errorCode = \"*UnauthorizedOperation\") || ($.errorCode = \"AccessDenied*\") || ($.sourceIPAddress!=\"delivery.logs.amazonaws.com\") || ($.eventName!=\"HeadBucket\") }"}],
 	}])
 
 	# No "AuthorizationFilterExists=true"
@@ -37,7 +37,7 @@ test_violation {
 			"Status": {"IsLogging": true},
 			"EventSelectors": [{"IncludeManagementEvents": true}],
 		},
-		"Topics": ["arn:aws:...sns"],
+		"MetricTopicBinding": {"filter_1": ["arn:aws:...sns"]},
 		"MetricFilters": [],
 	}])
 
@@ -48,8 +48,8 @@ test_violation {
 			"Status": {"IsLogging": false},
 			"EventSelectors": [{"IncludeManagementEvents": true}],
 		},
-		"Topics": ["arn:aws:...sns"],
-		"MetricFilters": [{"FilterPattern": "{ ($.errorCode = \"*UnauthorizedOperation\") || ($.errorCode = \"AccessDenied*\") || ($.sourceIPAddress!=\"delivery.logs.amazonaws.com\") || ($.eventName!=\"HeadBucket\") }"}],
+		"MetricFilters": [{"FilterName": "filter_1", "FilterPattern": "{ ($.errorCode = \"*UnauthorizedOperation\") || ($.errorCode = \"AccessDenied*\") || ($.sourceIPAddress!=\"delivery.logs.amazonaws.com\") || ($.eventName!=\"HeadBucket\") }"}],
+		"MetricTopicBinding": {"filter_1": ["arn:aws:...sns"]},
 	}])
 
 	# The event selector does include management events 
@@ -59,8 +59,8 @@ test_violation {
 			"Status": {"IsLogging": true},
 			"EventSelectors": [{"IncludeManagementEvents": false, "ReadWriteType": "All"}],
 		},
-		"Topics": ["arn:aws:...sns"],
-		"MetricFilters": [{"FilterPattern": "{ ($.errorCode = \"*UnauthorizedOperation\") || ($.errorCode = \"AccessDenied*\") || ($.sourceIPAddress!=\"delivery.logs.amazonaws.com\") || ($.eventName!=\"HeadBucket\") }"}],
+		"MetricFilters": [{"FilterName": "filter_1", "FilterPattern": "{ ($.errorCode = \"*UnauthorizedOperation\") || ($.errorCode = \"AccessDenied*\") || ($.sourceIPAddress!=\"delivery.logs.amazonaws.com\") || ($.eventName!=\"HeadBucket\") }"}],
+		"MetricTopicBinding": {"filter_1": ["arn:aws:...sns"]},
 	}])
 
 	eval_fail with input as rule_input([{
@@ -69,8 +69,8 @@ test_violation {
 			"Status": {"IsLogging": true},
 			"EventSelectors": [{"IncludeManagementEvents": true, "ReadWriteType": "WriteOnly"}],
 		},
-		"Topics": ["arn:aws:...sns"],
-		"MetricFilters": [{"FilterPattern": "{ ($.errorCode = \"*UnauthorizedOperation\") || ($.errorCode = \"AccessDenied*\") || ($.sourceIPAddress!=\"delivery.logs.amazonaws.com\") || ($.eventName!=\"HeadBucket\") }"}],
+		"MetricTopicBinding": {"filter_1": ["arn:aws:...sns"]},
+		"MetricFilters": [{"FilterName": "filter_1", "FilterPattern": "{ ($.errorCode = \"*UnauthorizedOperation\") || ($.errorCode = \"AccessDenied*\") || ($.sourceIPAddress!=\"delivery.logs.amazonaws.com\") || ($.eventName!=\"HeadBucket\") }"}],
 	}])
 
 	# Missing * wildcards
@@ -89,8 +89,8 @@ test_violation {
 			"Status": {"IsLogging": true},
 			"EventSelectors": [{"IncludeManagementEvents": true, "ReadWriteType": "All"}],
 		},
-		"MetricFilters": [{"FilterPattern": "{ ($.errorCode = \"*UnauthorizedOperation\") || ($.errorCode = \"AccessDenied\") || ($.sourceIPAddress!=\"delivery.logs.amazonaws.com\") || ($.eventName!=\"HeadBucket\") }"}],
-		"Topics": ["arn:aws:...sns"],
+		"MetricTopicBinding": {"filter_1": ["arn:aws:...sns"]},
+		"MetricFilters": [{"FilterName": "filter_1", "FilterPattern": "{ ($.errorCode = \"*UnauthorizedOperation\") || ($.errorCode = \"AccessDenied\") || ($.sourceIPAddress!=\"delivery.logs.amazonaws.com\") || ($.eventName!=\"HeadBucket\") }"}],
 	}])
 }
 
@@ -101,8 +101,8 @@ test_pass {
 			"Status": {"IsLogging": true},
 			"EventSelectors": [{"IncludeManagementEvents": true, "ReadWriteType": "All"}],
 		},
-		"MetricFilters": [{"FilterPattern": "{ ($.errorCode = \"*UnauthorizedOperation\") || ($.errorCode = \"AccessDenied*\") || ($.sourceIPAddress!=\"delivery.logs.amazonaws.com\") || ($.eventName!=\"HeadBucket\") }"}],
-		"Topics": ["arn:aws:...sns"],
+		"MetricFilters": [{"FilterName": "filter_1", "FilterPattern": "{ ($.errorCode = \"*UnauthorizedOperation\") || ($.errorCode = \"AccessDenied*\") || ($.sourceIPAddress!=\"delivery.logs.amazonaws.com\") || ($.eventName!=\"HeadBucket\") }"}],
+		"MetricTopicBinding": {"filter_1": ["arn:aws:...sns"]},
 	}])
 
 	# at least one is matching
@@ -113,8 +113,8 @@ test_pass {
 				"Status": {"IsLogging": true},
 				"EventSelectors": [{"IncludeManagementEvents": true, "ReadWriteType": "All"}],
 			},
-			"Topics": ["arn:aws:...sns"],
-			"MetricFilters": [{"FilterPattern": "{ ($.errorCode = \"*UnauthorizedOperation\") || ($.errorCode = \"AccessDenied*\") || ($.sourceIPAddress!=\"delivery.logs.amazonaws.com\") || ($.eventName!=\"HeadBucket\") }"}],
+			"MetricFilters": [{"FilterName": "filter_1", "FilterPattern": "{ ($.errorCode = \"*UnauthorizedOperation\") || ($.errorCode = \"AccessDenied*\") || ($.sourceIPAddress!=\"delivery.logs.amazonaws.com\") || ($.eventName!=\"HeadBucket\") }"}],
+			"MetricTopicBinding": {"filter_1": ["arn:aws:...sns"]},
 		},
 		{
 			"TrailInfo": {
@@ -122,7 +122,7 @@ test_pass {
 				"Status": {"IsLogging": false},
 				"EventSelectors": [{"IncludeManagementEvents": true, "ReadWriteType": "WriteOnly"}],
 			},
-			"Topics": ["arn:aws:...sns"],
+			"MetricTopicBinding": {"filter_1": ["arn:aws:...sns"]},
 			"MetricFilters": [],
 		},
 	])

--- a/bundle/compliance/cis_aws/rules/cis_4_10/test.rego
+++ b/bundle/compliance/cis_aws/rules/cis_4_10/test.rego
@@ -11,8 +11,8 @@ test_pass {
 			"Status": {"IsLogging": true},
 			"EventSelectors": [{"IncludeManagementEvents": true, "ReadWriteType": "All"}],
 		},
-		"MetricFilters": [{"FilterPattern": "{ ($.eventName = AuthorizeSecurityGroupIngress) || ($.eventName = AuthorizeSecurityGroupEgress) || ($.eventName = RevokeSecurityGroupIngress) || ($.eventName = RevokeSecurityGroupEgress) || ($.eventName = CreateSecurityGroup) || ($.eventName = DeleteSecurityGroup) }"}],
-		"Topics": ["arn:aws:...sns"],
+		"MetricFilters": [{"FilterName": "filter_1", "FilterPattern": "{ ($.eventName = AuthorizeSecurityGroupIngress) || ($.eventName = AuthorizeSecurityGroupEgress) || ($.eventName = RevokeSecurityGroupIngress) || ($.eventName = RevokeSecurityGroupEgress) || ($.eventName = CreateSecurityGroup) || ($.eventName = DeleteSecurityGroup) }"}],
+		"MetricTopicBinding": {"filter_1": ["arn:aws:...sns"]},
 	}])
 }
 

--- a/bundle/compliance/cis_aws/rules/cis_4_11/test.rego
+++ b/bundle/compliance/cis_aws/rules/cis_4_11/test.rego
@@ -11,8 +11,8 @@ test_pass {
 			"Status": {"IsLogging": true},
 			"EventSelectors": [{"IncludeManagementEvents": true, "ReadWriteType": "All"}],
 		},
-		"MetricFilters": [{"FilterPattern": "{ ($.eventName = CreateNetworkAcl) || ($.eventName = CreateNetworkAclEntry) || ($.eventName = DeleteNetworkAcl) || ($.eventName = DeleteNetworkAclEntry) || ($.eventName = ReplaceNetworkAclEntry) || ($.eventName = ReplaceNetworkAclAssociation) }"}],
-		"Topics": ["arn:aws:...sns"],
+		"MetricFilters": [{"FilterName": "filter_1", "FilterPattern": "{ ($.eventName = CreateNetworkAcl) || ($.eventName = CreateNetworkAclEntry) || ($.eventName = DeleteNetworkAcl) || ($.eventName = DeleteNetworkAclEntry) || ($.eventName = ReplaceNetworkAclEntry) || ($.eventName = ReplaceNetworkAclAssociation) }"}],
+		"MetricTopicBinding": {"filter_1": ["arn:aws:...sns"]},
 	}])
 }
 

--- a/bundle/compliance/cis_aws/rules/cis_4_12/test.rego
+++ b/bundle/compliance/cis_aws/rules/cis_4_12/test.rego
@@ -11,8 +11,8 @@ test_pass {
 			"Status": {"IsLogging": true},
 			"EventSelectors": [{"IncludeManagementEvents": true, "ReadWriteType": "All"}],
 		},
-		"MetricFilters": [{"FilterPattern": "{ ($.eventName = CreateCustomerGateway) || ($.eventName = DeleteCustomerGateway) || ($.eventName = AttachInternetGateway) || ($.eventName = CreateInternetGateway) || ($.eventName = DeleteInternetGateway) || ($.eventName = DetachInternetGateway) }"}],
-		"Topics": ["arn:aws:...sns"],
+		"MetricFilters": [{"FilterName": "filter_1", "FilterPattern": "{ ($.eventName = CreateCustomerGateway) || ($.eventName = DeleteCustomerGateway) || ($.eventName = AttachInternetGateway) || ($.eventName = CreateInternetGateway) || ($.eventName = DeleteInternetGateway) || ($.eventName = DetachInternetGateway) }"}],
+		"MetricTopicBinding": {"filter_1": ["arn:aws:...sns"]},
 	}])
 }
 

--- a/bundle/compliance/cis_aws/rules/cis_4_13/test.rego
+++ b/bundle/compliance/cis_aws/rules/cis_4_13/test.rego
@@ -11,8 +11,8 @@ test_pass {
 			"Status": {"IsLogging": true},
 			"EventSelectors": [{"IncludeManagementEvents": true, "ReadWriteType": "All"}],
 		},
-		"MetricFilters": [{"FilterPattern": "{ ($.eventName = CreateRoute) || ($.eventName = CreateRouteTable) || ($.eventName = ReplaceRoute) || ($.eventName = ReplaceRouteTableAssociation) || ($.eventName = DeleteRouteTable) || ($.eventName = DeleteRoute) || ($.eventName = DisassociateRouteTable) }"}],
-		"Topics": ["arn:aws:...sns"],
+		"MetricFilters": [{"FilterName": "filter_1", "FilterPattern": "{ ($.eventName = CreateRoute) || ($.eventName = CreateRouteTable) || ($.eventName = ReplaceRoute) || ($.eventName = ReplaceRouteTableAssociation) || ($.eventName = DeleteRouteTable) || ($.eventName = DeleteRoute) || ($.eventName = DisassociateRouteTable) }"}],
+		"MetricTopicBinding": {"filter_1": ["arn:aws:...sns"]},
 	}])
 }
 

--- a/bundle/compliance/cis_aws/rules/cis_4_14/test.rego
+++ b/bundle/compliance/cis_aws/rules/cis_4_14/test.rego
@@ -11,8 +11,8 @@ test_pass {
 			"Status": {"IsLogging": true},
 			"EventSelectors": [{"IncludeManagementEvents": true, "ReadWriteType": "All"}],
 		},
-		"MetricFilters": [{"FilterPattern": "{ ($.eventName = CreateVpc) || ($.eventName = DeleteVpc) || ($.eventName = ModifyVpcAttribute) || ($.eventName = AcceptVpcPeeringConnection) || ($.eventName = CreateVpcPeeringConnection) || ($.eventName = DeleteVpcPeeringConnection) || ($.eventName = RejectVpcPeeringConnection) || ($.eventName = AttachClassicLinkVpc) || ($.eventName = DetachClassicLinkVpc) || ($.eventName = DisableVpcClassicLink) || ($.eventName = EnableVpcClassicLink) }"}],
-		"Topics": ["arn:aws:...sns"],
+		"MetricFilters": [{"FilterName": "filter_1", "FilterPattern": "{ ($.eventName = CreateVpc) || ($.eventName = DeleteVpc) || ($.eventName = ModifyVpcAttribute) || ($.eventName = AcceptVpcPeeringConnection) || ($.eventName = CreateVpcPeeringConnection) || ($.eventName = DeleteVpcPeeringConnection) || ($.eventName = RejectVpcPeeringConnection) || ($.eventName = AttachClassicLinkVpc) || ($.eventName = DetachClassicLinkVpc) || ($.eventName = DisableVpcClassicLink) || ($.eventName = EnableVpcClassicLink) }"}],
+		"MetricTopicBinding": {"filter_1": ["arn:aws:...sns"]},
 	}])
 }
 

--- a/bundle/compliance/cis_aws/rules/cis_4_15/test.rego
+++ b/bundle/compliance/cis_aws/rules/cis_4_15/test.rego
@@ -11,8 +11,8 @@ test_pass {
 			"Status": {"IsLogging": true},
 			"EventSelectors": [{"IncludeManagementEvents": true, "ReadWriteType": "All"}],
 		},
-		"MetricFilters": [{"FilterPattern": "{ ($.eventSource = organizations.amazonaws.com) && (($.eventName = \"AcceptHandshake\") || ($.eventName = \"AttachPolicy\") || ($.eventName = \"CreateAccount\") || ($.eventName = \"CreateOrganizationalUnit\") || ($.eventName = \"CreatePolicy\") || ($.eventName = \"DeclineHandshake\") || ($.eventName = \"DeleteOrganization\") || ($.eventName = \"DeleteOrganizationalUnit\") || ($.eventName = \"DeletePolicy\") || ($.eventName = \"DetachPolicy\") || ($.eventName = \"DisablePolicyType\") || ($.eventName = \"EnablePolicyType\") || ($.eventName = \"InviteAccountToOrganization\") || ($.eventName = \"LeaveOrganization\") || ($.eventName = \"MoveAccount\") || ($.eventName = \"RemoveAccountFromOrganization\") || ($.eventName = \"UpdatePolicy\") || ($.eventName = \"UpdateOrganizationalUnit\")) }"}],
-		"Topics": ["arn:aws:...sns"],
+		"MetricFilters": [{"FilterName": "filter_1", "FilterPattern": "{ ($.eventSource = organizations.amazonaws.com) && (($.eventName = \"AcceptHandshake\") || ($.eventName = \"AttachPolicy\") || ($.eventName = \"CreateAccount\") || ($.eventName = \"CreateOrganizationalUnit\") || ($.eventName = \"CreatePolicy\") || ($.eventName = \"DeclineHandshake\") || ($.eventName = \"DeleteOrganization\") || ($.eventName = \"DeleteOrganizationalUnit\") || ($.eventName = \"DeletePolicy\") || ($.eventName = \"DetachPolicy\") || ($.eventName = \"DisablePolicyType\") || ($.eventName = \"EnablePolicyType\") || ($.eventName = \"InviteAccountToOrganization\") || ($.eventName = \"LeaveOrganization\") || ($.eventName = \"MoveAccount\") || ($.eventName = \"RemoveAccountFromOrganization\") || ($.eventName = \"UpdatePolicy\") || ($.eventName = \"UpdateOrganizationalUnit\")) }"}],
+		"MetricTopicBinding": {"filter_1": ["arn:aws:...sns"]},
 	}])
 }
 

--- a/bundle/compliance/cis_aws/rules/cis_4_2/test.rego
+++ b/bundle/compliance/cis_aws/rules/cis_4_2/test.rego
@@ -11,8 +11,8 @@ test_pass {
 			"Status": {"IsLogging": true},
 			"EventSelectors": [{"IncludeManagementEvents": true, "ReadWriteType": "All"}],
 		},
-		"MetricFilters": [{"FilterPattern": "{ ($.eventName = \"ConsoleLogin\") && ($.additionalEventData.MFAUsed != \"Yes\") }"}],
-		"Topics": ["arn:aws:...sns"],
+		"MetricFilters": [{"FilterName": "filter_1", "FilterPattern": "{ ($.eventName = \"ConsoleLogin\") && ($.additionalEventData.MFAUsed != \"Yes\") }"}],
+		"MetricTopicBinding": {"filter_1": ["arn:aws:...sns"]},
 	}])
 
 	eval_pass with input as rule_input([{
@@ -21,8 +21,8 @@ test_pass {
 			"Status": {"IsLogging": true},
 			"EventSelectors": [{"IncludeManagementEvents": true, "ReadWriteType": "All"}],
 		},
-		"MetricFilters": [{"FilterPattern": "{ ($.eventName = \"ConsoleLogin\") && ($.additionalEventData.MFAUsed != \"Yes\") && ($.userIdentity.type = \"IAMUser\") && ($.responseElements.ConsoleLogin = \"Success\") }"}],
-		"Topics": ["arn:aws:...sns"],
+		"MetricFilters": [{"FilterName": "filter_1", "FilterPattern": "{ ($.eventName = \"ConsoleLogin\") && ($.additionalEventData.MFAUsed != \"Yes\") && ($.userIdentity.type = \"IAMUser\") && ($.responseElements.ConsoleLogin = \"Success\") }"}],
+		"MetricTopicBinding": {"filter_1": ["arn:aws:...sns"]},
 	}])
 }
 

--- a/bundle/compliance/cis_aws/rules/cis_4_3/test.rego
+++ b/bundle/compliance/cis_aws/rules/cis_4_3/test.rego
@@ -11,13 +11,43 @@ test_pass {
 			"Status": {"IsLogging": true},
 			"EventSelectors": [{"IncludeManagementEvents": true, "ReadWriteType": "All"}],
 		},
-		"MetricFilters": [{"FilterPattern": "{ $.userIdentity.type = \"Root\" && $.userIdentity.invokedBy NOT EXISTS && $.eventType != \"AwsServiceEvent\" }"}],
-		"Topics": ["arn:aws:...sns"],
+		"MetricFilters": [{"FilterName": "filter_1", "FilterPattern": "{ $.userIdentity.type = \"Root\" && $.userIdentity.invokedBy NOT EXISTS && $.eventType != \"AwsServiceEvent\" }"}],
+		"MetricTopicBinding": {"filter_1": ["arn:aws:...sns"]},
 	}])
+}
+
+test_fail {
+	# on the required filter alarm is not configured with sns topic
+	# and on irrelevant filter an alaram is configured
+	# so it should not pass
+	eval_fail with input as rule_input([
+		{
+			"TrailInfo": {
+				"Trail": {"IsMultiRegionTrail": true},
+				"Status": {"IsLogging": true},
+				"EventSelectors": [{"IncludeManagementEvents": true, "ReadWriteType": "All"}],
+			},
+			"MetricFilters": [{"FilterName": "filter_1", "FilterPattern": "{ $.userIdentity.type = \"Root\" && $.userIdentity.invokedBy NOT EXISTS && $.eventType != \"AwsServiceEvent\" }"}],
+			"MetricTopicBinding": {},
+		},
+		{
+			"TrailInfo": {
+				"Trail": {"IsMultiRegionTrail": true},
+				"Status": {"IsLogging": true},
+				"EventSelectors": [{"IncludeManagementEvents": true, "ReadWriteType": "All"}],
+			},
+			"MetricFilters": [{"FilterName": "filter_2", "FilterPattern": "{ pattern_not_matched: true }"}],
+			"MetricTopicBinding": {"filter_2": ["arn:aws:...sns"]},
+		},
+	])
 }
 
 rule_input(entry) = test_data.generate_monitoring_resources(entry)
 
 eval_pass {
 	test.assert_pass(finding) with data.benchmark_data_adapter as data_adapter
+}
+
+eval_fail {
+	test.assert_fail(finding) with data.benchmark_data_adapter as data_adapter
 }

--- a/bundle/compliance/cis_aws/rules/cis_4_4/test.rego
+++ b/bundle/compliance/cis_aws/rules/cis_4_4/test.rego
@@ -26,8 +26,8 @@ test_pass {
 			"Status": {"IsLogging": true},
 			"EventSelectors": [{"IncludeManagementEvents": true, "ReadWriteType": "All"}],
 		},
-		"MetricFilters": [{"FilterPattern": "{($.eventName=DeleteGroupPolicy)||($.eventName=DeleteRolePolicy)||($.eventName=DeleteUserPolicy)||($.eventName=PutGroupPolicy)||($.eventName=PutRolePolicy)||($.eventName=PutUserPolicy)||($.eventName=CreatePolicy)||($.eventName=DeletePolicy)||($.eventName=CreatePolicyVersion)||($.eventName=DeletePolicyVersion)||($.eventName=AttachRolePolicy)||($.eventName=DetachRolePolicy)||($.eventName=AttachUserPolicy)||($.eventName=DetachUserPolicy)||($.eventName=AttachGroupPolicy)||($.eventName=DetachGroupPolicy)}"}],
-		"Topics": ["arn:aws:...sns"],
+		"MetricFilters": [{"FilterName": "filter_1", "FilterPattern": "{($.eventName=DeleteGroupPolicy)||($.eventName=DeleteRolePolicy)||($.eventName=DeleteUserPolicy)||($.eventName=PutGroupPolicy)||($.eventName=PutRolePolicy)||($.eventName=PutUserPolicy)||($.eventName=CreatePolicy)||($.eventName=DeletePolicy)||($.eventName=CreatePolicyVersion)||($.eventName=DeletePolicyVersion)||($.eventName=AttachRolePolicy)||($.eventName=DetachRolePolicy)||($.eventName=AttachUserPolicy)||($.eventName=DetachUserPolicy)||($.eventName=AttachGroupPolicy)||($.eventName=DetachGroupPolicy)}"}],
+		"MetricTopicBinding": {"filter_1": ["arn:aws:...sns"]},
 	}])
 }
 

--- a/bundle/compliance/cis_aws/rules/cis_4_5/test.rego
+++ b/bundle/compliance/cis_aws/rules/cis_4_5/test.rego
@@ -11,8 +11,8 @@ test_pass {
 			"Status": {"IsLogging": true},
 			"EventSelectors": [{"IncludeManagementEvents": true, "ReadWriteType": "All"}],
 		},
-		"MetricFilters": [{"FilterPattern": "{ ($.eventName = CreateTrail) || ($.eventName = UpdateTrail) || ($.eventName = DeleteTrail) || ($.eventName = StartLogging) || ($.eventName = StopLogging) }"}],
-		"Topics": ["arn:aws:...sns"],
+		"MetricFilters": [{"FilterName": "filter_1", "FilterPattern": "{ ($.eventName = CreateTrail) || ($.eventName = UpdateTrail) || ($.eventName = DeleteTrail) || ($.eventName = StartLogging) || ($.eventName = StopLogging) }"}],
+		"MetricTopicBinding": {"filter_1": ["arn:aws:...sns"]},
 	}])
 }
 

--- a/bundle/compliance/cis_aws/rules/cis_4_6/test.rego
+++ b/bundle/compliance/cis_aws/rules/cis_4_6/test.rego
@@ -11,8 +11,8 @@ test_pass {
 			"Status": {"IsLogging": true},
 			"EventSelectors": [{"IncludeManagementEvents": true, "ReadWriteType": "All"}],
 		},
-		"MetricFilters": [{"FilterPattern": "{ ($.eventName = ConsoleLogin) && ($.errorMessage = \"Failed authentication\") }"}],
-		"Topics": ["arn:aws:...sns"],
+		"MetricFilters": [{"FilterName": "filter_1", "FilterPattern": "{ ($.eventName = ConsoleLogin) && ($.errorMessage = \"Failed authentication\") }"}],
+		"MetricTopicBinding": {"filter_1": ["arn:aws:...sns"]},
 	}])
 }
 

--- a/bundle/compliance/cis_aws/rules/cis_4_7/test.rego
+++ b/bundle/compliance/cis_aws/rules/cis_4_7/test.rego
@@ -11,8 +11,8 @@ test_pass {
 			"Status": {"IsLogging": true},
 			"EventSelectors": [{"IncludeManagementEvents": true, "ReadWriteType": "All"}],
 		},
-		"MetricFilters": [{"FilterPattern": "{($.eventSource = kms.amazonaws.com) && (($.eventName=DisableKey)||($.eventName=ScheduleKeyDeletion)) }"}],
-		"Topics": ["arn:aws:...sns"],
+		"MetricFilters": [{"FilterName": "filter_1", "FilterPattern": "{($.eventSource = kms.amazonaws.com) && (($.eventName=DisableKey)||($.eventName=ScheduleKeyDeletion)) }"}],
+		"MetricTopicBinding": {"filter_1": ["arn:aws:...sns"]},
 	}])
 }
 

--- a/bundle/compliance/cis_aws/rules/cis_4_8/test.rego
+++ b/bundle/compliance/cis_aws/rules/cis_4_8/test.rego
@@ -11,8 +11,8 @@ test_pass {
 			"Status": {"IsLogging": true},
 			"EventSelectors": [{"IncludeManagementEvents": true, "ReadWriteType": "All"}],
 		},
-		"MetricFilters": [{"FilterPattern": "{ ($.eventSource = s3.amazonaws.com) && (($.eventName = PutBucketAcl) || ($.eventName = PutBucketPolicy) || ($.eventName = PutBucketCors) || ($.eventName = PutBucketLifecycle) || ($.eventName = PutBucketReplication) || ($.eventName = DeleteBucketPolicy) || ($.eventName = DeleteBucketCors) || ($.eventName = DeleteBucketLifecycle) || ($.eventName = DeleteBucketReplication)) }"}],
-		"Topics": ["arn:aws:...sns"],
+		"MetricFilters": [{"FilterName": "filter_1", "FilterPattern": "{ ($.eventSource = s3.amazonaws.com) && (($.eventName = PutBucketAcl) || ($.eventName = PutBucketPolicy) || ($.eventName = PutBucketCors) || ($.eventName = PutBucketLifecycle) || ($.eventName = PutBucketReplication) || ($.eventName = DeleteBucketPolicy) || ($.eventName = DeleteBucketCors) || ($.eventName = DeleteBucketLifecycle) || ($.eventName = DeleteBucketReplication)) }"}],
+		"MetricTopicBinding": {"filter_1": ["arn:aws:...sns"]},
 	}])
 }
 

--- a/bundle/compliance/cis_aws/rules/cis_4_9/test.rego
+++ b/bundle/compliance/cis_aws/rules/cis_4_9/test.rego
@@ -11,8 +11,8 @@ test_pass {
 			"Status": {"IsLogging": true},
 			"EventSelectors": [{"IncludeManagementEvents": true, "ReadWriteType": "All"}],
 		},
-		"MetricFilters": [{"FilterPattern": "{ ($.eventSource = config.amazonaws.com) && (($.eventName=StopConfigurationRecorder)||($.eventName=DeleteDeliveryChannel) ||($.eventName=PutDeliveryChannel)||($.eventName=PutConfigurationRecorder)) }"}],
-		"Topics": ["arn:aws:...sns"],
+		"MetricFilters": [{"FilterName": "filter_1", "FilterPattern": "{ ($.eventSource = config.amazonaws.com) && (($.eventName=StopConfigurationRecorder)||($.eventName=DeleteDeliveryChannel) ||($.eventName=PutDeliveryChannel)||($.eventName=PutConfigurationRecorder)) }"}],
+		"MetricTopicBinding": {"filter_1": ["arn:aws:...sns"]},
 	}])
 }
 

--- a/bundle/compliance/policy/aws_cloudtrail/pattern.rego
+++ b/bundle/compliance/policy/aws_cloudtrail/pattern.rego
@@ -1,9 +1,10 @@
 package compliance.policy.aws_cloudtrail.pattern
 
-# check that a trail has at least one metric filter pattern that matches at least one pattern
-at_least_one_metric_exists(trail, patterns) {
+# get a filter from a trail has at least one metric filter pattern that matches at least one pattern
+get_filter_matched_to_pattern(trail, patterns) = name {
 	some i, j
 	filter := trail.MetricFilters[i]
 	pattern := patterns[j]
 	filter.FilterPattern == pattern
-} else = false
+	name := filter.FilterName
+} else = ""

--- a/bundle/compliance/policy/aws_cloudtrail/pattern_test.rego
+++ b/bundle/compliance/policy/aws_cloudtrail/pattern_test.rego
@@ -1,8 +1,8 @@
 package compliance.policy.aws_cloudtrail.pattern
 
-filter_1 = {"FilterPattern": "filter_1"}
+filter_1 = {"FilterPattern": "filter_1", "FilterName": "filter_1"}
 
-filter_2 = {"FilterPattern": "filter_2"}
+filter_2 = {"FilterPattern": "filter_2", "FilterName": "filter_2"}
 
 pattern_1 = "filter_1"
 
@@ -11,13 +11,13 @@ pattern_2 = "filter_2"
 pattern_never_match = "not_match"
 
 test_pass {
-	at_least_one_metric_exists({"MetricFilters": [filter_1]}, [pattern_1])
-	at_least_one_metric_exists({"MetricFilters": [filter_1, filter_2]}, [pattern_1])
-	at_least_one_metric_exists({"MetricFilters": [filter_1, filter_2]}, [pattern_2])
-	at_least_one_metric_exists({"MetricFilters": [filter_1, filter_2]}, [pattern_never_match, pattern_1])
+	get_filter_matched_to_pattern({"MetricFilters": [filter_1]}, [pattern_1])
+	get_filter_matched_to_pattern({"MetricFilters": [filter_1, filter_2]}, [pattern_1])
+	get_filter_matched_to_pattern({"MetricFilters": [filter_1, filter_2]}, [pattern_2])
+	get_filter_matched_to_pattern({"MetricFilters": [filter_1, filter_2]}, [pattern_never_match, pattern_1])
 }
 
 test_fail {
-	not at_least_one_metric_exists({"MetricFilters": [filter_1, filter_2]}, [pattern_never_match])
-	not at_least_one_metric_exists({"MetricFilters": []}, [])
+	get_filter_matched_to_pattern({"MetricFilters": [filter_1, filter_2]}, [pattern_never_match]) == ""
+	get_filter_matched_to_pattern({"MetricFilters": []}, []) == ""
 }

--- a/bundle/compliance/policy/aws_cloudtrail/trail.rego
+++ b/bundle/compliance/policy/aws_cloudtrail/trail.rego
@@ -15,10 +15,10 @@ at_least_one_trail_satisfied(metric_filter_patterns) {
 	cloudtrail_enabled(trail)
 
 	# and the metric filter pattern is as expected
-	pattern.at_least_one_metric_exists(trail, metric_filter_patterns)
+	filter := pattern.get_filter_matched_to_pattern(trail, metric_filter_patterns)
 
 	# and it has at least one subscription
-	count(trail.Topics) > 0
+	count(trail.MetricTopicBinding[filter]) > 0
 }
 
 cloudtrail_enabled(trail) {


### PR DESCRIPTION
### Summary of your changes
Fix the bug that happens when multiple trails exist, but only some are configured with an alarm and SNS topic to cause passing findings. 
This way we make sure that the sns topic is configured with the require metric filter

### Related Issues
- https://github.com/elastic/cloudbeat/pull/846
- https://github.com/elastic/cloudbeat/issues/826

### Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary README/documentation (if appropriate)

> **Note** Make sure to bump cloudbeat [`version/policy.go`](https://github.com/elastic/cloudbeat/blob/main/version/policy.go#L20) after merging this PR and drafting a new release.
