### PR TITLE
CIS AWS rule 2.1.5 can now handle missing public block config

### DIFF
--- a/bundle/compliance/cis_aws/rules/cis_2_1_5/test.rego
+++ b/bundle/compliance/cis_aws/rules/cis_2_1_5/test.rego
@@ -12,6 +12,15 @@ test_violation {
 	eval_fail with input as rule_input(true, true, false, true, true, true, false, true)
 	eval_fail with input as rule_input(true, false, true, true, true, false, true, true)
 	eval_fail with input as rule_input(false, true, true, true, false, true, true, true)
+
+	# No public access block config
+	eval_fail with input as test_data.generate_s3_bucket("Bucket", "", null, null, null, null)
+
+	# Only bucket-level public access block config
+	eval_fail with input as test_data.generate_s3_bucket("Bucket", "", null, null, test_data.generate_s3_public_access_block_configuration(true, false, true, true), null)
+
+	# Only account-level public access block config
+	eval_fail with input as test_data.generate_s3_bucket("Bucket", "", null, null, null, test_data.generate_s3_public_access_block_configuration(true, true, false, true))
 }
 
 test_pass {
@@ -19,19 +28,16 @@ test_pass {
 	eval_pass with input as rule_input(false, false, false, false, true, true, true, true)
 	eval_pass with input as rule_input(true, false, true, false, false, true, false, true)
 	eval_pass with input as rule_input(false, true, false, true, true, false, true, false)
+
+	# Only bucket-level public access block config
+	eval_pass with input as test_data.generate_s3_bucket("Bucket", "", null, null, test_data.generate_s3_public_access_block_configuration(true, true, true, true), null)
+
+	# Only account-level public access block config
+	eval_pass with input as test_data.generate_s3_bucket("Bucket", "", null, null, null, test_data.generate_s3_public_access_block_configuration(true, true, true, true))
 }
 
 test_not_evaluated {
 	not_eval with input as test_data.not_evaluated_s3_bucket
-
-	# A bucket without any public access block config
-	not_eval with input as test_data.generate_s3_bucket("Bucket", "", null, null, null, null)
-
-	# A bucket without an account-level public access block config
-	not_eval with input as test_data.generate_s3_bucket("Bucket", "", null, null, test_data.generate_s3_public_access_block_configuration(true, true, true, true), null)
-
-	# A bucket without a bucket-level public access block config
-	not_eval with input as test_data.generate_s3_bucket("Bucket", "", null, null, null, test_data.generate_s3_public_access_block_configuration(true, true, true, true))
 }
 
 rule_input(block_public_acls, block_public_policy, ignore_public_acls, restrict_public_buckets, account_block_public_acls, account_block_public_policy, account_ignore_public_acls, account_restrict_public_buckets) = test_data.generate_s3_bucket("Bucket", "", null, null, test_data.generate_s3_public_access_block_configuration(block_public_acls, block_public_policy, ignore_public_acls, restrict_public_buckets), test_data.generate_s3_public_access_block_configuration(account_block_public_acls, account_block_public_policy, account_ignore_public_acls, account_restrict_public_buckets))

--- a/bundle/compliance/policy/aws_s3/ensure_block_public_access.rego
+++ b/bundle/compliance/policy/aws_s3/ensure_block_public_access.rego
@@ -10,9 +10,7 @@ public_access_block_config_is_blocked(config) {
 	config.BlockPublicPolicy == true
 	config.IgnorePublicAcls == true
 	config.RestrictPublicBuckets == true
-} else = false {
-	true
-}
+} else = false
 
 default rule_evaluation = false
 

--- a/bundle/compliance/policy/aws_s3/ensure_block_public_access.rego
+++ b/bundle/compliance/policy/aws_s3/ensure_block_public_access.rego
@@ -7,17 +7,38 @@ import future.keywords.in
 
 default rule_evaluation = false
 
