### PR TITLE
Add tests for recursive pki/ directories

### DIFF
--- a/bundle/compliance/cis_k8s/rules/cis_1_1_19/test.rego
+++ b/bundle/compliance/cis_k8s/rules/cis_1_1_19/test.rego
@@ -8,11 +8,13 @@ test_violation {
 	test.assert_fail(finding) with input as rule_input("etc/kubernetes/pki", "user", "root")
 	test.assert_fail(finding) with input as rule_input("etc/kubernetes/pki", "user", "user")
 	test.assert_fail(finding) with input as rule_input("etc/kubernetes/pki/some_file.txt", "root", "user")
+	test.assert_fail(finding) with input as rule_input("etc/kubernetes/pki/some/directory/some_file.txt", "root", "user")
 }
 
 test_pass {
 	test.assert_pass(finding) with input as rule_input("etc/kubernetes/pki", "root", "root")
 	test.assert_pass(finding) with input as rule_input("etc/kubernetes/pki/some_file.txt", "root", "root")
+	test.assert_pass(finding) with input as rule_input("etc/kubernetes/pki/some/directory/some_file.txt", "root", "root")
 }
 
 test_not_evaluated {


### PR DESCRIPTION
Complimentary of https://github.com/elastic/cloudbeat/pull/981

The test is not really necessary but it doesn't hurt to have it as a future guard for breaking changes.