### PR TITLE
Fixing CIS AWS cloudtrail rule 3.4

### DIFF
--- a/bundle/compliance/cis_aws/test_data.rego
+++ b/bundle/compliance/cis_aws/test_data.rego
@@ -185,7 +185,7 @@ generate_enriched_trail(is_log_validation_enabled, cloudwatch_log_group_arn, log
 			"CloudWatchLogsLogGroupArn": cloudwatch_log_group_arn,
 			"KmsKeyId": kms_key_id,
 		},
-		"Status": {"LatestcloudwatchLogdDeliveryTime": log_delivery_time},
+		"Status": {"LatestDeliveryTime": log_delivery_time},
 		"bucket_info": {"logging": {"Enabled": is_bucket_logging_enabled}},
 	},
 }

--- a/bundle/compliance/cis_aws/test_data.rego
+++ b/bundle/compliance/cis_aws/test_data.rego
@@ -185,7 +185,7 @@ generate_enriched_trail(is_log_validation_enabled, cloudwatch_log_group_arn, log
 			"CloudWatchLogsLogGroupArn": cloudwatch_log_group_arn,
 			"KmsKeyId": kms_key_id,
 		},
-		"Status": {"LatestDeliveryTime": log_delivery_time},
+		"Status": {"LatestCloudWatchLogsDeliveryTime": log_delivery_time},
 		"bucket_info": {"logging": {"Enabled": is_bucket_logging_enabled}},
 	},
 }

--- a/bundle/compliance/policy/aws_cloudtrail/ensure_cloudwatch_integration.rego
+++ b/bundle/compliance/policy/aws_cloudtrail/ensure_cloudwatch_integration.rego
@@ -7,5 +7,5 @@ default ensure_cloudwatch_logs_enabled = false
 
 ensure_cloudwatch_logs_enabled {
 	data_adapter.trail.CloudWatchLogsLogGroupArn != ""
-	common.date_within_duration(time.parse_rfc3339_ns(data_adapter.trail_status.LatestDeliveryTime), "24h")
+	common.date_within_duration(time.parse_rfc3339_ns(data_adapter.trail_status.LatestCloudWatchLogsDeliveryTime), "24h")
 }

--- a/bundle/compliance/policy/aws_cloudtrail/ensure_cloudwatch_integration.rego
+++ b/bundle/compliance/policy/aws_cloudtrail/ensure_cloudwatch_integration.rego
@@ -7,5 +7,5 @@ default ensure_cloudwatch_logs_enabled = false
 
 ensure_cloudwatch_logs_enabled {
 	data_adapter.trail.CloudWatchLogsLogGroupArn != ""
-	common.date_within_duration(time.parse_rfc3339_ns(data_adapter.trail_status.LatestcloudwatchLogdDeliveryTime), "24h")
+	common.date_within_duration(time.parse_rfc3339_ns(data_adapter.trail_status.LatestDeliveryTime), "24h")
 }


