### PR TITLE
Add CIS GCP 6.1.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![CIS K8S](https://img.shields.io/badge/CIS-Kubernetes%20(74%25)-326CE5?logo=Kubernetes)](RULES.md#k8s-cis-benchmark)
 [![CIS EKS](https://img.shields.io/badge/CIS-Amazon%20EKS%20(60%25)-FF9900?logo=Amazon+EKS)](RULES.md#eks-cis-benchmark)
 [![CIS AWS](https://img.shields.io/badge/CIS-AWS%20(87%25)-232F3E?logo=Amazon+AWS)](RULES.md#aws-cis-benchmark)
-[![CIS GCP](https://img.shields.io/badge/CIS-GCP%20(58%25)-4285F4?logo=Google+Cloud)](RULES.md#gcp-cis-benchmark)
+[![CIS GCP](https://img.shields.io/badge/CIS-GCP%20(60%25)-4285F4?logo=Google+Cloud)](RULES.md#gcp-cis-benchmark)
 
 ![Coverage Badge](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/oren-zohar/a7160df46e48dff45b24096de9302d38/raw/csp-security-policies_coverage.json)
 

--- a/RULES.md
+++ b/RULES.md
@@ -275,9 +275,9 @@
 
 ## GCP CIS Benchmark
 
-### 49/84 implemented rules (58%)
+### 50/84 implemented rules (60%)
 
-#### Automated rules: 49/73 (67%)
+#### Automated rules: 50/73 (68%)
 
 #### Manual rules: 0/11 (0%)
 
@@ -343,7 +343,7 @@
 |   [5.2](bundle/compliance/cis_gcp/rules/cis_5_2)   | Storage                        | Ensure That Cloud Storage Buckets Have Uniform Bucket-Level Access Enabled                                                        | :white_check_mark: | Automated |
 |                       6.1.1                        | MySQL Database                 | Ensure That a MySQL Database Instance Does Not Allow Anyone To Connect With Administrative Privileges                             |        :x:         |  Manual   |
 |                       6.1.2                        | MySQL Database                 | Ensure ‘Skip_show_database’ Database Flag for Cloud SQL MySQL Instance Is Set to ‘On’                                             |        :x:         | Automated |
-|                       6.1.3                        | MySQL Database                 | Ensure That the ‘Local_infile’ Database Flag for a Cloud SQL MySQL Instance Is Set to ‘Off’                                       |        :x:         | Automated |
+| [6.1.3](bundle/compliance/cis_gcp/rules/cis_6_1_3) | MySQL Database                 | Ensure That the ‘Local_infile’ Database Flag for a Cloud SQL MySQL Instance Is Set to ‘Off’                                       | :white_check_mark: | Automated |
 |                       6.2.1                        | PostgreSQL Database            | Ensure ‘Log_error_verbosity’ Database Flag for Cloud SQL PostgreSQL Instance Is Set to ‘DEFAULT’ or Stricter                      |        :x:         | Automated |
 |                       6.2.2                        | PostgreSQL Database            | Ensure That the ‘Log_connections’ Database Flag for Cloud SQL PostgreSQL Instance Is Set to ‘On’                                  |        :x:         | Automated |
 |                       6.2.3                        | PostgreSQL Database            | Ensure That the ‘Log_disconnections’ Database Flag for Cloud SQL PostgreSQL Instance Is Set to ‘On’                               |        :x:         | Automated |

--- a/bundle/compliance/cis_gcp/rules/cis_6_1_3/data.yaml
+++ b/bundle/compliance/cis_gcp/rules/cis_6_1_3/data.yaml
@@ -1,0 +1,82 @@
+metadata:
+  id: f62488d2-4b52-57d4-8ecd-d8f47dcb3dda
+  name: Ensure That the ‘Local_infile’ Database Flag for a Cloud SQL MySQL Instance
+    Is Set to ‘Off’
+  profile_applicability: '* Level 1'
+  description: It is recommended to set the `local_infile` database flag for a Cloud
+    SQL MySQL instance to `off`.
+  rationale: |-
+    The `local_infile` flag controls the server-side LOCAL capability for LOAD DATA statements.
+    Depending on the `local_infile` setting, the server refuses or permits local data loading by clients that have LOCAL enabled on the client side.
+
+    To explicitly cause the server to refuse LOAD DATA LOCAL statements (regardless of how client programs and libraries are configured at build time or runtime), start mysqld with local_infile disabled.
+    local_infile can also be set at runtime.
+
+    Due to security issues associated with the `local_infile` flag, it is recommended to disable it.
+    This recommendation is applicable to MySQL database instances.
+  audit: |-
+    **From Google Cloud Console**
+
+    1. Go to the Cloud SQL Instances page in the Google Cloud Console by visiting [https://console.cloud.google.com/sql/instances](https://console.cloud.google.com/sql/instances).
+    2. Select the instance to open its `Instance Overview` page
+    3. Ensure the database flag `local_infile` that has been set is listed under the `Database flags` section.
+
+    **From Google Cloud CLI**
+
+    4. List all Cloud SQL database instances:
+    ```
+    gcloud sql instances list
+    ```
+    5. Ensure the below command returns `off` for every Cloud SQL MySQL database instance.
+    ```
+    gcloud sql instances describe INSTANCE_NAME --format=json | jq '.settings.databaseFlags[] | select(.name=="local_infile")|.value'
+    ```
+  remediation: |-
+    **From Google Cloud Console**
+
+    1. Go to the Cloud SQL Instances page in the Google Cloud Console by visiting [https://console.cloud.google.com/sql/instances](https://console.cloud.google.com/sql/instances).
+    2. Select the MySQL instance where the database flag needs to be enabled.
+    3. Click `Edit`.
+    4. Scroll down to the `Flags` section.
+    5. To set a flag that has not been set on the instance before, click `Add item`, choose the flag `local_infile` from the drop-down menu, and set its value to `off`.
+    6. Click `Save`.
+    7. Confirm the changes under `Flags` on the Overview page.
+
+    **From Google Cloud CLI**
+
+    8. List all Cloud SQL database instances using the following command:
+    ```
+    gcloud sql instances list
+    ```
+    9. Configure the `local_infile` database flag for every Cloud SQL Mysql database instance using the below command:
+    ```
+    gcloud sql instances patch INSTANCE_NAME --database-flags local_infile=off
+    ```
+
+    ```
+    Note : 
+
+    This command will overwrite all database flags that were previously set.
+    To keep those and add new ones, include the values for all flags to be set on the instance; any flag not specifically included is set to its default value.
+    For flags that do not take a value, specify the flag name followed by an equals sign ("=").
+    ```
+  impact: |-
+    Disabling `local_infile` makes the server refuse local data loading by clients that have LOCAL enabled on the client side.
+  default_value: ''
+  references: |-
+    1. https://cloud.google.com/sql/docs/mysql/flags
+    2. https://dev.mysql.com/doc/refman/5.7/en/server-system-variables.html#sysvar_local_infile
+    3. https://dev.mysql.com/doc/refman/5.7/en/load-data-local.html
+  section: MySQL Database
+  version: '1.0'
+  tags:
+  - CIS
+  - GCP
+  - CIS 6.1.3
+  - MySQL Database
+  benchmark:
+    name: CIS Google Cloud Platform Foundation
+    version: v2.0.0
+    id: cis_gcp
+    rule_number: 6.1.3
+    posture_type: cspm

--- a/bundle/compliance/cis_gcp/rules/cis_6_1_3/rule.rego
+++ b/bundle/compliance/cis_gcp/rules/cis_6_1_3/rule.rego
@@ -1,0 +1,19 @@
+package compliance.cis_gcp.rules.cis_6_1_3
+
+import data.compliance.lib.common
+import data.compliance.policy.gcp.data_adapter
+
+finding = result {
+	data_adapter.is_cloud_sql
+
+	result := common.generate_result_without_expected(
+		common.calculate_result(is_local_infile_flag_disabled),
+		data_adapter.resource,
+	)
+}
+
+is_local_infile_flag_disabled {
+	flags := data_adapter.resource.settings.databaseFlags[i]
+	flags.name == "local_infile"
+	flags.value == "off"
+} else = false

--- a/bundle/compliance/cis_gcp/rules/cis_6_1_3/test.rego
+++ b/bundle/compliance/cis_gcp/rules/cis_6_1_3/test.rego
@@ -1,0 +1,44 @@
+package compliance.cis_gcp.rules.cis_6_1_3
+
+import data.cis_gcp.test_data
+import data.compliance.policy.gcp.data_adapter
+import data.lib.test
+
+type := "cloud-database"
+
+subtype := "gcp-sqladmin-instance"
+
+test_violation {
+	# fail when databaseFlags is not set
+	eval_fail with input as test_data.generate_gcp_asset(
+		type, subtype, {"settings": {}},
+		{},
+	)
+
+	# fail when databaseFlags is set to off
+	eval_fail with input as test_data.generate_gcp_asset(
+		type, subtype, {"settings": {"databaseFlags": [{"name": "local_infile", "value": "on"}]}},
+		{},
+	)
+}
+
+test_pass {
+	# pass when local_infile is off
+	eval_pass with input as test_data.generate_gcp_asset(type, subtype, {"settings": {"databaseFlags": [{"name": "local_infile", "value": "off"}]}}, {})
+}
+
+test_not_evaluated {
+	not_eval with input as test_data.not_eval_resource
+}
+
+eval_fail {
+	test.assert_fail(finding) with data.benchmark_data_adapter as data_adapter
+}
+
+eval_pass {
+	test.assert_pass(finding) with data.benchmark_data_adapter as data_adapter
+}
+
+not_eval {
+	not finding with data.benchmark_data_adapter as data_adapter
+}


### PR DESCRIPTION
### Summary of your changes

Adds CIS GCP 6.1.3

| failed (`local_infile` is on) |  passed (`local_infile` is off)  |
|-----------|---|
| <img width="1315" alt="Screenshot 2023-08-13 at 13 15 47" src="https://github.com/elastic/csp-security-policies/assets/20814186/e0366b2f-24f1-425d-b383-bed72b21b1a7"> - |


### Related Issues
 - 
### Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary README/documentation (if appropriate)

#### Introducing a new rule?
- [x] Generate rule metadata using [this script](https://github.com/elastic/csp-security-policies/tree/main/dev#generate-rules-metadata)
- [x] Add relevant unit tests
- [ ] Generate relevant rule templates using [this script](https://github.com/elastic/csp-security-policies/tree/main/dev#generate-rule-templates), and open a PR in [elastic/packages/cloud_security_posture](https://github.com/elastic/integrations/tree/main/packages/cloud_security_posture)

> **Note** Make sure to bump cloudbeat [`version/policy.go`](https://github.com/elastic/cloudbeat/blob/main/version/policy.go#L20) after merging this PR and drafting a new release.