+# If we got public access block config for both account and bucket
 rule_evaluation {
+	not data_adapter.public_access_block_configuration == null
+	not data_adapter.account_public_access_block_configuration == null
 	assert.some_true([data_adapter.public_access_block_configuration.BlockPublicAcls, data_adapter.account_public_access_block_configuration.BlockPublicAcls])
 	assert.some_true([data_adapter.public_access_block_configuration.BlockPublicPolicy, data_adapter.account_public_access_block_configuration.BlockPublicPolicy])
 	assert.some_true([data_adapter.public_access_block_configuration.IgnorePublicAcls, data_adapter.account_public_access_block_configuration.IgnorePublicAcls])
 	assert.some_true([data_adapter.public_access_block_configuration.RestrictPublicBuckets, data_adapter.account_public_access_block_configuration.RestrictPublicBuckets])
 }
 
+# If we got only account-level public access block config
+rule_evaluation {
+	not data_adapter.account_public_access_block_configuration == null
+	data_adapter.public_access_block_configuration == null
+	data_adapter.account_public_access_block_configuration.BlockPublicAcls == true
+	data_adapter.account_public_access_block_configuration.BlockPublicPolicy == true
+	data_adapter.account_public_access_block_configuration.IgnorePublicAcls == true
+	data_adapter.account_public_access_block_configuration.RestrictPublicBuckets == true
+}
+
+# If we got only bucket-level public access block config
+rule_evaluation {
+	not data_adapter.public_access_block_configuration == null
+	data_adapter.account_public_access_block_configuration == null
+	data_adapter.public_access_block_configuration.BlockPublicAcls == true
+	data_adapter.public_access_block_configuration.BlockPublicPolicy == true
+	data_adapter.public_access_block_configuration.IgnorePublicAcls == true
+	data_adapter.public_access_block_configuration.RestrictPublicBuckets == true
+}
+
 finding = result {
 	data_adapter.is_s3
-	not data_adapter.public_access_block_configuration == null
-	not data_adapter.account_public_access_block_configuration == null
 
 	result := lib_common.generate_result_without_expected(
 		lib_common.calculate_result(rule_evaluation),

--- a/bundle/compliance/policy/aws_s3/ensure_block_public_access.rego
+++ b/bundle/compliance/policy/aws_s3/ensure_block_public_access.rego
@@ -5,6 +5,15 @@ import data.compliance.lib.common as lib_common
 import data.compliance.policy.aws_s3.data_adapter
 import future.keywords.in
 
+public_access_block_config_is_blocked(config) {
+	config.BlockPublicAcls == true
+	config.BlockPublicPolicy == true
+	config.IgnorePublicAcls == true
+	config.RestrictPublicBuckets == true
+} else = false {
+	true
+}
+
 default rule_evaluation = false
 
 # If we got public access block config for both account and bucket
@@ -21,20 +30,14 @@ rule_evaluation {
 rule_evaluation {
 	not data_adapter.account_public_access_block_configuration == null
 	data_adapter.public_access_block_configuration == null
-	data_adapter.account_public_access_block_configuration.BlockPublicAcls == true
-	data_adapter.account_public_access_block_configuration.BlockPublicPolicy == true
-	data_adapter.account_public_access_block_configuration.IgnorePublicAcls == true
-	data_adapter.account_public_access_block_configuration.RestrictPublicBuckets == true
+	public_access_block_config_is_blocked(data_adapter.account_public_access_block_configuration)
 }
 
 # If we got only bucket-level public access block config
 rule_evaluation {
 	not data_adapter.public_access_block_configuration == null
 	data_adapter.account_public_access_block_configuration == null
-	data_adapter.public_access_block_configuration.BlockPublicAcls == true
-	data_adapter.public_access_block_configuration.BlockPublicPolicy == true
-	data_adapter.public_access_block_configuration.IgnorePublicAcls == true
-	data_adapter.public_access_block_configuration.RestrictPublicBuckets == true
+	public_access_block_config_is_blocked(data_adapter.public_access_block_configuration)
 }
 
 finding = result {


### PR DESCRIPTION
### Summary of your changes
Fix CIS AWS rule 2.1.5 so it can handle missing account/bucket level public access block configuration.

### Related Issues
Fixes #233 

### Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
