### PR TITLE
Add a workflow to generate markdown files

### DIFF
--- a/.github/workflows/rule-status.yml
+++ b/.github/workflows/rule-status.yml
@@ -47,5 +47,5 @@ jobs:
           git config --local user.name 'Elastic Machine'
           git config --local user.email 'elasticmachine@users.noreply.github.com'
           git add README.md RULES.md
-          git commit -m "Update rule status"
+          git commit -m "Update rules markdown files"
           git push origin HEAD:${{ github.head_ref }}

--- a/.github/workflows/rule-status.yml
+++ b/.github/workflows/rule-status.yml
@@ -1,0 +1,52 @@
+name: Update rules status
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  update_and_commit:
+    name: Update and Commit
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Set up Python environment
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.x
+
+      - name: Install Poetry
+        run: pip install poetry
+
+      - name: Install dependencies
+        run: poetry install
+
+      # possibly modifies README.md and RULES.md
+      - name: Update rule status
+        run: poetry run python dev/update_rule_status.py
+
+      # check for modified files
+      - name: Check for modified files
+        id: check_files
+        run: |
+          if [[ -n "$(git diff --name-only)" ]]; then
+            echo "Modified files found."
+            echo "::set-output name=modified::true"  
+          else
+            echo "No modified files found."
+            echo "::set-output name=modified::false" 
+          fi
+
+      # Commit changes if there are any
+      - name: Commit changes
+        if: steps.check_files.outputs.modified == 'true'
+        run: |
+          git config --local user.name 'Elastic Machine'
+          git config --local user.email 'elasticmachine@users.noreply.github.com'
+          git add README.md RULES.md
+          git commit -m "Update rule status"
+          git push origin HEAD:${{ github.head_ref }}

--- a/.github/workflows/rule-status.yml
+++ b/.github/workflows/rule-status.yml
@@ -29,21 +29,20 @@ jobs:
       - name: Update rule status
         run: poetry run python dev/update_rule_status.py
 
-      # check for modified files
       - name: Check for modified files
         id: check_files
         run: |
           if [[ -n "$(git diff --name-only)" ]]; then
             echo "Modified files found."
-            echo "::set-output name=modified::true"  
+            echo "has_changes=true" >> $GITHUB_OUTPUT
           else
             echo "No modified files found."
-            echo "::set-output name=modified::false" 
+            echo "has_changes=false" >> $GITHUB_OUTPUT
           fi
 
       # Commit changes if there are any
       - name: Commit changes
-        if: steps.check_files.outputs.modified == 'true'
+        if: steps.check_files.outputs.has_changes == 'true'
         run: |
           git config --local user.name 'Elastic Machine'
           git config --local user.email 'elasticmachine@users.noreply.github.com'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,13 +26,6 @@ repos:
         pass_filenames: false
         language: system
 
-      - id: update-rules-status
-        name: Update rules status
-        description: Update rules status in rules_table.md
-        require_serial: true
-        entry: poetry run python ./dev/update_rule_status.py
-        language: system
-
   - repo: https://github.com/igorshubovych/markdownlint-cli
     rev: v0.32.2
     hooks:


### PR DESCRIPTION
this PR introduces a new workflow that will generate `RULES.md` and `README.md` pre-merge by calling `poetry run python dev/update_rule_status.py` and update the PR 



1 - [doesn't commit when there are no changes: ](https://github.com/elastic/csp-security-policies/actions/runs/5665953337/job/15351714162?pr=262)
2 - [commits when there are changes](https://github.com/orouz/csp-security-policies/actions/runs/5665864941/job/15351453008?pr=13)  (note: this workflow is slightly different because it's on a fork)

looks like this:
<img width="879" alt="Screenshot 2023-07-26 at 10 23 47" src="https://github.com/elastic/csp-security-policies/assets/20814186/64658c87-0e0b-424c-8016-92c390aa9007">

