### PR TITLE
Add Regal Rego linting to project

### DIFF
--- a/.github/workflows/test-policies.yml
+++ b/.github/workflows/test-policies.yml
@@ -33,6 +33,14 @@ jobs:
       - name: OPA check -strict
         run: opa check --strict --bundle ./bundle
 
+      - name: Set up Regal
+        uses: StyraInc/setup-regal@v0.1.0
+        with:
+          version: v0.10.1
+
+      - name: Lint Rego
+        run: regal lint --format github bundle
+
   update-rules-status:
     name: Update rules status
     runs-on: ubuntu-latest

--- a/.regal/config.yaml
+++ b/.regal/config.yaml
@@ -1,0 +1,35 @@
+rules:
+  idiomatic:
+    use-some-for-output-vars:
+      level: ignore
+  imports:
+    prefer-package-imports:
+      level: ignore
+  style:
+    avoid-get-and-list-prefix:
+      level: ignore
+    default-over-else:
+      level: ignore
+    external-reference:
+      level: ignore
+    line-length:
+      level: ignore
+    prefer-some-in-iteration:
+      level: ignore
+    prefer-snake-case:
+      level: ignore
+    rule-length:
+      level: error
+      max-rule-length: 50
+    todo-comment:
+      level: ignore
+    use-assignment-operator:
+      level: ignore
+  testing:
+    file-missing-test-suffix:
+      level: ignore
+    print-or-trace-call:
+      # unsure if these are intentional
+      level: ignore
+    test-outside-test-package:
+      level: ignore

--- a/bundle/compliance/cis_aws/rules/cis_1_16/rule.rego
+++ b/bundle/compliance/cis_aws/rules/cis_1_16/rule.rego
@@ -6,7 +6,7 @@ import future.keywords.if
 import future.keywords.in
 
 # Ensure IAM policies that allow full "*:*" administrative privileges are not attached
-finding = result if {
+finding := result if {
 	# filter
 	data_adapter.is_iam_policy
 
@@ -20,6 +20,6 @@ finding = result if {
 policy_is_permissive if {
 	some statement in data_adapter.policy_document.Statement
 	statement.Effect == "Allow"
-	common.array_contains(common.ensure_array(statement.Action), "*")
-	common.array_contains(common.ensure_array(statement.Resource), "*")
+	"*" in common.ensure_array(statement.Action)
+	"*" in common.ensure_array(statement.Resource)
 } else = false

--- a/bundle/compliance/cis_aws/rules/cis_1_16/test.rego
+++ b/bundle/compliance/cis_aws/rules/cis_1_16/test.rego
@@ -49,6 +49,7 @@ test_violation {
 	])
 }
 
+# regal ignore:rule-length
 test_pass {
 	# No statements, no problems
 	eval_pass with input as generate_input([])

--- a/bundle/compliance/cis_aws/rules/cis_3_1/rule.rego
+++ b/bundle/compliance/cis_aws/rules/cis_3_1/rule.rego
@@ -7,7 +7,7 @@ import data.compliance.policy.aws_cloudtrail.trail
 default rule_evaluation = false
 
 finding = result {
-	# filter 
+	# filter
 	data_adapter.is_multi_trails_type
 
 	# set result

--- a/bundle/compliance/cis_aws/rules/cis_3_1/test.rego
+++ b/bundle/compliance/cis_aws/rules/cis_3_1/test.rego
@@ -22,7 +22,7 @@ test_violation {
 		"EventSelectors": [{"IncludeManagementEvents": true}],
 	}}])
 
