### PR TITLE
[CIS GCP] Implement rule 2.2 - Log Sinks

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![CIS K8S](https://img.shields.io/badge/CIS-Kubernetes%20(74%25)-326CE5?logo=Kubernetes)](RULES.md#k8s-cis-benchmark)
 [![CIS EKS](https://img.shields.io/badge/CIS-Amazon%20EKS%20(60%25)-FF9900?logo=Amazon+EKS)](RULES.md#eks-cis-benchmark)
 [![CIS AWS](https://img.shields.io/badge/CIS-AWS%20(87%25)-232F3E?logo=Amazon+AWS)](RULES.md#aws-cis-benchmark)
-[![CIS GCP](https://img.shields.io/badge/CIS-GCP%20(82%25)-4285F4?logo=Google+Cloud)](RULES.md#gcp-cis-benchmark)
+[![CIS GCP](https://img.shields.io/badge/CIS-GCP%20(83%25)-4285F4?logo=Google+Cloud)](RULES.md#gcp-cis-benchmark)
 [![CIS AZURE](https://img.shields.io/badge/CIS-AZURE%20(1%25)-F00EE8?logo=Microsoft+Azure)](RULES.md#azure-cis-benchmark)
 
 ![Coverage Badge](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/oren-zohar/a7160df46e48dff45b24096de9302d38/raw/csp-security-policies_coverage.json)

--- a/RULES.md
+++ b/RULES.md
@@ -275,9 +275,9 @@
 
 ## GCP CIS Benchmark
 
-### 69/84 implemented rules (82%)
+### 70/84 implemented rules (83%)
 
-#### Automated rules: 69/73 (95%)
+#### Automated rules: 70/73 (96%)
 
 #### Manual rules: 0/11 (0%)
 
@@ -309,7 +309,7 @@
 |                        2.14                        | Logging and Monitoring         | Ensure 'Access Transparency' is 'Enabled'                                                                                         |        :x:         |  Manual   |
 |                        2.15                        | Logging and Monitoring         | Ensure 'Access Approval' is 'Enabled'                                                                                             |        :x:         | Automated |
 |  [2.16](bundle/compliance/cis_gcp/rules/cis_2_16)  | Logging and Monitoring         | Ensure Logging is enabled for HTTP(S) Load Balancer                                                                               | :white_check_mark: | Automated |
-|                        2.2                         | Logging and Monitoring         | Ensure That Sinks Are Configured for All Log Entries                                                                              |        :x:         | Automated |
+|   [2.2](bundle/compliance/cis_gcp/rules/cis_2_2)   | Logging and Monitoring         | Ensure That Sinks Are Configured for All Log Entries                                                                              | :white_check_mark: | Automated |
 |   [2.3](bundle/compliance/cis_gcp/rules/cis_2_3)   | Logging and Monitoring         | Ensure That Retention Policies on Cloud Storage Buckets Used for Exporting Logs Are Configured Using Bucket Lock                  | :white_check_mark: | Automated |
 |   [2.4](bundle/compliance/cis_gcp/rules/cis_2_4)   | Logging and Monitoring         | Ensure Log Metric Filter and Alerts Exist for Project Ownership Assignments/Changes                                               | :white_check_mark: | Automated |
 |   [2.5](bundle/compliance/cis_gcp/rules/cis_2_5)   | Logging and Monitoring         | Ensure That the Log Metric Filter and Alerts Exist for Audit Configuration Changes                                                | :white_check_mark: | Automated |

--- a/bundle/compliance/cis_gcp/rules/cis_2_2/data.yaml
+++ b/bundle/compliance/cis_gcp/rules/cis_2_2/data.yaml
@@ -1,0 +1,102 @@
+metadata:
+  id: a9f473e3-a8b4-5076-b59a-f0d1c5a961ba
+  name: Ensure That Sinks Are Configured for All Log Entries
+  profile_applicability: '* Level 1'
+  description: |-
+    It is recommended to create a sink that will export copies of all the log entries.
+    This can help aggregate logs from multiple projects and export them to a Security Information and Event Management (SIEM).
+  rationale: |-
+    Log entries are held in Cloud Logging.
+    To aggregate logs, export them to a SIEM.
+    To keep them longer, it is recommended to set up a log sink.
+    Exporting involves writing a filter that selects the log entries to export, and choosing a destination in Cloud Storage, BigQuery, or Cloud Pub/Sub.
+    The filter and destination are held in an object called a sink.
+    To ensure all log entries are exported to sinks, ensure that there is no filter configured for a sink.
+    Sinks can be created in projects, organizations, folders, and billing accounts.
+  audit: |-
+    **From Google Cloud Console**
+
+    1. Go to `Logs Router` by visiting [https://console.cloud.google.com/logs/router](https://console.cloud.google.com/logs/router).
+
+    2. For every sink, click the 3-dot button for Menu options and select `View sink details`.
+
+    3. Ensure there is at least one sink with an `empty` Inclusion filter.
+
+    4. Additionally, ensure that the resource configured as `Destination` exists.
+
+    **From Google Cloud CLI**
+
+    5. Ensure that a sink with an `empty filter` exists. List the sinks for the project, folder or organization. If sinks are configured at a folder or organization level, they do not need to be configured for each project:
+    ```
+    gcloud logging sinks list --folder=FOLDER_ID | --organization=ORGANIZATION_ID | --project=PROJECT_ID
+    ```
+
+    The output should list at least one sink with an `empty filter`.
+
+    6. Additionally, ensure that the resource configured as `Destination` exists.
+
+    See [https://cloud.google.com/sdk/gcloud/reference/beta/logging/sinks/list](https://cloud.google.com/sdk/gcloud/reference/beta/logging/sinks/list) for more information.
+  remediation: |-
+    **From Google Cloud Console**
+
+    1. Go to `Logs Router` by visiting [https://console.cloud.google.com/logs/router](https://console.cloud.google.com/logs/router).
+
+    2. Click on the arrow symbol with `CREATE SINK` text.
+
+    3. Fill out the fields for `Sink details`.
+
+    4. Choose Cloud Logging bucket in the Select sink destination drop down menu.
+
+    5. Choose a log bucket in the next drop down menu.
+
+    6. If an inclusion filter is not provided for this sink, all ingested logs will be routed to the destination provided above. This may result in higher than expected resource usage.
+
+    7. Click `Create Sink`.
+
+    For more information, see [https://cloud.google.com/logging/docs/export/configure_export_v2#dest-create](https://cloud.google.com/logging/docs/export/configure_export_v2#dest-create).
+
+    **From Google Cloud CLI**
+
+    To create a sink to export all log entries in a Google Cloud Storage bucket: 
+
+    ```
+    gcloud logging sinks create <sink-name> storage.googleapis.com/DESTINATION_BUCKET_NAME
+    ```
+
+    Sinks can be created for a folder or organization, which will include all projects.
+
+    ```
+    gcloud logging sinks create <sink-name> storage.googleapis.com/DESTINATION_BUCKET_NAME --include-children --folder=FOLDER_ID | --organization=ORGANIZATION_ID
+    ```
+
+    **Note:** 
+
+    8. A sink created by the command-line above will export logs in storage buckets. However, sinks can be configured to export logs into BigQuery, or Cloud Pub/Sub, or `Custom Destination`.
+
+    9. While creating a sink, the sink option `--log-filter` is not used to ensure the sink exports all log entries.
+
+    10. A sink can be created at a folder or organization level that collects the logs of all the projects underneath bypassing the option `--include-children` in the gcloud command.
+  impact: |-
+    There are no costs or limitations in Cloud Logging for exporting logs, but the export destinations charge for storing or transmitting the log data.
+  default_value: ''
+  references: |-
+    1. https://cloud.google.com/logging/docs/reference/tools/gcloud-logging
+    2. https://cloud.google.com/logging/quotas
+    3. https://cloud.google.com/logging/docs/routing/overview
+    4. https://cloud.google.com/logging/docs/export/using_exported_logs
+    5. https://cloud.google.com/logging/docs/export/configure_export_v2
+    6. https://cloud.google.com/logging/docs/export/aggregated_exports
+    7. https://cloud.google.com/sdk/gcloud/reference/beta/logging/sinks/list
+  section: Logging and Monitoring
+  version: '1.0'
+  tags:
+  - CIS
+  - GCP
+  - CIS 2.2
+  - Logging and Monitoring
+  benchmark:
+    name: CIS Google Cloud Platform Foundation
+    version: v2.0.0
+    id: cis_gcp
+    rule_number: '2.2'
+    posture_type: cspm

--- a/bundle/compliance/cis_gcp/rules/cis_2_2/rule.rego
+++ b/bundle/compliance/cis_gcp/rules/cis_2_2/rule.rego
@@ -1,0 +1,23 @@
+package compliance.cis_gcp.rules.cis_2_2
+
+import data.compliance.lib.common
+import data.compliance.policy.gcp.data_adapter
+import future.keywords.if
+import future.keywords.in
+
+# Ensure That Sinks Are Configured for All Log Entries.
+finding = result if {
+	data_adapter.is_logging_asset
+
+	result := common.generate_result_without_expected(
+		common.calculate_result(is_sink_without_filter),
+		input.resource.log_sinks,
+	)
+}
+
+# We recieved all sinks configured at the project, folder and org level.
+# We check if any of the sinks are configured without a filter.
+is_sink_without_filter if {
+	some sink in input.resource.log_sinks
+	not sink.resource.data.filter
+} else = false

--- a/bundle/compliance/cis_gcp/rules/cis_2_2/test.rego
+++ b/bundle/compliance/cis_gcp/rules/cis_2_2/test.rego
@@ -1,0 +1,43 @@
+package compliance.cis_gcp.rules.cis_2_2
+
+import data.cis_gcp.test_data
+import data.compliance.policy.gcp.data_adapter
+import data.lib.test
+
+test_violation {
+	# no sinks
+	eval_fail with input as test_data.generate_logging_asset([])
+
+	# sinks with filter
+	eval_fail with input as test_data.generate_logging_asset([
+		{"resource": {"data": {"name": "log_sink1", "filter": "logName:syslog AND severity>=ERROR"}, "parent": "//cloudresourcemanager.googleapis.com/projects/123"}},
+		{"resource": {"data": {"name": "log_sink2", "filter": "logName:syslog AND severity>=ERROR"}, "parent": "//cloudresourcemanager.googleapis.com/folders/123"}},
+	])
+}
+
+test_pass {
+	# sinks without filter
+	eval_pass with input as test_data.generate_logging_asset([{"resource": {"data": {"name": "log_sink1"}, "parent": "//cloudresourcemanager.googleapis.com/projects/123"}}])
+
+	# project sink with filter and folde sink without filter
+	eval_pass with input as test_data.generate_logging_asset([
+		{"resource": {"data": {"name": "log_sink1", "filter": "logName:syslog AND severity>=ERROR"}, "parent": "//cloudresourcemanager.googleapis.com/projects/123"}},
+		{"resource": {"data": {"name": "log_sink2"}, "parent": "//cloudresourcemanager.googleapis.com/folders/123"}},
+	])
+}
+
+test_not_evaluated {
+	not_eval with input as test_data.not_eval_resource
+}
+
+eval_fail {
+	test.assert_fail(finding) with data.benchmark_data_adapter as data_adapter
+}
+
+eval_pass {
+	test.assert_pass(finding) with data.benchmark_data_adapter as data_adapter
+}
+
+not_eval {
+	not finding with data.benchmark_data_adapter as data_adapter
+}

--- a/bundle/compliance/cis_gcp/test_data.rego
+++ b/bundle/compliance/cis_gcp/test_data.rego
@@ -31,6 +31,12 @@ generate_serviceusage_asset(services) = {
 	"subType": "gcp-service-usage",
 }
 
+generate_logging_asset(sinks) = {
+	"resource": {"log_sinks": sinks},
+	"type": "logging",
+	"subType": "gcp-logging",
+}
+
 generate_kms_resource(members, rotationPeriod, nextRotationTime, primary) = generate_gcp_asset(
 	"key-management",
 	"gcp-cloudkms-crypto-key",

--- a/bundle/compliance/policy/gcp/data_adapter.rego
+++ b/bundle/compliance/policy/gcp/data_adapter.rego
@@ -115,3 +115,7 @@ is_log_bucket {
 is_services_usage {
 	input.subType == "gcp-service-usage"
 }
+
+is_logging_asset {
+	input.subType == "gcp-logging"
+}


### PR DESCRIPTION
### Summary of your changes
This rule is tricky.
The evaluated asset is an array of log sinks, consisting of those configured specifically for a single project, as well as those configured at higher levels (folders and organization).
This approach ensures that even if a log sink is configured at a higher level than a project, the project is covered, and the rule should still pass.


### Related Issues
- #305 

### Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary README/documentation (if appropriate)

#### Introducing a new rule?

- [x] Generate rule metadata using [this script](https://github.com/elastic/csp-security-policies/tree/main/dev#generate-rules-metadata)
- [x] Add relevant unit tests
- [ ] Generate relevant rule templates using [this script](https://github.com/elastic/csp-security-policies/tree/main/dev#generate-rule-templates), and open a PR in [elastic/packages/cloud_security_posture](https://github.com/elastic/integrations/tree/main/packages/cloud_security_posture)

> **Note** Make sure to bump cloudbeat [`version/policy.go`](https://github.com/elastic/cloudbeat/blob/main/version/policy.go#L20) after merging this PR and drafting a new release.
