### PR TITLE
[GCP] Use new resource interface

### DIFF
--- a/bundle/compliance/cis_gcp/test_data.rego
+++ b/bundle/compliance/cis_gcp/test_data.rego
@@ -1,7 +1,7 @@
 package cis_gcp.test_data
 
 generate_kms_resource(members, rotationPeriod, nextRotationTime, primary) = {
-	"resource": {"asset": {
+	"resource": {
 		"resource": {"data": {
 			"nextRotationTime": nextRotationTime,
 			"rotationPeriod": rotationPeriod,
@@ -11,31 +11,31 @@ generate_kms_resource(members, rotationPeriod, nextRotationTime, primary) = {
 			"role": "roles/cloudkms.cryptoKeyEncrypterDecrypter",
 			"members": members,
 		}]},
-	}},
+	},
 	"type": "key-management",
 	"subType": "gcp-kms",
 }
 
 generate_gcs_resource(members, isBucketLevelAccessEnabled) = {
-	"resource": {"asset": {
+	"resource": {
 		"resource": {"data": {"iamConfiguration": {"uniformBucketLevelAccess": {"enabled": isBucketLevelAccessEnabled}}}},
 		"iam_policy": {"bindings": [{
 			"role": "roles/storage.objectViewer",
 			"members": members,
 		}]},
-	}},
+	},
 	"type": "cloud-storage",
 	"subType": "gcp-gcs",
 }
 
 generate_bq_resource(config, subType, members) = {
-	"resource": {"asset": {
+	"resource": {
 		"resource": {"data": {"defaultEncryptionConfiguration": config}},
 		"iam_policy": {"bindings": [{
 			"role": "roles/bigquery.dataViewer",
 			"members": members,
 		}]},
-	}},
+	},
 	"type": "cloud-storage",
 	"subType": subType,
 }

--- a/bundle/compliance/policy/gcp/data_adapter.rego
+++ b/bundle/compliance/policy/gcp/data_adapter.rego
@@ -1,8 +1,12 @@
 package compliance.policy.gcp.data_adapter
 
-resource = input.resource.asset.resource
+import data.compliance.lib.common
 
-iam_policy = object.get(input.resource.asset, "iam_policy", {})
+resource = input.resource.resource
+
+iam_policy = input.resource.iam_policy
+
+has_policy = common.contains_key(input.resource, "iam_policy")
 
 is_gcs_bucket {
 	input.subType == "gcp-gcs"


### PR DESCRIPTION
this changes existing rules to not reference `resource.asset` as we removed it