-	# The event selector does include management events 
+	# The event selector does include management events
 	eval_fail with input as rule_input([{"TrailInfo": {
 		"Trail": {"IsMultiRegionTrail": true},
 		"Status": {"IsLogging": true},

--- a/bundle/compliance/cis_aws/rules/cis_3_5/test.rego
+++ b/bundle/compliance/cis_aws/rules/cis_3_5/test.rego
@@ -8,7 +8,7 @@ import data.lib.test
 finding = audit.finding
 
 test_violation {
-	# single region, single recorder config 
+	# single region, single recorder config
 	eval_fail with input as rule_input(false, false)
 	eval_fail with input as rule_input(true, false)
 	eval_fail with input as rule_input(false, true)

--- a/bundle/compliance/cis_aws/rules/cis_4_1/rule.rego
+++ b/bundle/compliance/cis_aws/rules/cis_4_1/rule.rego
@@ -7,7 +7,7 @@ import data.compliance.policy.aws_cloudtrail.trail
 default rule_evaluation = false
 
 finding = result {
-	# filter 
+	# filter
 	data_adapter.is_multi_trails_type
 
 	# set result

--- a/bundle/compliance/cis_aws/rules/cis_4_1/test.rego
+++ b/bundle/compliance/cis_aws/rules/cis_4_1/test.rego
@@ -4,6 +4,7 @@ import data.cis_aws.test_data
 import data.compliance.cis_aws.data_adapter
 import data.lib.test
 
+# regal ignore:rule-length
 test_violation {
 	# No items
 	eval_fail with input as rule_input([])
@@ -52,7 +53,7 @@ test_violation {
 		"MetricTopicBinding": {"filter_1": ["arn:aws:...sns"]},
 	}])
 
-	# The event selector does include management events 
+	# The event selector does include management events
 	eval_fail with input as rule_input([{
 		"TrailInfo": {
 			"Trail": {"IsMultiRegionTrail": true},

--- a/bundle/compliance/cis_aws/rules/cis_4_10/rule.rego
+++ b/bundle/compliance/cis_aws/rules/cis_4_10/rule.rego
@@ -7,7 +7,7 @@ import data.compliance.policy.aws_cloudtrail.trail
 default rule_evaluation = false
 
 finding = result {
-	# filter 
+	# filter
 	data_adapter.is_multi_trails_type
 
 	# set result

--- a/bundle/compliance/cis_aws/rules/cis_4_11/rule.rego
+++ b/bundle/compliance/cis_aws/rules/cis_4_11/rule.rego
@@ -7,7 +7,7 @@ import data.compliance.policy.aws_cloudtrail.trail
 default rule_evaluation = false
 
 finding = result {
-	# filter 
+	# filter
 	data_adapter.is_multi_trails_type
 
 	# set result

--- a/bundle/compliance/cis_aws/rules/cis_4_12/rule.rego
+++ b/bundle/compliance/cis_aws/rules/cis_4_12/rule.rego
@@ -7,7 +7,7 @@ import data.compliance.policy.aws_cloudtrail.trail
 default rule_evaluation = false
 
 finding = result {
-	# filter 
+	# filter
 	data_adapter.is_multi_trails_type
 
 	# set result

--- a/bundle/compliance/cis_aws/rules/cis_4_13/rule.rego
+++ b/bundle/compliance/cis_aws/rules/cis_4_13/rule.rego
@@ -7,7 +7,7 @@ import data.compliance.policy.aws_cloudtrail.trail
 default rule_evaluation = false
 
 finding = result {
-	# filter 
+	# filter
 	data_adapter.is_multi_trails_type
 
 	# set result

--- a/bundle/compliance/cis_aws/rules/cis_4_14/rule.rego
+++ b/bundle/compliance/cis_aws/rules/cis_4_14/rule.rego
@@ -7,7 +7,7 @@ import data.compliance.policy.aws_cloudtrail.trail
 default rule_evaluation = false
 
 finding = result {
-	# filter 
+	# filter
 	data_adapter.is_multi_trails_type
 
 	# set result

--- a/bundle/compliance/cis_aws/rules/cis_4_15/rule.rego
+++ b/bundle/compliance/cis_aws/rules/cis_4_15/rule.rego
@@ -7,7 +7,7 @@ import data.compliance.policy.aws_cloudtrail.trail
 default rule_evaluation = false
 
 finding = result {
-	# filter 
+	# filter
 	data_adapter.is_multi_trails_type
 
 	# set result

--- a/bundle/compliance/cis_aws/rules/cis_4_16/rule.rego
+++ b/bundle/compliance/cis_aws/rules/cis_4_16/rule.rego
@@ -6,7 +6,7 @@ import data.compliance.policy.aws_securityhub.data_adapter
 default rule_evaluation = false
 
 finding = result {
-	# filter 
+	# filter
 	data_adapter.is_securityhub_subType
 
 	# set result

--- a/bundle/compliance/cis_aws/rules/cis_4_2/rule.rego
+++ b/bundle/compliance/cis_aws/rules/cis_4_2/rule.rego
@@ -7,7 +7,7 @@ import data.compliance.policy.aws_cloudtrail.trail
 default rule_evaluation = false
 
 finding = result {
-	# filter 
+	# filter
 	data_adapter.is_multi_trails_type
 
 	# set result

--- a/bundle/compliance/cis_aws/rules/cis_4_3/rule.rego
+++ b/bundle/compliance/cis_aws/rules/cis_4_3/rule.rego
@@ -7,7 +7,7 @@ import data.compliance.policy.aws_cloudtrail.trail
 default rule_evaluation = false
 
 finding = result {
-	# filter 
+	# filter
 	data_adapter.is_multi_trails_type
 
 	# set result

--- a/bundle/compliance/cis_aws/rules/cis_4_4/rule.rego
+++ b/bundle/compliance/cis_aws/rules/cis_4_4/rule.rego
@@ -7,7 +7,7 @@ import data.compliance.policy.aws_cloudtrail.trail
 default rule_evaluation = false
 
 finding = result {
-	# filter 
+	# filter
 	data_adapter.is_multi_trails_type
 
 	# set result

--- a/bundle/compliance/cis_aws/rules/cis_4_5/rule.rego
+++ b/bundle/compliance/cis_aws/rules/cis_4_5/rule.rego
@@ -7,7 +7,7 @@ import data.compliance.policy.aws_cloudtrail.trail
 default rule_evaluation = false
 
 finding = result {
-	# filter 
+	# filter
 	data_adapter.is_multi_trails_type
 
 	# set result

--- a/bundle/compliance/cis_aws/rules/cis_4_6/rule.rego
+++ b/bundle/compliance/cis_aws/rules/cis_4_6/rule.rego
@@ -7,7 +7,7 @@ import data.compliance.policy.aws_cloudtrail.trail
 default rule_evaluation = false
 
 finding = result {
-	# filter 
+	# filter
 	data_adapter.is_multi_trails_type
 
 	# set result

--- a/bundle/compliance/cis_aws/rules/cis_4_7/rule.rego
+++ b/bundle/compliance/cis_aws/rules/cis_4_7/rule.rego
@@ -7,7 +7,7 @@ import data.compliance.policy.aws_cloudtrail.trail
 default rule_evaluation = false
 
 finding = result {
-	# filter 
+	# filter
 	data_adapter.is_multi_trails_type
 
 	# set result

--- a/bundle/compliance/cis_aws/rules/cis_4_8/rule.rego
+++ b/bundle/compliance/cis_aws/rules/cis_4_8/rule.rego
@@ -7,7 +7,7 @@ import data.compliance.policy.aws_cloudtrail.trail
 default rule_evaluation = false
 
 finding = result {
-	# filter 
+	# filter
 	data_adapter.is_multi_trails_type
 
 	# set result

--- a/bundle/compliance/cis_aws/rules/cis_4_9/rule.rego
+++ b/bundle/compliance/cis_aws/rules/cis_4_9/rule.rego
@@ -7,7 +7,7 @@ import data.compliance.policy.aws_cloudtrail.trail
 default rule_evaluation = false
 
 finding = result {
-	# filter 
+	# filter
 	data_adapter.is_multi_trails_type
 
 	# set result

--- a/bundle/compliance/cis_azure/rules/cis_5_5/rule.rego
+++ b/bundle/compliance/cis_azure/rules/cis_5_5/rule.rego
@@ -3,15 +3,11 @@ package compliance.cis_azure.rules.cis_5_5
 import data.compliance.lib.common
 import data.compliance.policy.azure.data_adapter
 
-finding = result {
-	# No filter, all resources will be checked
-
-	# set result
-	result := common.generate_result_without_expected(
-		common.calculate_result(ensure_sku_valid),
-		{"Resource": data_adapter.resource},
-	)
-}
+# No filter, all resources will be checked
+finding := common.generate_result_without_expected(
+	common.calculate_result(ensure_sku_valid),
+	{"Resource": data_adapter.resource},
+)
 
 ensure_sku_tier {
 	data_adapter.resource.sku.tier != "Basic"

--- a/bundle/compliance/cis_eks/rules/cis_3_2_9/rule.rego
+++ b/bundle/compliance/cis_eks/rules/cis_3_2_9/rule.rego
@@ -3,7 +3,7 @@ package compliance.cis_eks.rules.cis_3_2_9
 import data.compliance.policy.process.ensure_arguments_and_config as audit
 
 # Ensure that the --event-qps argument is set to 0 or a level which
-# ensures appropriate event capture 
+# ensures appropriate event capture
 default rule_evaluation = false
 
 rule_evaluation {

--- a/bundle/compliance/cis_eks/rules/cis_4_2_1/rule.rego
+++ b/bundle/compliance/cis_eks/rules/cis_4_2_1/rule.rego
@@ -2,6 +2,4 @@ package compliance.cis_eks.rules.cis_4_2_1
 
 import data.compliance.policy.kube_api.minimize_admission as audit
 
-finding = result {
-	result := audit.finding("privileged")
-}
+finding := audit.finding("privileged")

--- a/bundle/compliance/cis_eks/rules/cis_4_2_2/rule.rego
+++ b/bundle/compliance/cis_eks/rules/cis_4_2_2/rule.rego
@@ -2,6 +2,4 @@ package compliance.cis_eks.rules.cis_4_2_2
 
 import data.compliance.policy.kube_api.minimize_sharing as audit
 
-finding = result {
-	result := audit.finding("hostPID")
-}
+finding := audit.finding("hostPID")

--- a/bundle/compliance/cis_eks/rules/cis_4_2_3/rule.rego
+++ b/bundle/compliance/cis_eks/rules/cis_4_2_3/rule.rego
@@ -2,6 +2,4 @@ package compliance.cis_eks.rules.cis_4_2_3
 
 import data.compliance.policy.kube_api.minimize_sharing as audit
 
-finding = result {
-	result := audit.finding("hostIPC")
-}
+finding := audit.finding("hostIPC")

--- a/bundle/compliance/cis_eks/rules/cis_4_2_4/rule.rego
+++ b/bundle/compliance/cis_eks/rules/cis_4_2_4/rule.rego
@@ -2,6 +2,4 @@ package compliance.cis_eks.rules.cis_4_2_4
 
 import data.compliance.policy.kube_api.minimize_sharing as audit
 
-finding = result {
-	result := audit.finding("hostNetwork")
-}
+finding := audit.finding("hostNetwork")

--- a/bundle/compliance/cis_eks/rules/cis_4_2_5/rule.rego
+++ b/bundle/compliance/cis_eks/rules/cis_4_2_5/rule.rego
@@ -2,6 +2,4 @@ package compliance.cis_eks.rules.cis_4_2_5
 
 import data.compliance.policy.kube_api.minimize_admission as audit
 
-finding = result {
-	result := audit.finding("allowPrivilegeEscalation")
-}
+finding := audit.finding("allowPrivilegeEscalation")

--- a/bundle/compliance/cis_eks/rules/cis_4_2_6/rule.rego
+++ b/bundle/compliance/cis_eks/rules/cis_4_2_6/rule.rego
@@ -2,6 +2,4 @@ package compliance.cis_eks.rules.cis_4_2_6
 
 import data.compliance.policy.kube_api.minimize_admission_root as audit
 
-finding = result {
-	result := audit.finding
-}
+finding := audit.finding

--- a/bundle/compliance/cis_eks/rules/cis_4_2_7/rule.rego
+++ b/bundle/compliance/cis_eks/rules/cis_4_2_7/rule.rego
@@ -2,6 +2,4 @@ package compliance.cis_eks.rules.cis_4_2_7
 
 import data.compliance.policy.kube_api.minimize_certain_capability as audit
 
-finding = result {
-	result := audit.finding
-}
+finding := audit.finding

--- a/bundle/compliance/cis_eks/rules/cis_4_2_8/rule.rego
+++ b/bundle/compliance/cis_eks/rules/cis_4_2_8/rule.rego
@@ -2,6 +2,4 @@ package compliance.cis_eks.rules.cis_4_2_8
 
 import data.compliance.policy.kube_api.minimize_added_capabilities as audit
 
-finding = result {
-	result := audit.finding
-}
+finding := audit.finding

--- a/bundle/compliance/cis_eks/rules/cis_4_2_9/rule.rego
+++ b/bundle/compliance/cis_eks/rules/cis_4_2_9/rule.rego
@@ -2,6 +2,4 @@ package compliance.cis_eks.rules.cis_4_2_9
 
 import data.compliance.policy.kube_api.minimize_assigned_capabilities as audit
 
-finding = result {
-	result := audit.finding
-}
+finding := audit.finding

--- a/bundle/compliance/cis_gcp/rules/cis_1_11/test.rego
+++ b/bundle/compliance/cis_gcp/rules/cis_1_11/test.rego
@@ -16,7 +16,7 @@ admin_role := {
 }
 
 test_violation {
-	# fail when same user (user:a) is both: 
+	# fail when same user (user:a) is both:
 	# roles/cloudkms.admin and roles/cloudkms.cryptoKeyEncrypter
 	eval_fail with input as test_data.generate_gcp_asset(type, subtype, {}, {"bindings": [
 		admin_role,

--- a/bundle/compliance/cis_gcp/rules/cis_1_14/rule.rego
+++ b/bundle/compliance/cis_gcp/rules/cis_1_14/rule.rego
@@ -3,6 +3,7 @@ package compliance.cis_gcp.rules.cis_1_14
 import data.compliance.lib.common
 import data.compliance.policy.gcp.data_adapter
 import future.keywords.if
+import future.keywords.in
 
 default has_valid_apikey_restrictions = false
 
@@ -17,8 +18,8 @@ finding = result if {
 
 has_valid_apikey_restrictions if {
 	# apikey is not un-restricted
-	common.contains_key(data_adapter.resource.data, "restrictions")
-	common.contains_key(data_adapter.resource.data.restrictions, "apiTargets")
+	"restrictions" in object.keys(data_adapter.resource.data)
+	"apiTargets" in object.keys(data_adapter.resource.data.restrictions)
 	api_targets := data_adapter.resource.data.restrictions.apiTargets[i]
 
 	# at least 1 restriction

--- a/bundle/compliance/cis_gcp/rules/cis_1_8/rule.rego
+++ b/bundle/compliance/cis_gcp/rules/cis_1_8/rule.rego
@@ -5,7 +5,7 @@ import data.compliance.policy.gcp.data_adapter
 import future.keywords.if
 
 # a user should not have both admin and user role
-# this creates a set of such members, and 
+# this creates a set of such members, and
 # if the set is empty, the policy is valid
 members_with_both_roles := {m |
 	# get all members with admin role

--- a/bundle/compliance/cis_gcp/rules/cis_2_1/rule.rego
+++ b/bundle/compliance/cis_gcp/rules/cis_2_1/rule.rego
@@ -24,7 +24,7 @@ has_read_write_logs(policy) if {
 	log_types := {t | t = policy.audit_configs[i].audit_log_configs[j].log_type}
 	1 in log_types # "ADMIN_READ"
 	2 in log_types # "DATA_WRITE"
-	3 in log_types # "DATA_READ" 
+	3 in log_types # "DATA_READ"
 	policy.audit_configs[_].service == "allServices"
 } else = false
 

--- a/bundle/compliance/cis_gcp/rules/cis_2_1/test.rego
+++ b/bundle/compliance/cis_gcp/rules/cis_2_1/test.rego
@@ -55,7 +55,7 @@ test_violation {
 }
 
 test_pass {
-	# passes when project has DATA_READ/DATA_WRITE/ADMIN_READ  
+	# passes when project has DATA_READ/DATA_WRITE/ADMIN_READ
 	# for all services, and with no exempted members
 	eval_pass with input as test_data.generate_policies_asset([{"iam_policy": {"audit_configs": [{
 		"audit_log_configs": [

--- a/bundle/compliance/cis_gcp/rules/cis_2_13/rule.rego
+++ b/bundle/compliance/cis_gcp/rules/cis_2_13/rule.rego
@@ -5,7 +5,7 @@ import data.compliance.policy.gcp.data_adapter
 import future.keywords.if
 import future.keywords.in
 
-#Ensure Cloud Asset Inventory Is Enabled
+# Ensure Cloud Asset Inventory Is Enabled
 finding = result if {
 	data_adapter.is_services_usage
 

--- a/bundle/compliance/cis_gcp/rules/cis_3_8/test.rego
+++ b/bundle/compliance/cis_gcp/rules/cis_3_8/test.rego
@@ -9,6 +9,7 @@ type := "cloud-compute"
 
 subtype := "gcp-compute-subnetwork"
 
+# regal ignore:rule-length
 test_violation {
 	# fail when enableFlowLogs is missing
 	eval_fail with input as test_data.generate_gcp_asset(

--- a/bundle/compliance/cis_gcp/rules/cis_6_3_6/rule.rego
+++ b/bundle/compliance/cis_gcp/rules/cis_6_3_6/rule.rego
@@ -16,4 +16,4 @@ finding = result {
 	)
 }
 
-is_flag_configured_as_expected := audit.is_flag_configured_as_expected("3625", ["on"]) #trace flag
+is_flag_configured_as_expected := audit.is_flag_configured_as_expected("3625", ["on"]) # trace flag

--- a/bundle/compliance/cis_gcp/rules/cis_6_5/test.rego
+++ b/bundle/compliance/cis_gcp/rules/cis_6_5/test.rego
@@ -9,7 +9,7 @@ type := "cloud-database"
 subtype := "gcp-sqladmin-instance"
 
 test_violation {
-	# fail when authorizedNetworks includes 0.0.0.0/0 
+	# fail when authorizedNetworks includes 0.0.0.0/0
 	eval_fail with input as test_data.generate_gcp_asset(
 		type, subtype,
 		{"data": {"settings": {"ipConfiguration": {"authorizedNetworks": [
@@ -21,7 +21,7 @@ test_violation {
 }
 
 test_pass {
-	# pass when authorizedNetworks is not defined 
+	# pass when authorizedNetworks is not defined
 	eval_pass with input as test_data.generate_gcp_asset(
 		type, subtype,
 		{"data": {"settings": {}}},

--- a/bundle/compliance/cis_k8s/rules/cis_1_2_10/rule.rego
+++ b/bundle/compliance/cis_k8s/rules/cis_1_2_10/rule.rego
@@ -2,6 +2,4 @@ package compliance.cis_k8s.rules.cis_1_2_10
 
 import data.compliance.policy.process.ensure_arguments_contain_value as audit
 
-finding = result {
-	result := audit.finding(audit.contains("--enable-admission-plugins", "EventRateLimit"))
-}
+finding := audit.finding(audit.contains("--enable-admission-plugins", "EventRateLimit"))

--- a/bundle/compliance/cis_k8s/rules/cis_1_2_11/rule.rego
+++ b/bundle/compliance/cis_k8s/rules/cis_1_2_11/rule.rego
@@ -2,6 +2,4 @@ package compliance.cis_k8s.rules.cis_1_2_11
 
 import data.compliance.policy.process.ensure_arguments_contain_value as audit
 
-finding = result {
-	result := audit.finding(audit.not_contains("--enable-admission-plugins", "AlwaysAdmit"))
-}
+finding := audit.finding(audit.not_contains("--enable-admission-plugins", "AlwaysAdmit"))

--- a/bundle/compliance/cis_k8s/rules/cis_1_2_12/rule.rego
+++ b/bundle/compliance/cis_k8s/rules/cis_1_2_12/rule.rego
@@ -2,6 +2,4 @@ package compliance.cis_k8s.rules.cis_1_2_12
 
 import data.compliance.policy.process.ensure_arguments_contain_value as audit
 
-finding = result {
-	result := audit.finding(audit.contains("--enable-admission-plugins", "AlwaysPullImages"))
-}
+finding := audit.finding(audit.contains("--enable-admission-plugins", "AlwaysPullImages"))

--- a/bundle/compliance/cis_k8s/rules/cis_1_2_14/rule.rego
+++ b/bundle/compliance/cis_k8s/rules/cis_1_2_14/rule.rego
@@ -2,6 +2,4 @@ package compliance.cis_k8s.rules.cis_1_2_14
 
 import data.compliance.policy.process.ensure_arguments_not_contain_value_appropriate as audit
 
-finding = result {
-	result := audit.finding("--disable-admission-plugins", "ServiceAccount")
-}
+finding := audit.finding("--disable-admission-plugins", "ServiceAccount")

--- a/bundle/compliance/cis_k8s/rules/cis_1_2_15/rule.rego
+++ b/bundle/compliance/cis_k8s/rules/cis_1_2_15/rule.rego
@@ -2,6 +2,4 @@ package compliance.cis_k8s.rules.cis_1_2_15
 
 import data.compliance.policy.process.ensure_arguments_not_contain_value_appropriate as audit
 
-finding = result {
-	result := audit.finding("--disable-admission-plugins", "NamespaceLifecycle")
-}
+finding := audit.finding("--disable-admission-plugins", "NamespaceLifecycle")

--- a/bundle/compliance/cis_k8s/rules/cis_1_2_16/rule.rego
+++ b/bundle/compliance/cis_k8s/rules/cis_1_2_16/rule.rego
@@ -2,6 +2,4 @@ package compliance.cis_k8s.rules.cis_1_2_16
 
 import data.compliance.policy.process.ensure_arguments_contain_value as audit
 
-finding = result {
-	result := audit.finding(audit.contains("--enable-admission-plugins", "NodeRestriction"))
-}
+finding := audit.finding(audit.contains("--enable-admission-plugins", "NodeRestriction"))

--- a/bundle/compliance/cis_k8s/rules/cis_1_2_7/rule.rego
+++ b/bundle/compliance/cis_k8s/rules/cis_1_2_7/rule.rego
@@ -2,6 +2,4 @@ package compliance.cis_k8s.rules.cis_1_2_7
 
 import data.compliance.policy.process.ensure_arguments_contain_value as audit
 
-finding = result {
-	result := audit.finding(audit.not_contains("--authorization-mode", "AlwaysAllow"))
-}
+finding := audit.finding(audit.not_contains("--authorization-mode", "AlwaysAllow"))

--- a/bundle/compliance/cis_k8s/rules/cis_1_2_8/rule.rego
+++ b/bundle/compliance/cis_k8s/rules/cis_1_2_8/rule.rego
@@ -2,6 +2,4 @@ package compliance.cis_k8s.rules.cis_1_2_8
 
 import data.compliance.policy.process.ensure_arguments_contain_value as audit
 
-finding = result {
-	result := audit.finding(audit.contains("--authorization-mode", "Node"))
-}
+finding := audit.finding(audit.contains("--authorization-mode", "Node"))

--- a/bundle/compliance/cis_k8s/rules/cis_1_2_9/rule.rego
+++ b/bundle/compliance/cis_k8s/rules/cis_1_2_9/rule.rego
@@ -2,6 +2,4 @@ package compliance.cis_k8s.rules.cis_1_2_9
 
 import data.compliance.policy.process.ensure_arguments_contain_value as audit
 
-finding = result {
-	result := audit.finding(audit.contains("--authorization-mode", "RBAC"))
-}
+finding := audit.finding(audit.contains("--authorization-mode", "RBAC"))

--- a/bundle/compliance/cis_k8s/rules/cis_1_3_6/test.rego
+++ b/bundle/compliance/cis_k8s/rules/cis_1_3_6/test.rego
@@ -11,7 +11,6 @@ test_violation {
 
 test_pass {
 	eval_pass with input as rule_input("--feature-gates=RotateKubeletServerCertificate=true")
-	true
 }
 
 test_not_evaluated {

--- a/bundle/compliance/cis_k8s/rules/cis_5_1_3/rule.rego
+++ b/bundle/compliance/cis_k8s/rules/cis_5_1_3/rule.rego
@@ -2,6 +2,4 @@ package compliance.cis_k8s.rules.cis_5_1_3
 
 import data.compliance.policy.kube_api.minimize_wildcard as audit
 
-finding = result {
-	result := audit.finding
-}
+finding := audit.finding

--- a/bundle/compliance/cis_k8s/rules/cis_5_1_5/rule.rego
+++ b/bundle/compliance/cis_k8s/rules/cis_5_1_5/rule.rego
@@ -2,6 +2,4 @@ package compliance.cis_k8s.rules.cis_5_1_5
 
 import data.compliance.policy.kube_api.ensure_service_accounts as audit
 
-finding = result {
-	result := audit.finding(audit.service_account_default)
-}
+finding := audit.finding(audit.service_account_default)

--- a/bundle/compliance/cis_k8s/rules/cis_5_1_6/rule.rego
+++ b/bundle/compliance/cis_k8s/rules/cis_5_1_6/rule.rego
@@ -2,6 +2,4 @@ package compliance.cis_k8s.rules.cis_5_1_6
 
 import data.compliance.policy.kube_api.ensure_service_accounts as audit
 
-finding = result {
-	result := audit.finding(audit.service_account_automount)
-}
+finding := audit.finding(audit.service_account_automount)

--- a/bundle/compliance/cis_k8s/rules/cis_5_2_10/rule.rego
+++ b/bundle/compliance/cis_k8s/rules/cis_5_2_10/rule.rego
@@ -2,6 +2,4 @@ package compliance.cis_k8s.rules.cis_5_2_10
 
 import data.compliance.policy.kube_api.minimize_assigned_capabilities as audit
 
-finding = result {
-	result := audit.finding
-}
+finding := audit.finding

--- a/bundle/compliance/cis_k8s/rules/cis_5_2_2/rule.rego
+++ b/bundle/compliance/cis_k8s/rules/cis_5_2_2/rule.rego
@@ -2,6 +2,4 @@ package compliance.cis_k8s.rules.cis_5_2_2
 
 import data.compliance.policy.kube_api.minimize_admission as audit
 
-finding = result {
-	result := audit.finding("privileged")
-}
+finding := audit.finding("privileged")

--- a/bundle/compliance/cis_k8s/rules/cis_5_2_3/rule.rego
+++ b/bundle/compliance/cis_k8s/rules/cis_5_2_3/rule.rego
@@ -2,6 +2,4 @@ package compliance.cis_k8s.rules.cis_5_2_3
 
 import data.compliance.policy.kube_api.minimize_sharing as audit
 
-finding = result {
-	result := audit.finding("hostPID")
-}
+finding := audit.finding("hostPID")

--- a/bundle/compliance/cis_k8s/rules/cis_5_2_4/rule.rego
+++ b/bundle/compliance/cis_k8s/rules/cis_5_2_4/rule.rego
@@ -2,6 +2,4 @@ package compliance.cis_k8s.rules.cis_5_2_4
 
 import data.compliance.policy.kube_api.minimize_sharing as audit
 
-finding = result {
-	result := audit.finding("hostIPC")
-}
+finding := audit.finding("hostIPC")

--- a/bundle/compliance/cis_k8s/rules/cis_5_2_5/rule.rego
+++ b/bundle/compliance/cis_k8s/rules/cis_5_2_5/rule.rego
@@ -2,6 +2,4 @@ package compliance.cis_k8s.rules.cis_5_2_5
 
 import data.compliance.policy.kube_api.minimize_sharing as audit
 
-finding = result {
-	result := audit.finding("hostNetwork")
-}
+finding := audit.finding("hostNetwork")

--- a/bundle/compliance/cis_k8s/rules/cis_5_2_6/rule.rego
+++ b/bundle/compliance/cis_k8s/rules/cis_5_2_6/rule.rego
@@ -2,6 +2,4 @@ package compliance.cis_k8s.rules.cis_5_2_6
 
 import data.compliance.policy.kube_api.minimize_admission as audit
 
-finding = result {
-	result := audit.finding("allowPrivilegeEscalation")
-}
+finding := audit.finding("allowPrivilegeEscalation")

--- a/bundle/compliance/cis_k8s/rules/cis_5_2_7/rule.rego
+++ b/bundle/compliance/cis_k8s/rules/cis_5_2_7/rule.rego
@@ -2,6 +2,4 @@ package compliance.cis_k8s.rules.cis_5_2_7
 
 import data.compliance.policy.kube_api.minimize_admission_root as audit
 
-finding = result {
-	result := audit.finding
-}
+finding := audit.finding

--- a/bundle/compliance/cis_k8s/rules/cis_5_2_8/rule.rego
+++ b/bundle/compliance/cis_k8s/rules/cis_5_2_8/rule.rego
@@ -2,6 +2,4 @@ package compliance.cis_k8s.rules.cis_5_2_8
 
 import data.compliance.policy.kube_api.minimize_certain_capability as audit
 
-finding = result {
-	result := audit.finding
-}
+finding := audit.finding

--- a/bundle/compliance/cis_k8s/rules/cis_5_2_9/rule.rego
+++ b/bundle/compliance/cis_k8s/rules/cis_5_2_9/rule.rego
@@ -2,6 +2,4 @@ package compliance.cis_k8s.rules.cis_5_2_9
 
 import data.compliance.policy.kube_api.minimize_added_capabilities as audit
 
-finding = result {
-	result := audit.finding
-}
+finding := audit.finding

--- a/bundle/compliance/lib/common/common.rego
+++ b/bundle/compliance/lib/common/common.rego
@@ -36,10 +36,6 @@ ensure_array(value) = [value] {
 	not is_array(value)
 } else = value
 
-array_contains(array, key) {
-	array[_] == key
-} else = false
-
 contains_key(object, key) {
 	object[key]
 } else = false
@@ -102,17 +98,13 @@ ranges_gte(ranges, value) {
 	not ranges_smaller_than(ranges, value)
 }
 
-generate_result(evaluation, evidence, expected) = result {
-	result := {
-		"evaluation": evaluation,
-		"evidence": evidence,
-		"expected": expected,
-	}
+generate_result(evaluation, evidence, expected) := {
+	"evaluation": evaluation,
+	"evidence": evidence,
+	"expected": expected,
 }
 
-generate_result_without_expected(evaluation, evidence) = result {
-	result := {
-		"evaluation": evaluation,
-		"evidence": evidence,
-	}
+generate_result_without_expected(evaluation, evidence) := {
+	"evaluation": evaluation,
+	"evidence": evidence,
 }

--- a/bundle/compliance/lib/common/test.rego
+++ b/bundle/compliance/lib/common/test.rego
@@ -33,36 +33,6 @@ test_ensure_array_from_string {
 	ensure_array("a") == ["a"]
 }
 
-test_array_contains {
-	array := ["a", "b", "c"]
-	key := "c"
-	array_contains(array, key)
-}
-
-test_array_contains_not_contains {
-	array := ["a", "b", "c"]
-	key := "d"
-	assert.is_false(array_contains(array, key))
-}
-
-test_array_contains_not_contains_substring {
-	array := ["a", "b", "ccc"]
-	key := "c"
-	assert.is_false(array_contains(array, key))
-}
-
-test_contains_key {
-	array := {"a": "aa", "b": "bb"}
-	key := "a"
-	contains_key(array, key)
-}
-
-test_contains_key_not_contains {
-	array := {"a": "aa", "b": "bb"}
-	key := "c"
-	assert.is_false(contains_key(array, key))
-}
-
 test_greater_or_equal_greater {
 	value := 10
 	minimum := 9

--- a/bundle/compliance/main.rego
+++ b/bundle/compliance/main.rego
@@ -7,6 +7,8 @@ import data.compliance.lib.common
 # output is findings
 resource = input.resource
 
+# METADATA
+# entrypoint: true
 findings = f {
 	input.benchmark
 

--- a/bundle/compliance/policy/aws_cloudtrail/trail.rego
+++ b/bundle/compliance/policy/aws_cloudtrail/trail.rego
@@ -28,7 +28,7 @@ cloudtrail_enabled(trail) {
 	# and it is avtive
 	trail.TrailInfo.Status.IsLogging
 
-	# and it captures all management events 
+	# and it captures all management events
 	some i
 	selector := trail.TrailInfo.EventSelectors[i]
 	selector.IncludeManagementEvents

--- a/bundle/compliance/policy/aws_cloudtrail/verify_s3_object_logging.rego
+++ b/bundle/compliance/policy/aws_cloudtrail/verify_s3_object_logging.rego
@@ -1,18 +1,20 @@
 package compliance.policy.aws_cloudtrail.verify_s3_object_logging
 
+import future.keywords.in
+
 import data.compliance.lib.common
 import data.compliance.policy.aws_cloudtrail.data_adapter
 
-#1.Checks if trail is multi region
-#2.Checks if trail has an event selector of "allowed_types" type.
-#3.Checks if the type of data resource is "AWS::S3::Object" (S3 object).
-#4.Checks if the partial ARN of the data resource is "arn:aws:s3".
+# 1.Checks if trail is multi region
+# 2.Checks if trail has an event selector of "allowed_types" type.
+# 3.Checks if the type of data resource is "AWS::S3::Object" (S3 object).
+# 4.Checks if the partial ARN of the data resource is "arn:aws:s3".
 ensure_s3_object_logging(allowed_types) {
 	data_adapter.trail.IsMultiRegionTrail
 
 	some i, j, k
 	selector := data_adapter.event_selectors[i]
-	common.array_contains(allowed_types, selector.ReadWriteType)
+	selector.ReadWriteType in allowed_types
 
 	dataResource := selector.DataResources[j]
 	dataResource.Type == "AWS::S3::Object"

--- a/bundle/compliance/policy/aws_config/ensure_config_enabled.rego
+++ b/bundle/compliance/policy/aws_config/ensure_config_enabled.rego
@@ -1,6 +1,6 @@
 package compliance.policy.aws_config.ensure_config_enabled
 
-import data.compliance.lib.common as common
+import data.compliance.lib.common
 import data.compliance.policy.aws_config.data_adapter
 import future.keywords.every
 

--- a/bundle/compliance/policy/aws_ec2/data_adapter.rego
+++ b/bundle/compliance/policy/aws_ec2/data_adapter.rego
@@ -16,42 +16,30 @@ is_ebs_policy {
 	input.subType == "aws-ebs"
 }
 
-nacl_entries = entries {
-	entries := input.resource.Entries
-}
+nacl_entries := input.resource.Entries
 
-security_groups_ip_permissions = entries {
-	entries := input.resource.IpPermissions
-}
+security_groups_ip_permissions := input.resource.IpPermissions
 
 is_default_security_group {
 	input.resource.GroupName == "default"
 }
 
-# Filter all the entries that 
+# Filter all the entries that
 # 1. have ingres (egress == false)
 # 2. allow any source ip of 0.0.0.0/0
-nacl_ingresses = res {
-	res = [entry | entry := nacl_entries[_]; entry.Egress == false; entry.CidrBlock == "0.0.0.0/0"; entry.RuleAction == "allow"]
-}
+nacl_ingresses := [entry | entry := nacl_entries[_]; entry.Egress == false; entry.CidrBlock == "0.0.0.0/0"; entry.RuleAction == "allow"]
 
-# If the PortRange field is not specified for a network ACL rule, 
-# it means that the rule applies to all ports for the specified protocol. 
-# For example, if you create a rule that allows inbound traffic on TCP protocol and do not specify a PortRange, 
+# If the PortRange field is not specified for a network ACL rule,
+# it means that the rule applies to all ports for the specified protocol.
+# For example, if you create a rule that allows inbound traffic on TCP protocol and do not specify a PortRange,
 # the rule will allow inbound traffic on all TCP ports.
-ingresses_with_all_ports_open = res {
-	res = [entry | entry := nacl_ingresses[_]; not entry.PortRange]
-}
+ingresses_with_all_ports_open := [entry | entry := nacl_ingresses[_]; not entry.PortRange]
 
 # all the IpRanges from security groups that has an open inbound for all ipv4 cidr notions
-public_ipv4 = res {
-	res = [entry | entry := security_groups_ip_permissions[_]; entry.IpRanges[_].CidrIp == "0.0.0.0/0"]
-}
+public_ipv4 := [entry | entry := security_groups_ip_permissions[_]; entry.IpRanges[_].CidrIp == "0.0.0.0/0"]
 
 # all the IpRangesv6 from security groups that has an open inbound for all ipv6 cidr notions
-public_ipv6 = res {
-	res = [entry | entry := security_groups_ip_permissions[_]; entry.Ipv6Ranges[_].CidrIpv6 == "::/0"]
-}
+public_ipv6 := [entry | entry := security_groups_ip_permissions[_]; entry.Ipv6Ranges[_].CidrIpv6 == "::/0"]
 
 security_group_inbound_rules = input.resource.IpPermissions
 

--- a/bundle/compliance/policy/aws_ec2/ensure_default_security_group_restricted.rego
+++ b/bundle/compliance/policy/aws_ec2/ensure_default_security_group_restricted.rego
@@ -7,7 +7,7 @@ import data.compliance.policy.aws_ec2.data_adapter
 default rule_evaluation = false
 
 finding = result {
-	# filter 
+	# filter
 	data_adapter.is_security_group_policy
 	data_adapter.is_default_security_group
 

--- a/bundle/compliance/policy/aws_ec2/ensure_public_ingress.rego
+++ b/bundle/compliance/policy/aws_ec2/ensure_public_ingress.rego
@@ -8,7 +8,7 @@ import future.keywords.every
 default rule_evaluation = false
 
 finding = result {
-	# filter 
+	# filter
 	data_adapter.is_nacl_policy
 
 	# set result

--- a/bundle/compliance/policy/aws_ec2/ensure_security_group_public_ingress_ipv4.rego
+++ b/bundle/compliance/policy/aws_ec2/ensure_security_group_public_ingress_ipv4.rego
@@ -8,7 +8,7 @@ import future.keywords.every
 default rule_evaluation = false
 
 finding = result {
-	# filter 
+	# filter
 	data_adapter.is_security_group_policy
 
 	# set result

--- a/bundle/compliance/policy/aws_ec2/ensure_security_group_public_ingress_ipv6.rego
+++ b/bundle/compliance/policy/aws_ec2/ensure_security_group_public_ingress_ipv6.rego
@@ -8,7 +8,7 @@ import future.keywords.every
 default rule_evaluation = false
 
 finding = result {
-	# filter 
+	# filter
 	data_adapter.is_security_group_policy
 
 	# set result

--- a/bundle/compliance/policy/aws_elb/ensure_certificates.rego
+++ b/bundle/compliance/policy/aws_elb/ensure_certificates.rego
@@ -1,5 +1,7 @@
 package compliance.policy.aws_elb.ensure_certificates
 
+import future.keywords.every
+
 import data.compliance.lib.common as lib_common
 import data.compliance.policy.aws_elb.data_adapter
 
@@ -12,7 +14,13 @@ rule_evaluation = false {
 
 # Verify that all listeners use https protocoal
 rule_evaluation = false {
-	data_adapter.listener_descriptions[_].Listener.InstanceProtocol != "HTTPS"
+	not all_https
+}
+
+all_https {
+	every description in data_adapter.listener_descriptions {
+		description.Listener.InstanceProtocol == "HTTPS"
+	}
 }
 
 finding = result {

--- a/bundle/compliance/policy/aws_kms/ensure_symmetric_key_rotation_enabled.rego
+++ b/bundle/compliance/policy/aws_kms/ensure_symmetric_key_rotation_enabled.rego
@@ -1,6 +1,6 @@
 package compliance.policy.aws_kms.ensure_symmetric_key_rotation_enabled
 
-import data.compliance.lib.common as common
+import data.compliance.lib.common
 import data.compliance.policy.aws_kms.data_adapter
 
 default rule_evaluation = false

--- a/bundle/compliance/policy/aws_rds/ensure_no_public_access.rego
+++ b/bundle/compliance/policy/aws_rds/ensure_no_public_access.rego
@@ -2,7 +2,8 @@ package compliance.policy.aws_rds.ensure_no_public_access
 
 import data.compliance.lib.common as lib_common
 import data.compliance.policy.aws_rds.data_adapter
-import future.keywords
+import future.keywords.if
+import future.keywords.in
 
 default has_public_access = false
 

--- a/bundle/compliance/policy/file/common.rego
+++ b/bundle/compliance/policy/file/common.rego
@@ -22,13 +22,11 @@ file_permission_match_exact(filemode, user, group, other) {
 } else = false
 
 # return a list of file premission [user, group, other]
-parse_permission(filemode) = permissions {
-	# cast to numbers
-	permissions := [to_number(p) | p = split(filemode, "")[_]]
-}
+# cast to numbers
+parse_permission(filemode) := [to_number(p) | p := split(filemode, "")[_]]
 
 check_permissions(permissions, max_permissions) {
-	assert.all_true([r | r = bits.and(permissions[p], bits.negate(max_permissions[p])) == 0])
+	assert.all_true([r | some p; r = bits.and(permissions[p], bits.negate(max_permissions[p])) == 0])
 } else = false
 
 # check if file is in path

--- a/bundle/compliance/policy/file/ensure_permissions.rego
+++ b/bundle/compliance/policy/file/ensure_permissions.rego
@@ -4,14 +4,11 @@ import data.compliance.lib.common as lib_common
 import data.compliance.policy.file.common as file_common
 import data.compliance.policy.file.data_adapter
 
-finding(rule_evaluation) := result {
-	# set result
-	result := lib_common.generate_result(
-		lib_common.calculate_result(rule_evaluation.evaluation),
-		{"filemode": rule_evaluation.mode},
-		{"filemode": sprintf("%d%d%d", [rule_evaluation.user, rule_evaluation.group, rule_evaluation.other])},
-	)
-}
+finding(rule_evaluation) := lib_common.generate_result(
+	lib_common.calculate_result(rule_evaluation.evaluation),
+	{"filemode": rule_evaluation.mode},
+	{"filemode": sprintf("%d%d%d", [rule_evaluation.user, rule_evaluation.group, rule_evaluation.other])},
+)
 
 path_filter(name) := file_common.file_in_path(name, data_adapter.file_path)
 

--- a/bundle/compliance/policy/gcp/compute/ensure_fw_rule.rego
+++ b/bundle/compliance/policy/gcp/compute/ensure_fw_rule.rego
@@ -13,7 +13,7 @@ is_valid_fw_rule(port) = false if {
 	data_adapter.resource.data.direction == "INGRESS"
 
 	some action in data_adapter.resource.data.allowed
-	common.array_contains(["tcp", "all"], action.IPProtocol)
+	action.IPProtocol in {"tcp", "all"}
 	is_port_effective(port, object.get(action, ["ports"], []))
 } else = true
 

--- a/bundle/compliance/policy/gcp/data_adapter.rego
+++ b/bundle/compliance/policy/gcp/data_adapter.rego
@@ -1,12 +1,14 @@
 package compliance.policy.gcp.data_adapter
 
+import future.keywords.in
+
 import data.compliance.lib.common
 
-resource = input.resource.resource
+resource := input.resource.resource
 
-iam_policy = input.resource.iam_policy
+iam_policy := input.resource.iam_policy
 
-has_policy = common.contains_key(input.resource, "iam_policy")
+has_policy := "iam_policy" in object.keys(input.resource)
 
 is_policies_resource {
 	input.subType == "gcp-policies"

--- a/bundle/compliance/policy/kube_api/minimize_certain_capability.rego
+++ b/bundle/compliance/policy/kube_api/minimize_certain_capability.rego
@@ -1,5 +1,7 @@
 package compliance.policy.kube_api.minimize_certain_capability
 
+import future.keywords.in
+
 import data.compliance.lib.common
 import data.compliance.policy.kube_api.data_adapter
 
@@ -7,13 +9,13 @@ default rule_evaluation = false
 
 rule_evaluation {
 	container := data_adapter.containers.app_containers[_]
-	common.array_contains(container.securityContext.capabilities.drop, "NET_RAW")
+	"NET_RAW" in container.securityContext.capabilities.drop
 }
 
 # or
 rule_evaluation {
 	container := data_adapter.containers.app_containers[_]
-	common.array_contains(container.securityContext.capabilities.drop, "ALL")
+	"ALL" in container.securityContext.capabilities.drop
 }
 
 finding := result {

--- a/bundle/compliance/policy/process/common.rego
+++ b/bundle/compliance/policy/process/common.rego
@@ -1,10 +1,12 @@
 package compliance.policy.process.common
 
+import future.keywords.in
+
 # checks if argument contains value (argument format is csv)
 arg_values_contains(arguments, key, value) {
 	argument := arguments[key]
 	values := split(argument, ",")
-	value == values[_]
+	value in values
 } else = false
 
 # splits key value string by first occurrence of =

--- a/bundle/compliance/policy/process/data_adapter.rego
+++ b/bundle/compliance/policy/process/data_adapter.rego
@@ -22,7 +22,7 @@ process_args_list = args_list {
 parse_argument(argument) = [flag, value] {
 	# We would like to split the argument by the first delimiter
 	# The dilimiter can be either a space or an equal sign
-	splitted_argument := regex.split("\\s|\\=", argument)
+	splitted_argument := regex.split(`\s|\=`, argument)
 	flag = concat("", ["--", splitted_argument[0]])
 
 	# We would like to take the entire string after the first delimiter

--- a/bundle/compliance/policy/process/ensure_appropriate_arguments.rego
+++ b/bundle/compliance/policy/process/ensure_appropriate_arguments.rego
@@ -6,13 +6,10 @@ import data.compliance.policy.process.data_adapter
 
 process_args := benchmark_data_adapter.process_args
 
-finding(entities) = result {
-	# set result
-	result := lib_common.generate_result_without_expected(
-		lib_common.calculate_result(rule_evaluation(entities)),
-		{"process_args": process_args},
-	)
-}
+finding(entities) := lib_common.generate_result_without_expected(
+	lib_common.calculate_result(rule_evaluation(entities)),
+	{"process_args": process_args},
+)
 
 # TODO: Change index access to cycle
 rule_evaluation(entities) {

--- a/bundle/compliance/policy/process/ensure_arguments_and_config.rego
+++ b/bundle/compliance/policy/process/ensure_arguments_and_config.rego
@@ -1,5 +1,7 @@
 package compliance.policy.process.ensure_arguments_and_config
 
+import future.keywords.in
+
 import data.benchmark_data_adapter
 import data.compliance.lib.common as lib_common
 import data.compliance.policy.process.data_adapter
@@ -47,7 +49,7 @@ process_arg_not_key_value(entity, key, value) {
 }
 
 process_contains_key(entity) {
-	lib_common.contains_key(process_args, entity)
+	entity in object.keys(process_args)
 }
 
 not_process_key_comparison(entity, variable, value) {

--- a/bundle/compliance/policy/process/ensure_arguments_contain_key.rego
+++ b/bundle/compliance/policy/process/ensure_arguments_contain_key.rego
@@ -1,5 +1,7 @@
 package compliance.policy.process.ensure_arguments_contain_key
 
+import future.keywords.in
+
 import data.benchmark_data_adapter
 import data.compliance.lib.assert
 import data.compliance.lib.common as lib_common
@@ -7,17 +9,15 @@ import data.compliance.policy.process.data_adapter
 
 process_args := benchmark_data_adapter.process_args
 
-finding(rule_evaluation) = result {
-	# set result
-	result := lib_common.generate_result_without_expected(
-		lib_common.calculate_result(rule_evaluation),
-		{"process_args": process_args},
-	)
-}
+finding(rule_evaluation) := lib_common.generate_result_without_expected(
+	lib_common.calculate_result(rule_evaluation),
+	{"process_args": process_args},
+)
 
 not_contains(entity) := assert.is_false(lib_common.contains_key(process_args, entity))
 
-contains(entity) := lib_common.contains_key(process_args, entity)
+# regal ignore:rule-shadows-builtin
+contains(entity) := entity in object.keys(process_args)
 
 apiserver_filter := data_adapter.is_kube_apiserver
 

--- a/bundle/compliance/policy/process/ensure_arguments_contain_key_value.rego
+++ b/bundle/compliance/policy/process/ensure_arguments_contain_key_value.rego
@@ -7,16 +7,14 @@ import data.compliance.policy.process.data_adapter
 
 process_args := benchmark_data_adapter.process_args
 
-finding(rule_evaluation) = result {
-	# set result
-	result := lib_common.generate_result_without_expected(
-		lib_common.calculate_result(rule_evaluation),
-		{"process_args": process_args},
-	)
-}
+finding(rule_evaluation) := lib_common.generate_result_without_expected(
+	lib_common.calculate_result(rule_evaluation),
+	{"process_args": process_args},
+)
 
 not_contains(entity, value) := assert.is_false(lib_common.contains_key_with_value(process_args, entity, value))
 
+# regal ignore:rule-shadows-builtin
 contains(entity, value) := lib_common.contains_key_with_value(process_args, entity, value)
 
 apiserver_filter := data_adapter.is_kube_apiserver

--- a/bundle/compliance/policy/process/ensure_arguments_contain_value.rego
+++ b/bundle/compliance/policy/process/ensure_arguments_contain_value.rego
@@ -20,4 +20,5 @@ finding(rule_evaluation) = result {
 
 not_contains(entity, value) := assert.is_false(process_common.arg_values_contains(process_args, entity, value))
 
+# regal ignore:rule-shadows-builtin
 contains(entity, value) := process_common.arg_values_contains(process_args, entity, value)

--- a/bundle/compliance/policy/process/ensure_arguments_if_contain_equal.rego
+++ b/bundle/compliance/policy/process/ensure_arguments_if_contain_equal.rego
@@ -1,5 +1,7 @@
 package compliance.policy.process.ensure_arguments_if_contain_equal
 
+import future.keywords.in
+
 import data.benchmark_data_adapter
 import data.compliance.lib.assert
 import data.compliance.lib.common as lib_common
@@ -12,7 +14,7 @@ default rule_evaluation = false
 rule_evaluation {
 	lib_common.contains_key_with_value(process_args, "--service-account-lookup", "true")
 } else {
-	assert.is_false(lib_common.contains_key(process_args, "--service-account-lookup"))
+	not "--service-account-lookup" in object.keys(process_args)
 }
 
 finding = result {

--- a/bundle/compliance/policy/process/ensure_ciphers.rego
+++ b/bundle/compliance/policy/process/ensure_ciphers.rego
@@ -1,5 +1,7 @@
 package compliance.policy.process.ensure_ciphers
 
+import future.keywords.in
+
 import data.benchmark_data_adapter
 import data.compliance.lib.common as lib_common
 import data.compliance.policy.process.data_adapter
@@ -8,7 +10,7 @@ process_args := benchmark_data_adapter.process_args
 
 is_process_args_includes_non_supported_cipher(supported_ciphers) {
 	ciphers := split(process_args["--tls-cipher-suites"], ",")
-	cipher := ciphers[_]
+	some cipher in ciphers
 	not is_supported_cipher(supported_ciphers, cipher)
 }
 
@@ -20,19 +22,16 @@ is_process_config_includes_non_supported_cipher(supported_ciphers) {
 }
 
 is_supported_cipher(supported_ciphers, cipher) {
-	supported_ciphers[_] == cipher
+	cipher in supported_ciphers
 }
 
-finding(rule_evaluation) = result {
-	# set result
-	result := lib_common.generate_result_without_expected(
-		lib_common.calculate_result(rule_evaluation),
-		{
-			"process_args": process_args,
-			"process_config": data_adapter.process_config,
-		},
-	)
-}
+finding(rule_evaluation) := lib_common.generate_result_without_expected(
+	lib_common.calculate_result(rule_evaluation),
+	{
+		"process_args": process_args,
+		"process_config": data_adapter.process_config,
+	},
+)
 
 apiserver_filter = data_adapter.is_kube_apiserver
 


### PR DESCRIPTION
Hello Elastic friends! 👋😃 Good to see so many familiar faces in the list of contributors here. [Regal](https://github.com/StyraInc/regal) is a linter for Rego, and it's reaching a level of maturity where I feel confident putting it to use in some serious policy libraries.

Besides linting, the CI integration helps annotate PRs with violations at the location they happened, helping developers quickly figure out what they need to change.

As part of integrating the linter in this repo, I went ahead and fixed a number of issues reported. Naturally, I've made sure that all the Rego tests pass, but if there's any change you feel was too invasive, or perhaps changed code that some other project depend on, do let me know and I'll be happy to revert that.

Issues fixed for the following rules:

* [not-equals-in-loop](https://docs.styra.com/regal/rules/bugs/not-equals-in-loop)
* [unconditional-assignment](https://docs.styra.com/regal/rules/style/unconditional-assignment)
* [use-in-operator](https://docs.styra.com/regal/rules/idiomatic/use-in-operator)
* [redundant-alias](https://docs.styra.com/regal/rules/imports/redundant-alias)
* [no-whitespace-comment](https://docs.styra.com/regal/rules/style/no-whitespace-comment)
* [constant-condition](https://docs.styra.com/regal/rules/bugs/constant-condition)
* [non-raw-regex-pattern](https://docs.styra.com/regal/rules/idiomatic/non-raw-regex-pattern)
* [redundant-alias](https://docs.styra.com/regal/rules/imports/redundant-alias)

Many issues, primarily related to style, have been disabled in the Regal config for now, and I'm sure you'll want to work on having some of them enabled later.

Have a great weekend!