### PR DESCRIPTION
### Summary of your changes
There was a misspelling in the code on fields that were checked.
The resource that was used for validation:
```json
{
  "subType": "aws-trail",
  "resource": {
    "Status": {
      "LatestCloudWatchLogsDeliveryTime": "2023-03-04T16:09:47.346000+03:00"
    },
    "Trail": {
      "CloudWatchLogsLogGroupArn": "jenia"
    }
  }
}
```
Getting a failed finding:
```json
{
                "result": {
                  "evaluation": "failed",
                  "evidence": {
                    "Status": {
                      "LatestCloudWatchLogsDeliveryTime": "2023-02-04T16:09:47.346000+03:00"
                    },
                    "Trail": {
                      "CloudWatchLogsLogGroupArn": "jenia"
                    }
                  }
                },
                "rule": {
                  "audit": "Perform the following to ensure CloudTrail is configured as prescribed:\n\n**From Console:**\n\n1. Login to the CloudTrail console at `https://console.aws.amazon.com/cloudtrail/`\n2. Under `Trails` , click on the CloudTrail you wish to evaluate\n3. Under the `CloudWatch Logs` section.\n4. Ensure a `CloudWatch Logs` log group is configured and listed.\n5. Under `General details` confirm `Last log file delivered` has a recent (~one day old) timestamp.\n\n**From Command Line:**\n\n6. Run the following command to get a listing of existing trails:\n```\n aws cloudtrail describe-trails\n```\n7. Ensure `CloudWatchLogsLogGroupArn` is not empty and note the value of the `Name` property.\n8. Using the noted value of the `Name` property, run the following command:\n```\n aws cloudtrail get-trail-status --name \u003ctrail_name\u003e\n```\n9. Ensure the `LatestcloudwatchLogdDeliveryTime` property is set to a recent (~one day old) timestamp.\n\nIf the `CloudWatch Logs` log group is not setup and the delivery time is not recent refer to the remediation below.",
                  "benchmark": {
                    "id": "cis_aws",
                    "name": "CIS Amazon Web Services Foundations",
                    "posture_type": "cspm",
                    "rule_number": "3.4",
                    "version": "v1.5.0"
                  },
                  "default_value": "",
                  "description": "AWS CloudTrail is a web service that records AWS API calls made in a given AWS account.\nThe recorded information includes the identity of the API caller, the time of the API call, the source IP address of the API caller, the request parameters, and the response elements returned by the AWS service.\nCloudTrail uses Amazon S3 for log file storage and delivery, so log files are stored durably.\nIn addition to capturing CloudTrail logs within a specified S3 bucket for long term analysis, realtime analysis can be performed by configuring CloudTrail to send logs to CloudWatch Logs.\nFor a trail that is enabled in all regions in an account, CloudTrail sends log files from all those regions to a CloudWatch Logs log group.\nIt is recommended that CloudTrail logs be sent to CloudWatch Logs.\n\nNote: The intent of this recommendation is to ensure AWS account activity is being captured, monitored, and appropriately alarmed on.\nCloudWatch Logs is a native way to accomplish this using AWS services but does not preclude the use of an alternate solution.",
                  "id": "c1581c69-3e5c-5ab2-bdde-3619955a1dcf",
                  "impact": "Note: By default, CloudWatch Logs will store Logs indefinitely unless a specific retention period is defined for the log group. When choosing the number of days to retain, keep in mind the average days it takes an organization to realize they have been breached is 210 days (at the time of this writing). Since additional time is required to research a breach, a minimum 365 day retention policy allows time for detection and research. You may also wish to archive the logs to a cheaper storage service rather than simply deleting them. See the following AWS resource to manage CloudWatch Logs retention periods:\n\n1. https://docs.aws.amazon.com/AmazonCloudWatch/latest/DeveloperGuide/SettingLogRetention.html",
                  "name": "Ensure CloudTrail trails are integrated with CloudWatch Logs",
                  "profile_applicability": "* Level 1",
                  "rationale": "Sending CloudTrail logs to CloudWatch Logs will facilitate real-time and historic activity logging based on user, API, resource, and IP address, and provides opportunity to establish alarms and notifications for anomalous or sensitivity account activity.",
                  "references": "1. https://docs.aws.amazon.com/awscloudtrail/latest/userguide/cloudtrail-user-guide.html\n2. https://docs.aws.amazon.com/awscloudtrail/latest/userguide/how-cloudtrail-works.html\n3. https://docs.aws.amazon.com/awscloudtrail/latest/userguide/cloudtrail-aws-service-specific-topics.html",
                  "remediation": "Perform the following to establish the prescribed state:\n\n**From Console:**\n\n1. Login to the CloudTrail console at `https://console.aws.amazon.com/cloudtrail/`\n2. Select the `Trail` the needs to be updated.\n3. Scroll down to `CloudWatch Logs`\n4. Click `Edit`\n5. Under `CloudWatch Logs` click the box `Enabled`\n6. Under `Log Group` pick new or select an existing log group\n7. Edit the `Log group name` to match the CloudTrail or pick the existing CloudWatch Group.\n8. Under `IAM Role` pick new or select an existing.\n9. Edit the `Role name` to match the CloudTrail or pick the existing IAM Role.\n10. Click `Save changes.\n\n**From Command Line:**\n```\naws cloudtrail update-trail --name \u003ctrail_name\u003e --cloudwatch-logs-log-group-arn \u003ccloudtrail_log_group_arn\u003e --cloudwatch-logs-role-arn \u003ccloudtrail_cloudwatchLogs_role_arn\u003e\n```",
                  "section": "Logging",
                  "tags": [
                    "CIS",
                    "AWS",
                    "CIS 3.4",
                    "Logging"
                  ],
                  "version": "1.0"
                }
              }
