### PR TITLE
Add CIS 1.15

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![CIS K8S](https://img.shields.io/badge/CIS-Kubernetes%20(74%25)-326CE5?logo=Kubernetes)](RULES.md#k8s-cis-benchmark)
 [![CIS EKS](https://img.shields.io/badge/CIS-Amazon%20EKS%20(60%25)-FF9900?logo=Amazon+EKS)](RULES.md#eks-cis-benchmark)
 [![CIS AWS](https://img.shields.io/badge/CIS-AWS%20(87%25)-232F3E?logo=Amazon+AWS)](RULES.md#aws-cis-benchmark)
-[![CIS GCP](https://img.shields.io/badge/CIS-GCP%20(15%25)-4285F4?logo=Google+Cloud)](RULES.md#gcp-cis-benchmark)
+[![CIS GCP](https://img.shields.io/badge/CIS-GCP%20(17%25)-4285F4?logo=Google+Cloud)](RULES.md#gcp-cis-benchmark)
 
 ![Coverage Badge](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/oren-zohar/a7160df46e48dff45b24096de9302d38/raw/csp-security-policies_coverage.json)
 

--- a/RULES.md
+++ b/RULES.md
@@ -275,9 +275,9 @@
 
 ## GCP CIS Benchmark
 
-### 13/84 implemented rules (15%)
+### 14/84 implemented rules (17%)
 
-#### Automated rules: 13/73 (18%)
+#### Automated rules: 14/73 (19%)
 
 #### Manual rules: 0/11 (0%)
 
@@ -289,7 +289,7 @@
 |                       1.12                       | Identity and Access Management | Ensure API Keys Only Exist for Active Services                                                                                    |        :x:         | Automated |
 |                       1.13                       | Identity and Access Management | Ensure API Keys Are Restricted To Use by Only Specified Hosts and Apps                                                            |        :x:         |  Manual   |
 |                       1.14                       | Identity and Access Management | Ensure API Keys Are Restricted to Only APIs That Application Needs Access                                                         |        :x:         | Automated |
-|                       1.15                       | Identity and Access Management | Ensure API Keys Are Rotated Every 90 Days                                                                                         |        :x:         | Automated |
+| [1.15](bundle/compliance/cis_gcp/rules/cis_1_15) | Identity and Access Management | Ensure API Keys Are Rotated Every 90 Days                                                                                         | :white_check_mark: | Automated |
 |                       1.16                       | Identity and Access Management | Ensure Essential Contacts is Configured for Organization                                                                          |        :x:         | Automated |
 |                       1.17                       | Identity and Access Management | Ensure that Dataproc Cluster is encrypted using Customer-Managed Encryption Key                                                   |        :x:         | Automated |
 |                       1.18                       | Identity and Access Management | Ensure Secrets are Not Stored in Cloud Functions Environment Variables by Using Secret Manager                                    |        :x:         |  Manual   |

--- a/bundle/compliance/cis_gcp/rules/cis_1_15/data.yaml
+++ b/bundle/compliance/cis_gcp/rules/cis_1_15/data.yaml
@@ -1,0 +1,105 @@
+metadata:
+  id: 2b7b51e2-7e54-5b24-bc9c-6d09416fd5dc
+  name: Ensure API Keys Are Rotated Every 90 Days
+  profile_applicability: '* Level 2'
+  description: |-
+    API Keys should only be used for services in cases where other authentication methods are unavailable.
+    If they are in use it is recommended to rotate API keys every 90 days.
+  rationale: |-
+    Security risks involved in using API-Keys are listed below:
+
+    - API keys are simple encrypted strings
+
+    - API keys do not identify the user or the application making the API request
+
+    - API keys are typically accessible to clients, making it easy to discover and steal an API key
+
+    Because of these potential risks, Google recommends using the standard authentication flow instead of API Keys.
+    However, there are limited cases where API keys are more appropriate.
+    For example, if there is a mobile application that needs to use the Google Cloud Translation API, but doesn't otherwise need a backend server, API keys are the simplest way to authenticate to that API.
+
+    Once a key is stolen, it has no expiration, meaning it may be used indefinitely unless the project owner revokes or regenerates the key.
+
+    Rotating API keys will reduce the window of opportunity for an access key that is associated with a compromised or terminated account to be used.
+
+
+    API keys should be rotated to ensure that data cannot be accessed with an old key that might have been lost, cracked, or stolen.
+  audit: |-
+    **From Google Cloud Console**
+
+    1. Go to `APIs & Services\Credentials` using `https://console.cloud.google.com/apis/credentials`
+
+    2. In the section `API Keys`, for every key ensure the `creation date` is less than 90 days.
+
+    **From Google Cloud CLI**
+
+    To list keys, use the command
+
+    ```
+    gcloud services api-keys list
+    ```
+    Ensure the date in `createTime` is within 90 days.
+  remediation: |-
+    **From Google Cloud Console**
+
+    1. Go to `APIs & Services\Credentials` using `https://console.cloud.google.com/apis/credentials`
+
+    2. In the section `API Keys`, Click the `API Key Name`. The API Key properties display on a new page.
+
+    3. Click `REGENERATE KEY` to rotate API key.
+
+    4. Click `Save`.
+
+    5. Repeat steps 2,3,4 for every API key that has not been rotated in the last 90 days.
+
+    **Note:** Do not set `HTTP referrers` to wild-cards (* or *.[TLD] or *.[TLD]/*) allowing access to any/wide HTTP referrer(s)
+    Do not set `IP addresses` and referrer to `any host (0.0.0.0 or 0.0.0.0/0 or ::0)`
+
+    **From Google Cloud CLI**
+
+    There is not currently a way to regenerate and API key using gcloud commands.
+    To 'regenerate' a key you will need to create a new one, duplicate the restrictions from the key being rotated, and delete the old key.
+
+    6. List existing keys.
+    ```
+    gcloud services api-keys list
+    ```
+    7. Note the `UID` and restrictions of the key to regenerate.
+
+    8. Run this command to create a new API key. <key_name> is the display name of the new key.
+    ````
+    gcloud alpha services api-keys create --display-name="<key_name>"
+    ````
+    Note the `UID` of the newly created key
+
+    9. Run the update command to add required restrictions. 
+
+    Note - the restriction may vary for each key.
+    Refer to this documentation for the appropriate flags.
+    https://cloud.google.com/sdk/gcloud/reference/alpha/services/api-keys/update
+    ```
+    gcloud alpha services api-keys update <UID of new key>
+    ```
+    10. Delete the old key.
+    ```
+    gcloud alpha services api-keys delete <UID of old key>
+    ```
+  impact: |-
+    `Regenerating Key` may break existing client connectivity as the client will try to connect with older API keys they have stored on devices.
+  default_value: ''
+  references: |-
+    1. https://developers.google.com/maps/api-security-best-practices#regenerate-apikey
+    2. https://cloud.google.com/sdk/gcloud/reference/alpha/services/api-keys
+  section: Identity and Access Management
+  version: '1.0'
+  tags:
+  - CIS
+  - GCP
+  - CIS 1.15
+  - Identity and Access Management
+  benchmark:
+    name: CIS Google Cloud Platform Foundation
+    version: v2.0.0
+    id: cis_gcp
+    rule_number: '1.15'
+    posture_type: cspm

--- a/bundle/compliance/cis_gcp/rules/cis_1_15/rule.rego
+++ b/bundle/compliance/cis_gcp/rules/cis_1_15/rule.rego
@@ -1,0 +1,24 @@
+package compliance.cis_gcp.rules.cis_1_15
+
+import data.compliance.lib.common
+import data.compliance.policy.gcp.data_adapter
+import future.keywords.contains
+import future.keywords.if
+
+default is_valid = false
+
+duration = sprintf("%dh", [90 * 24]) # 90 days converted to hours
+
+is_valid if {
+	date := time.parse_rfc3339_ns(data_adapter.resource.data.createTime)
+	common.date_within_duration(date, duration)
+}
+
+finding = result if {
+	data_adapter.is_api_key
+
+	result := common.generate_result_without_expected(
+		common.calculate_result(is_valid),
+		data_adapter.resource.data.createTime,
+	)
+}

--- a/bundle/compliance/cis_gcp/rules/cis_1_15/test.rego
+++ b/bundle/compliance/cis_gcp/rules/cis_1_15/test.rego
@@ -1,7 +1,6 @@
 package compliance.cis_gcp.rules.cis_1_15
 
 import data.cis_gcp.test_data
-import data.compliance.lib.common
 import data.compliance.policy.gcp.data_adapter
 import data.lib.test
 

--- a/bundle/compliance/cis_gcp/rules/cis_1_15/test.rego
+++ b/bundle/compliance/cis_gcp/rules/cis_1_15/test.rego
@@ -1,0 +1,46 @@
+package compliance.cis_gcp.rules.cis_1_15
+
+import data.cis_gcp.test_data
+import data.compliance.lib.common
+import data.compliance.policy.gcp.data_adapter
+import data.lib.test
+
+type := "key-management"
+
+subtype := "gcp-apikeys-key"
+
+date_within_last_90_days := time.format(time.add_date(time.now_ns(), 0, 0, -1))
+
+date_before_last_90_days := time.format(time.add_date(time.now_ns(), 0, 0, -91))
+
+test_violation {
+	eval_fail with input as test_data.generate_gcp_asset(
+		type, subtype,
+		{"data": {"createTime": date_before_last_90_days}},
+		{},
+	)
+}
+
+test_pass {
+	eval_pass with input as test_data.generate_gcp_asset(
+		type, subtype,
+		{"data": {"createTime": date_within_last_90_days}},
+		{},
+	)
+}
+
+test_not_evaluated {
+	not_eval with input as test_data.not_eval_resource
+}
+
+eval_fail {
+	test.assert_fail(finding) with data.benchmark_data_adapter as data_adapter
+}
+
+eval_pass {
+	test.assert_pass(finding) with data.benchmark_data_adapter as data_adapter
+}
+
+not_eval {
+	not finding with data.benchmark_data_adapter as data_adapter
+}

--- a/bundle/compliance/policy/gcp/data_adapter.rego
+++ b/bundle/compliance/policy/gcp/data_adapter.rego
@@ -8,6 +8,10 @@ iam_policy = input.resource.iam_policy
 
 has_policy = common.contains_key(input.resource, "iam_policy")
 
+is_api_key {
+	input.subType == "gcp-apikeys-key"
+}
+
 is_storage_bucket {
 	input.subType == "gcp-storage-bucket"
 }


### PR DESCRIPTION

### Summary of your changes

Adds CIS GCP 1.15

| failed (api key not within last 90 days) |  passed (api key not within last 90 days)  |
|-----------|---|
| can't set past date for api key, covered in tests | <img width="454" alt="Screenshot 2023-08-01 at 14 35 28" src="https://github.com/elastic/csp-security-policies/assets/20814186/1a27d0b8-3696-445c-b70a-34579e487c93">|


### Related Issues

- https://github.com/elastic/security-team/issues/6179

### Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary README/documentation (if appropriate)

#### Introducing a new rule?
- [x] Generate rule metadata using [this script](https://github.com/elastic/csp-security-policies/tree/main/dev#generate-rules-metadata)
- [x] Add relevant unit tests
- [ ] Generate relevant rule templates using [this script](https://github.com/elastic/csp-security-policies/tree/main/dev#generate-rule-templates), and open a PR in [elastic/packages/cloud_security_posture](https://github.com/elastic/integrations/tree/main/packages/cloud_security_posture)

> **Note** Make sure to bump cloudbeat [`version/policy.go`](https://github.com/elastic/cloudbeat/blob/main/version/policy.go#L20) after merging this PR and drafting a new release.
