### PR TITLE
Fixing storage account rules after QA cycle

### DIFF
--- a/bundle/compliance/cis_azure/rules/cis_3_10/test.rego
+++ b/bundle/compliance/cis_azure/rules/cis_3_10/test.rego
@@ -5,7 +5,7 @@ import data.compliance.policy.azure.data_adapter
 import data.lib.test
 
 test_violation {
-	eval_fail with input as test_data.generate_storage_account_with_property("privateEndpointConnections", [{"properties": {"privateLinkServiceConnectionState": {"status": "NotApproved"}}}])
+	eval_fail with input as test_data.generate_storage_account_with_property("privateEndpointConnections", [])
 }
 
 test_pass {

--- a/bundle/compliance/cis_azure/rules/cis_3_2/test.rego
+++ b/bundle/compliance/cis_azure/rules/cis_3_2/test.rego
@@ -7,6 +7,7 @@ import data.lib.test
 test_violation {
 	# fail if managed by user
 	eval_fail with input as test_data.generate_storage_account_with_property("encryption", {"requireInfrastructureEncryption": false})
+	eval_fail with input as test_data.generate_storage_account_with_property("encryption", {})
 }
 
 test_pass {
@@ -15,7 +16,7 @@ test_pass {
 }
 
 test_not_evaluated {
-	not_eval with input as test_data.generate_storage_account_with_property("encryption", {})
+	not_eval with input as test_data.not_eval_non_exist_type
 }
 
 eval_fail {

--- a/bundle/compliance/cis_azure/rules/cis_3_7/test.rego
+++ b/bundle/compliance/cis_azure/rules/cis_3_7/test.rego
@@ -5,11 +5,11 @@ import data.compliance.policy.azure.data_adapter
 import data.lib.test
 
 test_violation {
-	eval_fail with input as test_data.generate_storage_account_with_property("encryption", {"publicNetworkAccess": "Enabled"})
+	eval_fail with input as test_data.generate_storage_account_with_property("publicNetworkAccess", "Enabled")
 }
 
 test_pass {
-	eval_pass with input as test_data.generate_storage_account_with_property("encryption", {"publicNetworkAccess": "Disabled"})
+	eval_pass with input as test_data.generate_storage_account_with_property("publicNetworkAccess", "Disabled")
 }
 
 test_not_evaluated {

--- a/bundle/compliance/policy/azure/storage_account/ensure_connection.rego
+++ b/bundle/compliance/policy/azure/storage_account/ensure_connection.rego
@@ -5,9 +5,9 @@ import data.compliance.policy.azure.data_adapter
 import future.keywords.every
 
 is_every_private_connections {
-	every connection in data_adapter.private_endpoint_connections {
-		connection.properties.privateLinkServiceConnectionState.status == "Approved"
-	}
+	# Azure implemented it differently (like previous version of this file)
+	# Simplified and implemented exactly like the PDF audit
+	count(data_adapter.private_endpoint_connections) > 0
 } else = false
 
 is_private_connections = r {

--- a/bundle/compliance/policy/azure/storage_account/ensure_encryption.rego
+++ b/bundle/compliance/policy/azure/storage_account/ensure_encryption.rego
@@ -2,4 +2,6 @@ package compliance.policy.azure.storage_account.ensure_encryption
 
 import data.compliance.policy.azure.data_adapter
 
-is_encryption_enabled = data_adapter.properties.encryption.requireInfrastructureEncryption
+is_encryption_enabled {
+	data_adapter.properties.encryption.requireInfrastructureEncryption
+} else = false

--- a/bundle/compliance/policy/azure/storage_account/ensure_public_access.rego
+++ b/bundle/compliance/policy/azure/storage_account/ensure_public_access.rego
@@ -5,10 +5,10 @@ import data.compliance.policy.azure.data_adapter
 import future.keywords.if
 
 verify_public_access if {
-	data_adapter.properties.encryption.publicNetworkAccess == "Disabled"
+	data_adapter.properties.publicNetworkAccess == "Disabled"
 } else = false
 
 is_public_access_disabled = r if {
-	data_adapter.properties.encryption.publicNetworkAccess
+	data_adapter.properties.publicNetworkAccess
 	r = verify_public_access
 }


### PR DESCRIPTION
### Summary of your changes
After the QA cycle, we've found storage account rules issues.
This PR addresses these issues and fixes them.

### Related Issues
- Related: https://github.com/elastic/cloudbeat/issues/1254

### Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary README/documentation (if appropriate)

#### Introducing a new rule?

- [x] Generate rule metadata using [this script](https://github.com/elastic/csp-security-policies/tree/main/dev#generate-rules-metadata)
- [x] Add relevant unit tests
- [x] Generate relevant rule templates using [this script](https://github.com/elastic/csp-security-policies/tree/main/dev#generate-rule-templates), and open a PR in [elastic/packages/cloud_security_posture](https://github.com/elastic/integrations/tree/main/packages/cloud_security_posture)

> **Note** Make sure to bump cloudbeat [`version/policy.go`](https://github.com/elastic/cloudbeat/blob/main/version/policy.go#L20) after merging this PR and drafting a new release.