```
With a date within the range, we are getting a passed finding:
```json
{
                "result": {
                  "evaluation": "passed",
                  "evidence": {
                    "Status": {
                      "LatestCloudWatchLogsDeliveryTime": "2023-04-04T16:09:47.346000+03:00"
                    },
                    "Trail": {
                      "CloudWatchLogsLogGroupArn": "jenia"
                    }
                  }
                },
                "rule": {
                  "audit": "Perform the following to ensure CloudTrail is configured as prescribed:\n\n**From Console:**\n\n1. Login to the CloudTrail console at `https://console.aws.amazon.com/cloudtrail/`\n2. Under `Trails` , click on the CloudTrail you wish to evaluate\n3. Under the `CloudWatch Logs` section.\n4. Ensure a `CloudWatch Logs` log group is configured and listed.\n5. Under `General details` confirm `Last log file delivered` has a recent (~one day old) timestamp.\n\n**From Command Line:**\n\n6. Run the following command to get a listing of existing trails:\n```\n aws cloudtrail describe-trails\n```\n7. Ensure `CloudWatchLogsLogGroupArn` is not empty and note the value of the `Name` property.\n8. Using the noted value of the `Name` property, run the following command:\n```\n aws cloudtrail get-trail-status --name \u003ctrail_name\u003e\n```\n9. Ensure the `LatestcloudwatchLogdDeliveryTime` property is set to a recent (~one day old) timestamp.\n\nIf the `CloudWatch Logs` log group is not setup and the delivery time is not recent refer to the remediation below.",
                  "benchmark": {
                    "id": "cis_aws",
                    "name": "CIS Amazon Web Services Foundations",
                    "posture_type": "cspm",
                    "rule_number": "3.4",
                    "version": "v1.5.0"
                  },
                  "default_value": "",
                  "description": "AWS CloudTrail is a web service that records AWS API calls made in a given AWS account.\nThe recorded information includes the identity of the API caller, the time of the API call, the source IP address of the API caller, the request parameters, and the response elements returned by the AWS service.\nCloudTrail uses Amazon S3 for log file storage and delivery, so log files are stored durably.\nIn addition to capturing CloudTrail logs within a specified S3 bucket for long term analysis, realtime analysis can be performed by configuring CloudTrail to send logs to CloudWatch Logs.\nFor a trail that is enabled in all regions in an account, CloudTrail sends log files from all those regions to a CloudWatch Logs log group.\nIt is recommended that CloudTrail logs be sent to CloudWatch Logs.\n\nNote: The intent of this recommendation is to ensure AWS account activity is being captured, monitored, and appropriately alarmed on.\nCloudWatch Logs is a native way to accomplish this using AWS services but does not preclude the use of an alternate solution.",
                  "id": "c1581c69-3e5c-5ab2-bdde-3619955a1dcf",
                  "impact": "Note: By default, CloudWatch Logs will store Logs indefinitely unless a specific retention period is defined for the log group. When choosing the number of days to retain, keep in mind the average days it takes an organization to realize they have been breached is 210 days (at the time of this writing). Since additional time is required to research a breach, a minimum 365 day retention policy allows time for detection and research. You may also wish to archive the logs to a cheaper storage service rather than simply deleting them. See the following AWS resource to manage CloudWatch Logs retention periods:\n\n1. https://docs.aws.amazon.com/AmazonCloudWatch/latest/DeveloperGuide/SettingLogRetention.html",
                  "name": "Ensure CloudTrail trails are integrated with CloudWatch Logs",
                  "profile_applicability": "* Level 1",
                  "rationale": "Sending CloudTrail logs to CloudWatch Logs will facilitate real-time and historic activity logging based on user, API, resource, and IP address, and provides opportunity to establish alarms and notifications for anomalous or sensitivity account activity.",
                  "references": "1. https://docs.aws.amazon.com/awscloudtrail/latest/userguide/cloudtrail-user-guide.html\n2. https://docs.aws.amazon.com/awscloudtrail/latest/userguide/how-cloudtrail-works.html\n3. https://docs.aws.amazon.com/awscloudtrail/latest/userguide/cloudtrail-aws-service-specific-topics.html",
                  "remediation": "Perform the following to establish the prescribed state:\n\n**From Console:**\n\n1. Login to the CloudTrail console at `https://console.aws.amazon.com/cloudtrail/`\n2. Select the `Trail` the needs to be updated.\n3. Scroll down to `CloudWatch Logs`\n4. Click `Edit`\n5. Under `CloudWatch Logs` click the box `Enabled`\n6. Under `Log Group` pick new or select an existing log group\n7. Edit the `Log group name` to match the CloudTrail or pick the existing CloudWatch Group.\n8. Under `IAM Role` pick new or select an existing.\n9. Edit the `Role name` to match the CloudTrail or pick the existing IAM Role.\n10. Click `Save changes.\n\n**From Command Line:**\n```\naws cloudtrail update-trail --name \u003ctrail_name\u003e --cloudwatch-logs-log-group-arn \u003ccloudtrail_log_group_arn\u003e --cloudwatch-logs-role-arn \u003ccloudtrail_cloudwatchLogs_role_arn\u003e\n```",
                  "section": "Logging",
                  "tags": [
                    "CIS",
                    "AWS",
                    "CIS 3.4",
                    "Logging"
                  ],
                  "version": "1.0"
                }
              }
```

### Related Issues
- Fixes: https://github.com/elastic/cloudbeat/issues/809

### Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary README/documentation (if appropriate)

> **Note** Make sure to bump cloudbeat [`version/policy.go`](https://github.com/elastic/cloudbeat/blob/main/version/policy.go#L20) after merging this PR and drafting a new release.
