### PR TITLE
CIS 1.20: Only include failed regions in evidence

### DIFF
--- a/bundle/compliance/cis_aws/rules/cis_1_20/rule.rego
+++ b/bundle/compliance/cis_aws/rules/cis_1_20/rule.rego
@@ -13,14 +13,17 @@ finding = result if {
 
 	# set result
 	result := common.generate_result_without_expected(
-		common.calculate_result(analyzer_exists),
-		{"Access Analyzers": input.resource},
+		common.calculate_result(count(regions_without_analyzers) == 0),
+		{"Regions without access analyzers": regions_without_analyzers},
 	)
 }
 
-analyzer_exists if {
-	every region in data_adapter.analyzers {
-		some analyzer in region
-		analyzer.Status == "ACTIVE"
-	}
+regions_without_analyzers = {region |
+	analyzers := data_adapter.analyzers[region]
+	not analyzer_exists(analyzers)
+}
+
+analyzer_exists(analyzers) if {
+	some analyzer in analyzers
+	analyzer.Status == "ACTIVE"
 } else = false


### PR DESCRIPTION
### Summary of your changes

Otherwise, we are creating a lot of new fields which lead to elasticsearch errors:

```json
{
  "log.level": "warn",
  "@timestamp": "2023-04-30T09:19:30.121Z",
  "log.logger": "elasticsearch",
  "log.origin": {
    "file.name": "elasticsearch/client.go",
    "file.line": 429
  },
  "message": "Cannot index event publisher.Event{...<event data>...} (status=400): {\"type\":\"document_parsing_exception\",\"reason\":\"[1:6485] failed to parse: Limit of total fields [1000] has been exceeded while adding new fields [146]\",\"caused_by\":{\"type\":\"illegal_argument_exception\",\"reason\":\"Limit of total fields [1000] has been exceeded while adding new fields [146]\"}}, dropping event!",
  "service.name": "cloudbeat",
  "ecs.version": "1.6.0"
}
```

This is because every region in the map gets its own fields.

This is the simplest solution for now, because it's not possible to flatten the map into an array of all analyzers because we need to know which analyzers are missing for each region.

### Related Issues

https://github.com/elastic/csp-security-policies/issues/222

### Checklist

- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have added the necessary README/documentation (if appropriate)

> **Note** Make sure to bump cloudbeat [`version/policy.go`](https://github.com/elastic/cloudbeat/blob/main/version/policy.go#L20) after merging this PR and drafting a new release.
