### PR TITLE
Fix CIS EKS 3.2.5

### DIFF
--- a/bundle/compliance/cis_eks/rules/cis_3_2_5/rule.rego
+++ b/bundle/compliance/cis_eks/rules/cis_3_2_5/rule.rego
@@ -9,9 +9,17 @@ rule_evaluation = false {
 	audit.process_contains_key_with_value("--streaming-connection-idle-timeout", "0")
 }
 
+rule_evaluation = false {
+	audit.process_contains_key_with_value("--streaming-connection-idle-timeout", "0s")
+}
+
 # In case both flags and configuration file are specified, the executable argument takes precedence.
 rule_evaluation = false {
-	audit.not_process_arg_comparison("--streaming-connection-idle-timeout", ["streamingConnectionIdleTimeout"], 0)
+	audit.not_process_arg_comparison("--streaming-connection-idle-timeout", ["streamingConnectionIdleTimeout"], "0")
+}
+
+rule_evaluation = false {
+	audit.not_process_arg_comparison("--streaming-connection-idle-timeout", ["streamingConnectionIdleTimeout"], "0s")
 }
 
 finding = audit.finding(rule_evaluation)

--- a/bundle/compliance/cis_eks/rules/cis_3_2_5/test.rego
+++ b/bundle/compliance/cis_eks/rules/cis_3_2_5/test.rego
@@ -6,10 +6,12 @@ import data.lib.test
 
 test_violation {
 	eval_fail with input as rule_input("--streaming-connection-idle-timeout 0")
+	eval_fail with input as rule_input("--streaming-connection-idle-timeout 0s")
 	eval_fail with input as rule_input_with_external("--streaming-connection-idle-timeout 0", create_process_config(0))
 	eval_fail with input as rule_input_with_external("--streaming-connection-idle-timeout 0", create_process_config(10))
 	eval_fail with input as rule_input_with_external("--streaming-connection-idle-timeout=0", create_process_config(10))
-	eval_fail with input as rule_input_with_external("", create_process_config(0))
+	eval_fail with input as rule_input_with_external("", create_process_config("0s"))
+	eval_fail with input as rule_input_with_external("", create_process_config("0"))
 }
 
 test_pass {


### PR DESCRIPTION
### Summary of your changes

fail the rule if the value of `--streaming-connection-idle-timeout` or `streamingConnectionIdleTimeout` is `"0s"`, `"0"` or `0` 

| ![Screenshot 2023-04-23 at 14 00 48](https://user-images.githubusercontent.com/20814186/233836114-bf3d8901-d721-4304-abe1-5f8a394eb354.png) | ![Screenshot 2023-04-23 at 14 01 14](https://user-images.githubusercontent.com/20814186/233836091-dad0112d-8339-4155-8f13-b5525807f1f8.png) |
|---------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------|





### Related Issues

- closes: https://github.com/elastic/cloudbeat/issues/632


### Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary README/documentation (if appropriate)

> **Note** Make sure to bump cloudbeat [`version/policy.go`](https://github.com/elastic/cloudbeat/blob/main/version/policy.go#L20) after merging this PR and drafting a new release.
