### PR TITLE
[GCP] Fix 1.6 subtype

### DIFF
--- a/bundle/compliance/cis_gcp/rules/cis_1_6/rule.rego
+++ b/bundle/compliance/cis_gcp/rules/cis_1_6/rule.rego
@@ -6,7 +6,7 @@ import data.compliance.policy.gcp.iam.ensure_role_not_service_account_user as au
 import future.keywords.if
 
 finding = result if {
-	data_adapter.is_iam_service_account
+	data_adapter.is_cloud_resource_manager_project
 	data_adapter.has_policy
 
 	result := common.generate_result_without_expected(

--- a/bundle/compliance/cis_gcp/rules/cis_1_6/test.rego
+++ b/bundle/compliance/cis_gcp/rules/cis_1_6/test.rego
@@ -6,7 +6,7 @@ import data.lib.test
 
 type := "key-management"
 
-subtype := "gcp-iam-service-account"
+subtype := "gcp-cloudresourcemanager-project"
 
 test_violation {
 	eval_fail with input as test_data.generate_gcp_asset(type, subtype, {}, {"bindings": [{


### PR DESCRIPTION
this PR fixes a rule 1.6 subtype. using the wrong one, this rule ended up [not evaluating](https://github.com/elastic/cloudbeat/issues/672#issuecomment-1697318129) iam-policies. 